### PR TITLE
Fix hours facade

### DIFF
--- a/app/models/concerns/hours_facade.rb
+++ b/app/models/concerns/hours_facade.rb
@@ -10,7 +10,7 @@ module HoursFacade
   extend ActiveSupport::Concern
   # NOT YET fully tested to be working.
   def facade_minutes
-    return nil if self[:minutes].blank?
+    return nil if minutes.blank?
     minutes % 60
   end
 
@@ -19,7 +19,7 @@ module HoursFacade
   end
 
   def facade_hours
-    return nil if self[:minutes].blank?
+    return nil if minutes.blank?
     minutes / 60
   end
 

--- a/spec/models/concerns/hours_facade_spec.rb
+++ b/spec/models/concerns/hours_facade_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+class Entry
+  attr_accessor :minutes, :seconds, :thousands
+  include HoursFacade
+end
+
+describe "Entry" do
+  let(:subject) { Entry.new }
+
+  it "can calculate thousands from hundreds" do
+    subject.facade_hundreds = 123
+    expect(subject.thousands).to eq(1230)
+  end
+
+  it "can change minutes without affecting hours" do
+    subject.facade_minutes = 5
+    subject.facade_hours = 1
+    subject.facade_minutes = 10
+    expect(subject.facade_hours).to eq(1)
+    expect(subject.facade_minutes).to eq(10)
+    expect(subject.minutes).to eq(70)
+  end
+end


### PR DESCRIPTION
TwoAttemptEntry was failing because it uses HoursFacade with a non-ActiveRecord-backed element.