### PR TITLE
Prevent import with no time data column from crashing.

### DIFF
--- a/app/actions/importers/status_translation/german.rb
+++ b/app/actions/importers/status_translation/german.rb
@@ -3,9 +3,7 @@ class Importers::StatusTranslation::German
     case status
     when "", nil
       nil
-    when "disq"
-      "DQ"
-    when "abgem"
+    when "disq", "abgem"
       "DQ"
     else
       "active"

--- a/app/actions/importers/status_translation/swiss.rb
+++ b/app/actions/importers/status_translation/swiss.rb
@@ -1,7 +1,9 @@
 class Importers::StatusTranslation::Swiss
   def self.translate(status)
-    case status.downcase
+    case status.try(:downcase)
     when "gestürzt", "scratched", "nicht am start", "disq. rot", "disq. rot agh", "disqualifiziert", "disq. blau", "nicht im ziel"
+      "DQ"
+    when nil
       "DQ"
     else
       "active" # New behavior
@@ -9,7 +11,7 @@ class Importers::StatusTranslation::Swiss
   end
 
   def self.dq_description(status)
-    case status.downcase
+    case status.try(:downcase)
     when "gestürzt"
       "Dismount"
     when "scratched"
@@ -26,6 +28,8 @@ class Importers::StatusTranslation::Swiss
       "5m Line"
     when "nicht im ziel"
       "DNF"
+    when nil
+      "No Data"
     end
   end
 end

--- a/spec/models/swiss_heat_results_spec.rb
+++ b/spec/models/swiss_heat_results_spec.rb
@@ -29,4 +29,10 @@ describe SwissHeatResult do
     expect(result.status).to eq("DQ")
     expect(result.status_description).to eq("Restart")
   end
+
+  it "can parse a row without a time" do
+    result = described_class.from_string("DNK\t\t555\t1", 14)
+    expect(result.status).to eq("DQ")
+    expect(result.status_description).to eq("No Data")
+  end
 end


### PR DESCRIPTION
Fixes #360.

Marks entries as DQ if they have no Time nor Reason in the file