### PR TITLE
Clean up start and end data

### DIFF
--- a/app/actions/entered_data_exporter/max_distance.rb
+++ b/app/actions/entered_data_exporter/max_distance.rb
@@ -1,0 +1,20 @@
+class EnteredDataExporter::MaxDistance
+  attr_accessor :competition
+
+  def initialize(competition)
+    @competition = competition
+  end
+
+  def headers
+    %w(registrant_external_id distance)
+  end
+
+  def data
+    competition.competitors.map do |comp|
+      if comp.has_result?
+        [comp.export_id,
+         comp.result]
+      end
+    end.compact
+  end
+end

--- a/app/actions/entered_data_exporter/score.rb
+++ b/app/actions/entered_data_exporter/score.rb
@@ -1,0 +1,23 @@
+class EnteredDataExporter::Score
+  attr_accessor :competition
+
+  def initialize(competition)
+    @competition = competition
+  end
+
+  def headers
+    %w(judge_id judge_type_id registrant_external_id val1 val2 val3 val4)
+  end
+
+  def data
+    competition.scores.map do |score|
+      [score.judge.external_id,
+       score.judge.judge_type.name,
+       score.competitor.export_id, # use a single value even in groups
+       score.val_1,
+       score.val_2,
+       score.val_3,
+       score.val_4]
+    end
+  end
+end

--- a/app/actions/entered_data_exporter/time.rb
+++ b/app/actions/entered_data_exporter/time.rb
@@ -1,0 +1,27 @@
+class EnteredDataExporter::Time
+  attr_accessor :competition
+
+  def initialize(competition)
+    @competition = competition
+  end
+
+  def headers
+    %w(registrant_external_id gender age heat lane thousands result)
+  end
+
+  def data
+    competition.competitors.map do |comp|
+      next unless comp.has_result?
+      tr = comp.time_results.first
+      heat = tr.heat_lane_result
+
+      [comp.export_id,
+       comp.gender,
+       comp.age,
+       heat.try(:heat),
+       heat.try(:lane),
+       comp.best_time_in_thousands,
+       comp.result]
+    end.compact
+  end
+end

--- a/app/comparable_result_calculators/artistic_result_calculator.rb
+++ b/app/comparable_result_calculators/artistic_result_calculator.rb
@@ -27,6 +27,12 @@ class ArtisticResultCalculator
     total_points(competitor, jt)
   end
 
+  def eager_load_results_relations(competitors)
+    competitors.includes(
+      scores: [judge: :judge_type]
+    )
+  end
+
   # Must be 'public' so that we can show calculation steps on the chief-judge view
   def total_points(competitor, judge_type = nil)
     if judge_type.nil?

--- a/app/comparable_result_calculators/artistic_result_calculator_2015.rb
+++ b/app/comparable_result_calculators/artistic_result_calculator_2015.rb
@@ -23,6 +23,12 @@ class ArtisticResultCalculator_2015
     total_points(competitor, jt)
   end
 
+  def eager_load_results_relations(competitors)
+    competitors.includes(
+      scores: [judge: :judge_type]
+    )
+  end
+
   # Calculate the total number of points for a given competitor
   # judge_type: if specified, limit the results to a given judge_type.
   # NOTE: This function takes into account the "removed scores" by chief judge

--- a/app/comparable_result_calculators/distance_result_calculator.rb
+++ b/app/comparable_result_calculators/distance_result_calculator.rb
@@ -33,4 +33,11 @@ class DistanceResultCalculator
       0
     end
   end
+
+  def eager_load_results_relations(competitors)
+    competitors.includes(
+      :distance_attempts,
+      :tie_break_adjustment
+    )
+  end
 end

--- a/app/comparable_result_calculators/external_result_result_calculator.rb
+++ b/app/comparable_result_calculators/external_result_result_calculator.rb
@@ -22,4 +22,10 @@ class ExternalResultResultCalculator
   def competitor_tie_break_comparable_result(_competitor)
     nil
   end
+
+  def eager_load_results_relations(competitors)
+    competitors.includes(
+      :external_result
+    )
+  end
 end

--- a/app/comparable_result_calculators/external_result_result_calculator.rb
+++ b/app/comparable_result_calculators/external_result_result_calculator.rb
@@ -1,10 +1,4 @@
 class ExternalResultResultCalculator
-  attr_accessor :lower_is_better
-
-  def initialize(lower_is_better = true)
-    @lower_is_better = lower_is_better
-  end
-
   # describes whether the given competitor has any results associated
   def competitor_has_result?(competitor)
     competitor.external_result.try(:active?)

--- a/app/comparable_result_calculators/flatland_result_calculator.rb
+++ b/app/comparable_result_calculators/flatland_result_calculator.rb
@@ -22,6 +22,12 @@ class FlatlandResultCalculator
     total_last_trick_points(competitor)
   end
 
+  def eager_load_results_relations(competitors)
+    competitors.includes(
+      scores: [judge: :judge_type]
+    )
+  end
+
   # Return the resulting score for this competitor
   # after having eliminated the highest and lowest total score
   # Note: There is only 1 judge-type for flatland

--- a/app/comparable_result_calculators/multi_lap_result_calculator.rb
+++ b/app/comparable_result_calculators/multi_lap_result_calculator.rb
@@ -1,7 +1,7 @@
 class MultiLapResultCalculator
   # describes whether the given competitor has any results associated
   def competitor_has_result?(competitor)
-    competitor.time_results.finish_times.any?
+    competitor.finish_time_results.any?
   end
 
   # returns the result for this competitor

--- a/app/comparable_result_calculators/multi_lap_result_calculator.rb
+++ b/app/comparable_result_calculators/multi_lap_result_calculator.rb
@@ -27,6 +27,13 @@ class MultiLapResultCalculator
     nil
   end
 
+  def eager_load_results_relations(competitors)
+    competitors.includes(
+      :start_time_results,
+      :finish_time_results
+    )
+  end
+
   private
 
   # convert 1 lap int 9900000000, 2 laps into 980000000000....thus sorting by shortest time correctly.

--- a/app/comparable_result_calculators/overall_champion_result_calculator.rb
+++ b/app/comparable_result_calculators/overall_champion_result_calculator.rb
@@ -38,6 +38,11 @@ class OverallChampionResultCalculator
     nil
   end
 
+  def eager_load_results_relations(competitors)
+    # no-op
+    competitors
+  end
+
   # What are the bib numbers of all competitors
   # who have results in the overall competition?
   def competitor_bib_numbers

--- a/app/comparable_result_calculators/overall_champion_result_calculator.rb
+++ b/app/comparable_result_calculators/overall_champion_result_calculator.rb
@@ -12,10 +12,6 @@ class OverallChampionResultCalculator
     @registrant_bib_numbers ||= {}
   end
 
-  def lower_is_better
-    false
-  end
-
   # describes whether the given competitor has any results associated
   def competitor_has_result?(_competitor)
     true # always indicate that we have a result, so that all competitors are created.

--- a/app/comparable_result_calculators/race_result_calculator.rb
+++ b/app/comparable_result_calculators/race_result_calculator.rb
@@ -23,4 +23,11 @@ class RaceResultCalculator
   def competitor_tie_break_comparable_result(_competitor)
     nil
   end
+
+  def eager_load_results_relations(competitors)
+    competitors.includes(
+      :start_time_results,
+      :finish_time_results
+    )
+  end
 end

--- a/app/comparable_result_calculators/race_result_calculator.rb
+++ b/app/comparable_result_calculators/race_result_calculator.rb
@@ -1,10 +1,4 @@
 class RaceResultCalculator
-  attr_accessor :lower_is_better
-
-  def initialize(lower_is_better = true)
-    @lower_is_better = lower_is_better
-  end
-
   # describes whether the given competitor has any results associated
   def competitor_has_result?(competitor)
     competitor.finish_time_results.any?

--- a/app/comparable_result_calculators/shortest_time_with_tier_calculator.rb
+++ b/app/comparable_result_calculators/shortest_time_with_tier_calculator.rb
@@ -1,10 +1,4 @@
 class ShortestTimeWithTierCalculator
-  attr_accessor :lower_is_better
-
-  def initialize
-    @lower_is_better = true
-  end
-
   # describes whether the given competitor has any results associated
   def competitor_has_result?(competitor)
     competitor.finish_time_results.any?

--- a/app/comparable_result_calculators/shortest_time_with_tier_calculator.rb
+++ b/app/comparable_result_calculators/shortest_time_with_tier_calculator.rb
@@ -24,6 +24,13 @@ class ShortestTimeWithTierCalculator
     nil
   end
 
+  def eager_load_results_relations(competitors)
+    competitors.includes(
+      :start_time_results,
+      :finish_time_results
+    )
+  end
+
   private
 
   # convert tier 1 to 0, tier 2 to 11_000_000, tier 3 to 22_000_000

--- a/app/comparable_result_calculators/standard_skill_result_calculator.rb
+++ b/app/comparable_result_calculators/standard_skill_result_calculator.rb
@@ -32,6 +32,13 @@ class StandardSkillResultCalculator
     total_score / competitor.standard_skill_scores.count
   end
 
+  def eager_load_results_relations(competitors)
+    competitors.includes(
+      :standard_skill_scores,
+      standard_kill_routine: [standard_skill_routine_entries: :standard_skill_entry]
+    )
+  end
+
   # Calculate the total number of points for a given competitor
   # Minimum value is 0
   #

--- a/app/comparable_result_calculators/street_result_calculator.rb
+++ b/app/comparable_result_calculators/street_result_calculator.rb
@@ -21,6 +21,12 @@ class StreetResultCalculator
     nil
   end
 
+  def eager_load_results_relations(competitors)
+    competitors.includes(
+      scores: [judge: :judge_type]
+    )
+  end
+
   # must be exposed in order to allow displaying of per-judge-type points
   def total_points(competitor, judge_type = nil)
     if judge_type.nil?

--- a/app/distance_attempt_managers/distance_error/greater_than_or_equal.rb
+++ b/app/distance_attempt_managers/distance_error/greater_than_or_equal.rb
@@ -1,0 +1,34 @@
+class DistanceError::GreaterThanOrEqual
+  attr_reader :distance_attempts, :distance
+
+  def initialize(distance_attempts, distance)
+    @distance_attempts = distance_attempts
+    @distance = distance
+  end
+
+  def acceptable_distance?
+    acceptable_distance_error.nil?
+  end
+
+  def acceptable_distance_error
+    max_attempt = distance_attempts.first
+    if max_attempt.present?
+      if max_attempt.fault?
+        if distance < max_attempt.distance
+          "New Distance (#{distance}cm) must be greater than or equal to #{max_attempt.distance}cm"
+        end
+      else
+        # no fault
+        check_current_attempt_is_longer_than_previous_attempt(max_attempt.distance)
+      end
+    end
+  end
+
+  private
+
+  def check_current_attempt_is_longer_than_previous_attempt(max_distance)
+    if distance <= max_distance
+      "New Distance (#{distance}cm) must be greater than #{max_distance}cm"
+    end
+  end
+end

--- a/app/distance_attempt_managers/distance_error/succeed_at_each.rb
+++ b/app/distance_attempt_managers/distance_error/succeed_at_each.rb
@@ -1,0 +1,43 @@
+# Competitor must jump at the same distance as their previous fault
+# Once a Competitor faults 3 attempts at the same distance, they are done, and their previous successful distance stands.
+# After a fault, the next attempt must be at the same distance (no further), until they succeed, or are finished.
+class DistanceError::SucceedAtEach
+  attr_reader :distance_attempts, :distance
+
+  def initialize(distance_attempts, distance)
+    @distance_attempts = distance_attempts
+    @distance = distance
+  end
+
+  def acceptable_distance?
+    acceptable_distance_error(distance).nil?
+  end
+
+  def acceptable_distance_error
+    if fault? && distance != max_attempted_distance
+      "Riders must successfully complete each distance before moving on to the next distance. Please complete #{max_attempted_distance}cm"
+    else
+      # THis is very similar to GreaterThanorEqual#acceptable_distance_error...find a way to refactor?
+      max_attempt = distance_attempts.first
+      if max_attempt.present? && !max_attempt.fault?
+        # no fault
+        check_current_attempt_is_longer_than_previous_attempt(distance, max_attempt.distance)
+      end
+    end
+  end
+
+  def single_fault_message(distance)
+    # doesn't have the "+" sign on the message
+    "Fault. Next Distance #{distance}cm"
+  end
+
+  private
+
+  def fault?
+    if distance_attempts.count > 0
+      distance_attempts.first.fault?
+    else
+      false
+    end
+  end
+end

--- a/app/distance_attempt_managers/jump_limit/attempts_12.rb
+++ b/app/distance_attempt_managers/jump_limit/attempts_12.rb
@@ -1,0 +1,7 @@
+class JumpLimit::Attempts12
+  MAX_ATTEMPTS = 12
+
+  def no_more_jumps?(distance_attempts)
+    distance_attempts.count >= MAX_ATTEMPTS
+  end
+end

--- a/app/distance_attempt_managers/jump_limit/double_fault.rb
+++ b/app/distance_attempt_managers/jump_limit/double_fault.rb
@@ -1,0 +1,13 @@
+# Pre-2015 High/Long calculations (most recently used at UNICON 2014 in Montreal)
+class JumpLimit::DoubleFault
+  def no_more_jumps?(distance_attempts)
+    df = false
+    if distance_attempts.count > 1
+      if distance_attempts[0].fault? && distance_attempts[1].fault? && distance_attempts[0].distance == distance_attempts[1].distance
+        df = true
+      end
+    end
+
+    df
+  end
+end

--- a/app/distance_attempt_managers/jump_limit/triple_fault.rb
+++ b/app/distance_attempt_managers/jump_limit/triple_fault.rb
@@ -1,0 +1,17 @@
+# Competitor must jump at the same distance as their previous fault
+# Once a Competitor faults 3 attempts at the same distance, they are done, and their previous successful distance stands.
+# After a fault, the next attempt must be at the same distance (no further), until they succeed, or are finished.
+class JumpLimit::DoubleFault
+  def no_more_jumps?(distance_attempts)
+    df = false
+    if distance_attempts.count > 2
+      if distance_attempts[0].fault? && distance_attempts[1].fault? && distance_attempts[2].fault?
+        if distance_attempts[0].distance == distance_attempts[1].distance && distance_attempts[1].distance == distance_attempts[2].distance
+          df = true
+        end
+      end
+    end
+
+    df
+  end
+end

--- a/app/lib/ordered_result_calculator.rb
+++ b/app/lib/ordered_result_calculator.rb
@@ -1,8 +1,20 @@
 class OrderedResultCalculator
-  attr_reader :competition, :lower_is_better
+  attr_reader :competition, :competitors, :lower_is_better
 
   def initialize(competition, lower_is_better = true)
     @competition = competition
+
+    # TODO: Push this up into the caller, so that we pass in "competitors", and then "include" more'
+    calculator = competition.scoring_calculator
+    @competitors = calculator.eager_load_results_relations(@competition.competitors)
+
+    @competitors = @competitors.includes(
+      # Always need these relations loaded
+      :age_group_result,
+      :overall_result,
+      members: [registrant: [:competition_wheel_sizes]]
+    )
+    # eager-load other relations, depending on the calculator's needs
     @lower_is_better = lower_is_better
   end
 
@@ -11,17 +23,9 @@ class OrderedResultCalculator
     @place_calculators[age_group_desc] ||= PlaceCalculator.new
   end
 
-  # update the places for all age groups
-  def update_all_places
-    if @competition.has_age_group_entry_results?
-      update_age_group_results
-    end
-    update_overall_results
-  end
-
   def update_age_group_entry_results(entry)
-    competitors = competition.competitors.select{ |c| c.age_group_entry == entry }
-    competitors_in_sorted_order(competitors).each do |competitor|
+    age_group_competitors = competitors.select{ |c| c.age_group_entry == entry }
+    competitors_in_sorted_order(age_group_competitors).each do |competitor|
       age_place_calc = get_place_calculator(competitor.age_group_entry_description)
       new_place = age_place_calc.place_next(competitor.comparable_score, tie_break_points: competitor.comparable_tie_break_score, dq: competitor.disqualified?, ineligible: competitor.ineligible?)
       Result.create_new!(competitor, new_place, "AgeGroup", competitor.age_group_entry_description)
@@ -47,11 +51,10 @@ class OrderedResultCalculator
   private
 
   def all_competitors_in_sorted_order
-    # @all_competitors_in_sorted_order ||= competitors_in_sorted_order(competition.competitors.includes(:age_group_result, :overall_result, :external_result, :time_results, members: [registrant: [:competition_wheel_sizes]], scores: [judge: :judge_type]))
-    @all_competitors_in_sorted_order ||= competitors_in_sorted_order(competition.competitors.includes(:age_group_result, :overall_result, :external_result, :start_time_results, :finish_time_results, members: [registrant: [:competition_wheel_sizes]], scores: [judge: :judge_type]))
+    @all_competitors_in_sorted_order ||= competitors_in_sorted_order(competitors)
   end
 
-  def competitors_in_sorted_order(competitors)
-    @competitors_in_sorted_order ||= CompetitorOrderer.new(competitors, lower_is_better).sort
+  def competitors_in_sorted_order(selected_competitors)
+    @competitors_in_sorted_order ||= CompetitorOrderer.new(selected_competitors, lower_is_better).sort
   end
 end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -403,7 +403,11 @@ class Competition < ApplicationRecord
     if event_class == "Overall Champion"
       scoring_helper.rebuild_competitors(scoring_calculator.competitor_bib_numbers)
     end
-    OrderedResultCalculator.new(self, scoring_helper.lower_is_better).update_all_places
+    result_calculator = OrderedResultCalculator.new(self, scoring_helper.lower_is_better)
+    if has_age_group_entry_results?
+      result_calculator.update_age_group_results
+    end
+    result_calculator.update_overall_results
   end
 
   def place_age_group_entry(age_group_entry)

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -320,11 +320,11 @@ class Competition < ApplicationRecord
   end
 
   def has_num_laps?
-    event_class == "Timed Multi-Lap"
+    ScoringClass.for(event_class, self)[:num_laps_enabled]
   end
 
   def uses_tiers?
-    event_class == "Shortest Time with Tiers"
+    ScoringClass.for(event_class, self)[:tiers_enabled]
   end
 
   def age_group_entries

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -395,6 +395,10 @@ class Competition < ApplicationRecord
     end
   end
 
+  def exporter
+    @exporter ||= ScoringClass.for(event_class, self)[:exporter]
+  end
+
   def scoring_helper
     @scoring_helper ||= ScoringClass.for(event_class, self)[:helper]
   end

--- a/app/policies/competition_policy.rb
+++ b/app/policies/competition_policy.rb
@@ -63,11 +63,7 @@ class CompetitionPolicy < ApplicationPolicy
 
   ###### END State Machine transitions ############
 
-  def export_scores?
-    director?(record.event) || super_admin?
-  end
-
-  def export_times?
+  def export?
     director?(record.event) || super_admin?
   end
 

--- a/app/scoring_classes/scoring_class.rb
+++ b/app/scoring_classes/scoring_class.rb
@@ -47,18 +47,18 @@ class ScoringClass
         helper: ArtisticScoringClass_2015.new(competition)
       }
     when "Flatland"
-      helper = FlatlandScoringClass.new(competition)
+      scoring_helper = FlatlandScoringClass.new(competition)
       {
         calculator: FlatlandResultCalculator.new,
-        judge_score_calculator: GenericPlacingPointsCalculator.new(lower_is_better: helper.lower_is_better),
-        helper: helper
+        judge_score_calculator: GenericPlacingPointsCalculator.new(lower_is_better: scoring_helper.lower_is_better),
+        helper: scoring_helper
       }
     when "Street"
-      helper = StreetScoringClass.new(competition)
+      scoring_helper = StreetScoringClass.new(competition)
       {
         calculator: StreetResultCalculator.new,
-        judge_score_calculator: GenericPlacingPointsCalculator.new(lower_is_better: helper.lower_is_better),
-        helper: helper
+        judge_score_calculator: GenericPlacingPointsCalculator.new(lower_is_better: scoring_helper.lower_is_better),
+        helper: scoring_helper
       }
     when "Street Final"
       {

--- a/app/scoring_classes/scoring_class.rb
+++ b/app/scoring_classes/scoring_class.rb
@@ -1,24 +1,28 @@
 class ScoringClass
-  def self.for(scoring_class, competition)
+  def self.for(scoring_class, competition) # rubocop:disable Metrics/MethodLength
     case scoring_class
     when "Shortest Time with Tiers"
       {
         calculator: ShortestTimeWithTierCalculator.new,
+        exporter: EnteredDataExporter::Time.new(competition),
         helper: RaceScoringClass.new(competition)
       }
     when "Shortest Time"
       {
         calculator: RaceResultCalculator.new,
+        exporter: EnteredDataExporter::Time.new(competition),
         helper: RaceScoringClass.new(competition)
       }
     when "Longest Time"
       {
         calculator: RaceResultCalculator.new,
+        exporter: EnteredDataExporter::Time.new(competition),
         helper: RaceScoringClass.new(competition, false)
       }
     when "Timed Multi-Lap"
       {
         calculator: MultiLapResultCalculator.new,
+        exporter: EnteredDataExporter::Time.new(competition),
         helper: RaceScoringClass.new(competition)
       }
     when "Points Low to High"
@@ -35,6 +39,7 @@ class ScoringClass
       unicon_scoring = !EventConfiguration.singleton.artistic_score_elimination_mode_naucc?
       {
         calculator: ArtisticResultCalculator.new(unicon_scoring),
+        exporter: EnteredDataExporter::Score.new(competition),
         # For Freestyle, the judges enter higher scores for better riders
         judge_score_calculator: GenericPlacingPointsCalculator.new(lower_is_better: false),
         helper: ArtisticScoringClass.new(competition)
@@ -42,6 +47,7 @@ class ScoringClass
     when "Artistic Freestyle IUF 2015"
       {
         calculator: ArtisticResultCalculator_2015.new,
+        exporter: EnteredDataExporter::Score.new(competition),
         judge_score_calculator: Freestyle_2015_JudgePointsCalculator.new,
         helper: ArtisticScoringClass_2015.new(competition)
       }
@@ -49,6 +55,7 @@ class ScoringClass
       scoring_helper = FlatlandScoringClass.new(competition)
       {
         calculator: FlatlandResultCalculator.new,
+        exporter: EnteredDataExporter::Score.new(competition),
         judge_score_calculator: GenericPlacingPointsCalculator.new(lower_is_better: scoring_helper.lower_is_better),
         helper: scoring_helper
       }
@@ -56,12 +63,14 @@ class ScoringClass
       scoring_helper = StreetScoringClass.new(competition)
       {
         calculator: StreetResultCalculator.new,
+        exporter: EnteredDataExporter::Score.new(competition),
         judge_score_calculator: GenericPlacingPointsCalculator.new(lower_is_better: scoring_helper.lower_is_better),
         helper: scoring_helper
       }
     when "Street Final"
       {
         calculator: StreetResultCalculator.new,
+        exporter: EnteredDataExporter::Score.new(competition),
         # We know that Street Finals Are ALWAYS lower is better to assign the points
         # But, we want to leave StreetScoringClass as higher_is_better because
         # that way the higher resulting points win.
@@ -74,6 +83,7 @@ class ScoringClass
     when "High/Long", "High/Long Preliminary IUF 2015", "High/Long Final IUF 2015"
       {
         calculator: DistanceResultCalculator.new,
+        exporter: EnteredDataExporter::MaxDistance.new(competition),
         helper: DistanceScoringClass.new(competition)
       }
     when "Overall Champion"

--- a/app/scoring_classes/scoring_class.rb
+++ b/app/scoring_classes/scoring_class.rb
@@ -5,7 +5,8 @@ class ScoringClass
       {
         calculator: ShortestTimeWithTierCalculator.new,
         exporter: EnteredDataExporter::Time.new(competition),
-        helper: RaceScoringClass.new(competition)
+        helper: RaceScoringClass.new(competition),
+        tiers_enabled: true
       }
     when "Shortest Time"
       {
@@ -23,7 +24,8 @@ class ScoringClass
       {
         calculator: MultiLapResultCalculator.new,
         exporter: EnteredDataExporter::Time.new(competition),
-        helper: RaceScoringClass.new(competition)
+        helper: RaceScoringClass.new(competition),
+        num_laps_enabled: true
       }
     when "Points Low to High"
       {

--- a/app/scoring_classes/scoring_class.rb
+++ b/app/scoring_classes/scoring_class.rb
@@ -13,8 +13,7 @@ class ScoringClass
       }
     when "Longest Time"
       {
-        ### XXX this is strange...the determination as to which is the better score is not needed here?
-        calculator: RaceResultCalculator.new(false),
+        calculator: RaceResultCalculator.new,
         helper: RaceScoringClass.new(competition, false)
       }
     when "Timed Multi-Lap"

--- a/app/views/competitions/_finish_line_data_entry_links.html.haml
+++ b/app/views/competitions/_finish_line_data_entry_links.html.haml
@@ -6,9 +6,9 @@
       = link_to "Recording Sheets", two_attempt_recording_printing_competition_path(competition, options)
       = link_to "(pdf)", two_attempt_recording_printing_competition_path(competition, options.merge(:format => :pdf))
 
-    %li= link_to "Entry Form", user_competition_two_attempt_entries_path(current_user, competition, is_start_times: false)
+    %li= link_to "Entry Form", user_competition_two_attempt_entries_path(current_user, competition, options)
     - if competition.imports_times? && policy(competition).modify_result_data?
-      %li= link_to "Import CSV", display_csv_user_competition_two_attempt_entries_path(current_user, competition, is_start_times: false)
+      %li= link_to "Import CSV", display_csv_user_competition_two_attempt_entries_path(current_user, competition, options)
 
     %li= link_to "Verification", proof_user_competition_two_attempt_entries_path(current_user, competition, options)
 
@@ -18,7 +18,7 @@
       = link_to "(pdf)", single_attempt_recording_printing_competition_path(competition, options.merge(:format => :pdf))
 
     - if competition.imports_times?
-      %li= link_to "Entry Form", data_entry_user_competition_import_results_path(current_user, competition, is_start_times: false)
+      %li= link_to "Entry Form", data_entry_user_competition_import_results_path(current_user, competition, options)
       %li= link_to "Verification", review_user_competition_import_results_path(current_user, competition, options)
     - elsif competition.imports_points?
       %li= link_to "Entry Form", competition_preliminary_external_results_path(competition)
@@ -42,7 +42,7 @@
       %li= link_to "Import Swiss Data", user_competition_swiss_results_path(current_user, competition)
 
   - if competition.imports_times? && policy(competition).modify_result_data?
-    %li= link_to "Import CSV", display_csv_user_competition_import_results_path(current_user, competition, is_start_times: false)
+    %li= link_to "Import CSV", display_csv_user_competition_import_results_path(current_user, competition, options)
 
   - if competition.imports_points? && policy(competition).modify_result_data?
     %li= link_to "Import CSV", display_csv_competition_preliminary_external_results_path(competition)

--- a/app/views/competitions/_start_line_data_entry_links.html.haml
+++ b/app/views/competitions/_start_line_data_entry_links.html.haml
@@ -6,9 +6,9 @@
       = link_to "Recording Sheets", two_attempt_recording_printing_competition_path(competition, options)
       = link_to "(pdf)", two_attempt_recording_printing_competition_path(competition, options.merge(:format => :pdf))
 
-    %li= link_to "Entry Form", user_competition_two_attempt_entries_path(current_user, competition, is_start_times: true)
+    %li= link_to "Entry Form", user_competition_two_attempt_entries_path(current_user, competition, options)
     - if competition.imports_times? && policy(competition).modify_result_data?
-      %li= link_to "Import CSV", display_csv_user_competition_two_attempt_entries_path(current_user, competition, is_start_times: true)
+      %li= link_to "Import CSV", display_csv_user_competition_two_attempt_entries_path(current_user, competition, options)
 
     %li= link_to "Verification", proof_user_competition_two_attempt_entries_path(current_user, competition, options)
 
@@ -17,9 +17,9 @@
       = link_to "Recording Sheets", single_attempt_recording_printing_competition_path(competition, options)
       = link_to "(pdf)", single_attempt_recording_printing_competition_path(competition, options.merge(:format => :pdf))
 
-    %li= link_to "Entry Form", data_entry_user_competition_import_results_path(current_user, competition, is_start_times: true)
+    %li= link_to "Entry Form", data_entry_user_competition_import_results_path(current_user, competition, options)
     - if competition.imports_times? && policy(competition).modify_result_data?
-      %li= link_to "Import CSV", display_csv_user_competition_import_results_path(current_user, competition, is_start_times: true)
+      %li= link_to "Import CSV", display_csv_user_competition_import_results_path(current_user, competition, options)
 
     %li= link_to "Verification", review_user_competition_import_results_path(current_user, competition, options)
 
@@ -32,6 +32,7 @@
   - when "Externally Ranked"
     %li= link_to "View", review_user_competition_import_results_path(current_user, competition, options)
 
+  // Depends on event_class
   - if policy(competition).assign_tiers?
     %li= link_to "Assign Tiers", competition_tier_assignments_path(competition)
 

--- a/app/views/competitions/distance_attempts.html.haml
+++ b/app/views/competitions/distance_attempts.html.haml
@@ -24,5 +24,5 @@
           %td= da.competitor.place
           %td= da.competitor.overall_place_formatted
   %hr
-  - if policy(@competition).export_scores?
-    = link_to 'Download Scores CSV', export_scores_competition_path(@competition)
+  - if policy(@competition).export?
+    = link_to 'Download Scores CSV', export_competition_path(@competition)

--- a/app/views/competitions/freestyle_scores.html.haml
+++ b/app/views/competitions/freestyle_scores.html.haml
@@ -18,4 +18,4 @@
   = render partial: "scores_summary", locals: { competitors: @competition.competitors.active }
   .non_printable
     %hr
-    = link_to 'Download Scores CSV', export_scores_competition_path(@competition)
+    = link_to 'Download Scores CSV', export_competition_path(@competition)

--- a/app/views/competitions/time_results.html.haml
+++ b/app/views/competitions/time_results.html.haml
@@ -3,5 +3,5 @@
 = render :partial => "/competitions/results"
 = render :partial => "/time_results/results"
 
-- if policy(@competition).export_times?
-  = link_to 'Download Scores CSV', export_times_competition_path(@competition)
+- if policy(@competition).export?
+  = link_to 'Download Scores CSV', export_competition_path(@competition)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -551,8 +551,7 @@ Rails.application.routes.draw do
         post :sort_random
         post :set_age_group_places
         post :set_places
-        get :export_scores
-        get :export_times
+        get :export
         # view scores
         get :result
         delete :destroy_all_results

--- a/spec/lib/ordered_result_calculator_spec.rb
+++ b/spec/lib/ordered_result_calculator_spec.rb
@@ -3,7 +3,10 @@ require 'spec_helper'
 describe OrderedResultCalculator do
   def recalc
     Rails.cache.clear
-    @calc.update_all_places
+    if @competition.has_age_group_entry_results?
+      @calc.update_age_group_results
+    end
+    @calc.update_overall_results
   end
 
   before(:each) do

--- a/spec/lib/race_calculator_spec.rb
+++ b/spec/lib/race_calculator_spec.rb
@@ -3,7 +3,10 @@ require 'spec_helper'
 describe OrderedResultCalculator do
   def recalc(calc = @calc)
     Rails.cache.clear
-    calc.update_all_places
+    if @competition.has_age_group_entry_results?
+      calc.update_age_group_results
+    end
+    calc.update_overall_results
     @tr1.try(:reload)
     @tr2.try(:reload)
     @tr3.try(:reload)
@@ -192,17 +195,17 @@ describe OrderedResultCalculator do
     it "has increasing thousands" do
       @all_together = FactoryGirl.create(:age_group_type)
       FactoryGirl.create(:age_group_entry, age_group_type: @all_together, start_age: 0, end_age: 100, gender: "Male")
-      @comp = FactoryGirl.create(:timed_competition, age_group_type: @all_together)
+      @competition = FactoryGirl.create(:timed_competition, age_group_type: @all_together)
       travel 2.seconds do
-        tr1 = FactoryGirl.create(:time_result, minutes: 1, seconds: 15, thousands: 935, competitor: FactoryGirl.create(:event_competitor, competition: @comp))
-        tr2 = FactoryGirl.create(:time_result, minutes: 1, seconds: 23, thousands: 97, competitor: FactoryGirl.create(:event_competitor, competition: @comp))
-        tr4 = FactoryGirl.create(:time_result, minutes: 1, seconds: 26, thousands: 745, competitor: FactoryGirl.create(:event_competitor, competition: @comp))
-        tr5 = FactoryGirl.create(:time_result, minutes: 1, seconds: 28, thousands: 498, competitor: FactoryGirl.create(:event_competitor, competition: @comp))
-        tr3 = FactoryGirl.create(:time_result, minutes: 1, seconds: 25, thousands: 206, competitor: FactoryGirl.create(:event_competitor, competition: @comp))
-        tr6 = FactoryGirl.create(:time_result, minutes: 1, seconds: 32, thousands: 508, competitor: FactoryGirl.create(:event_competitor, competition: @comp))
-        tr7 = FactoryGirl.create(:time_result, minutes: 1, seconds: 32, thousands: 815, competitor: FactoryGirl.create(:event_competitor, competition: @comp))
+        tr1 = FactoryGirl.create(:time_result, minutes: 1, seconds: 15, thousands: 935, competitor: FactoryGirl.create(:event_competitor, competition: @competition))
+        tr2 = FactoryGirl.create(:time_result, minutes: 1, seconds: 23, thousands: 97, competitor: FactoryGirl.create(:event_competitor, competition: @competition))
+        tr4 = FactoryGirl.create(:time_result, minutes: 1, seconds: 26, thousands: 745, competitor: FactoryGirl.create(:event_competitor, competition: @competition))
+        tr5 = FactoryGirl.create(:time_result, minutes: 1, seconds: 28, thousands: 498, competitor: FactoryGirl.create(:event_competitor, competition: @competition))
+        tr3 = FactoryGirl.create(:time_result, minutes: 1, seconds: 25, thousands: 206, competitor: FactoryGirl.create(:event_competitor, competition: @competition))
+        tr6 = FactoryGirl.create(:time_result, minutes: 1, seconds: 32, thousands: 508, competitor: FactoryGirl.create(:event_competitor, competition: @competition))
+        tr7 = FactoryGirl.create(:time_result, minutes: 1, seconds: 32, thousands: 815, competitor: FactoryGirl.create(:event_competitor, competition: @competition))
 
-        rc = OrderedResultCalculator.new(@comp)
+        rc = OrderedResultCalculator.new(@competition)
         recalc(rc)
 
         expect(tr1.reload.competitor.place).to eq(1)


### PR DESCRIPTION
Break out various small pieces of code which are scattered throughout the codebase, start making the different scoring/display/export/import configurations more clearly specified.