### PR TITLE
Remove ' not guaranteed until your payment has been received' message…

### DIFF
--- a/app/views/registrant_expense_items/_expenses.html.haml
+++ b/app/views/registrant_expense_items/_expenses.html.haml
@@ -25,5 +25,5 @@
           %tr
             %th.text-right= t(".total")
             %th{ colspan: include_form ? 3 : 2}= print_formatted_currency(registrant.expenses_total)
-
-      %p.small.non_printable= t(".items_not_guaranteed")
+      - if @config.online_payment? || @config.offline_payment?
+        %p.small.non_printable= t(".items_not_guaranteed")


### PR DESCRIPTION
… when no online payment.

To reduce confusion for users on a system where all payment is on-site

Fixes #358