### PR TITLE
Update expense items view for fewer expense groups

### DIFF
--- a/app/views/registrant_expense_items/_new_expenses.html.haml
+++ b/app/views/registrant_expense_items/_new_expenses.html.haml
@@ -5,14 +5,20 @@
 
 .new_expenses.row
   - @groups.includes(:expense_items).each do |expense_group|
-    %fieldset.small-12.medium-6.large-4.columns
-      %legend= t(".add", group_name: expense_group)
-      %table
-        - if expense_group.additional_info?
-          %tr
-            %td{:colspan => "3"}
-              .event_link
-                = link_to t(".info") + ' [' + expense_group.to_s + ']', additional_information_url(expense_group, I18n.locale), { target: "_blank", class: "external_link fancybox"}
-        - expense_group.expense_items.each do |ei|
-          - @registrant_expense_item = RegistrantExpenseItem.new(:expense_item => ei, :registrant => @registrant)
-          = render :partial => "/registrant_expense_items/new_expense", :locals => { :item => ei, :show_as_free => @registrant.expense_item_is_free(ei) }
+    - if @groups.count = 1
+      %fieldset.small-12.medium-6.large-8.columns
+    - elsif @groups.count = 2
+      %fieldset.small-12.medium-6.large-6.columns
+    - else
+      %fieldset.small-12.medium-6.large-4.columns
+    - end  
+        %legend= t(".add", group_name: expense_group)
+        %table
+          - if expense_group.additional_info?
+            %tr
+              %td{:colspan => "3"}
+                .event_link
+                  = link_to t(".info") + ' [' + expense_group.to_s + ']', additional_information_url(expense_group, I18n.locale), { target: "_blank", class: "external_link fancybox"}
+          - expense_group.expense_items.each do |ei|
+            - @registrant_expense_item = RegistrantExpenseItem.new(:expense_item => ei, :registrant => @registrant)
+            = render :partial => "/registrant_expense_items/new_expense", :locals => { :item => ei, :show_as_free => @registrant.expense_item_is_free(ei) }


### PR DESCRIPTION
If there are fewer than 3 expense groups this widens the table's width to large-8 or large-6 for one or two expense groups, respectively.

This is to help make views like [this](http://register.ecunicycling2017.eu/en/registrants/2/build/expenses) look better.

**Note: This is probably incorrect code, it is simply an example of the behavior I would like.**

Also, in order for this fix to work, the following needs to be added to the stylesheet, but I wasn't sure where it should go.

```
.new_expenses table {
width:100%
}
```
