### PR TITLE
Prevent Age Group Type error if multiple entries are named the same

### DIFF
--- a/app/models/age_group_type.rb
+++ b/app/models/age_group_type.rb
@@ -20,6 +20,7 @@ class AgeGroupType < ApplicationRecord
   has_many :competitions, dependent: :nullify
 
   accepts_nested_attributes_for :age_group_entries, allow_destroy: true
+  validates_uniqueness :age_group_entries, attribute_name: :short_description
 
   after_save :update_competitor_age_group_entries
   after_touch :update_competitor_age_group_entries

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,4 +1,30 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  # https://github.com/rails/rails/issues/20676#issuecomment-250912430
+  def self.validates_uniqueness(*attr_names)
+    # Set the default configuration
+    configuration = { attribute_name: :name, message: I18n.t('validations.duplicate') }
+
+    # Update defaults with any supplied configuration values
+    configuration.update(attr_names.extract_options!)
+
+    validates_each(attr_names) do |record, record_attr_name, value|
+      duplicates = Set.new
+      attr_name = configuration[:attribute_name]
+      value.map do |obj|
+        # be sure to not count the destroyed objects
+        next if obj.marked_for_destruction?
+        cur_attr_value = obj.try(attr_name)
+        if duplicates.member?(cur_attr_value)
+          # mark the record as in error so validation will detect a failure
+          record.errors.add(record_attr_name, '')
+          obj.errors.add(attr_name, configuration[:message])
+        else
+          duplicates.add(cur_attr_value)
+        end
+      end
+    end
+  end
 end

--- a/config/locales/base.en.yml
+++ b/config/locales/base.en.yml
@@ -40,3 +40,5 @@ en:
     music: Music
     set_wheel_sizes: Wheel Sizes
   'yes': 'Yes'
+  validations:
+    duplicate: "Must be unique"

--- a/spec/actions/age_group_type_duplicator_spec.rb
+++ b/spec/actions/age_group_type_duplicator_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AgeGroupTypeDuplicator do
   let!(:age_group_entry) { FactoryGirl.create(:age_group_entry, age_group_type: age_group_type) }
 
   def do_action
-    described_class.new(age_group_type).duplicate
+    described_class.new(age_group_type.reload).duplicate
   end
 
   it 'can duplicate an age group' do

--- a/spec/actions/heat_assignment_creator_spec.rb
+++ b/spec/actions/heat_assignment_creator_spec.rb
@@ -22,6 +22,9 @@ describe HeatAssignmentCreator do
 
   describe "with a single age group" do
     let!(:age_group_entry) { FactoryGirl.create(:age_group_entry, age_group_type: age_group_type) }
+    before do
+      competition.reload # to load the age_group_entries
+    end
 
     it "assigns the competitors by their returned order" do
       expect{ perform }.to change(LaneAssignment, :count).by(3)

--- a/spec/models/competition_sign_up_spec.rb
+++ b/spec/models/competition_sign_up_spec.rb
@@ -16,6 +16,7 @@ describe CompetitionSignUp do
   let(:competition) { FactoryGirl.create(:competition, age_group_type: agt) }
   let(:competition_sign_up) { described_class.new(competition) }
   before do
+    agt.reload # load the age_group_entries
     allow(competition).to receive(:signed_up_registrants).and_return([young_registrant, middle_registrant, old_registrant])
   end
 


### PR DESCRIPTION
Resolves #359