### PR TITLE
Functional but not pretty fix for mobile scrolling issue

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,6 +35,6 @@
 }
 
 // Necessary in order to allow scrolling on small screens
-.off-canvas-wrap {
+.off-canvas-wrapper {
   overflow: auto;
 }


### PR DESCRIPTION
It looks like we tried to fix this before, but the css class was not quite correct. This should fix the problem for now, and allow #179 to no longer be high-priority.