### PR TITLE
Remove Paypal IPN setup instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,15 +217,6 @@ Specify whether to use the LIVE or TEST PAYPAL Site (default: Test)
 
 Paypal Settings required for proper integration:
 
-Instant Payment Notification (IPN)
-
-We used to think that the Paypal account had to have IPN settings enabled through the UI (Instructions from paypal: https://developer.paypal.com/docs/classic/ipn/integration-guide/IPNSetup/).
-
-  The <notification url> will be the hosted website URL, with /payments/notification at the end.
-  Example: https://registrationtest.unicycling-software.com/payments/notification
-
-NOTE: We no longer believe that this is necessary. When a user is sent to paypal to pay, that request includes the necessary IPN `notify_url` so that we will receive a message. The following settings may be necessary though:
-
 Auto-Return
 
 Enable Auto Return:

--- a/app/views/convention_setup/event_configurations/payment_settings.html.haml
+++ b/app/views/convention_setup/event_configurations/payment_settings.html.haml
@@ -6,22 +6,10 @@
 %h2 Paypal Settings
 
 %p
-  There are 3 paypal settings which need to be configured within the receiving paypal account:
+  There are 2 paypal settings which can to be configured within the receiving paypal account:
 
 %div
-  %h3 1) Instant Payment Notification (IPN)
-
-  %p
-    We used to think that the Paypal account had to have IPN settings enabled through the UI (Instructions from paypal: https://developer.paypal.com/docs/classic/ipn/integration-guide/IPNSetup/).
-
-  %p
-    The <notification url> will be the hosted website URL, with /payments/notification at the end.
-    Example: https://registrationtest.unicycling-software.com/payments/notification
-  %p
-    NOTE: We no longer believe that this is necessary. When a user is sent to paypal to pay, that request includes the necessary IPN `notify_url` so that we will receive a message. The following settings may be necessary though:
-
-%div
-  %h3 2) Auto-Return
+  %h3 1) Auto-Return
 
   %p
     This means that after a payment is done, the user's browser will be redirected back to the registration website
@@ -39,7 +27,7 @@
   <return_url> will be https://registrationtest.regtest.unicycling-software.com/payments/
 
 %div
-  %h3 3) Account Optional
+  %h3 2) Account Optional
 
   %p Make it so that user can pay with paypal, without having a paypal account (useful if they just want to pay with a credit card
 
@@ -47,10 +35,6 @@
 
   %p
     "My Account -> Profile -> Sellers Preferences -> Website Payment Preferences -> PayPal Account Optional (On) -> save"
-
-
-%p
-  = t(".ipn_url", url: "https://#{@tenant.permanent_url}/payments/notification")
 
 %fieldset.form__fieldset
   = simple_form_for(@event_configuration, url: update_payment_settings_event_configuration_path, method: :put) do |f|

--- a/config/locales/views/convention_setup/event_configurations/payment_settings.de.yml
+++ b/config/locales/views/convention_setup/event_configurations/payment_settings.de.yml
@@ -4,7 +4,5 @@ de:
     event_configurations:
       payment_settings:
         description: "Wenn du Zahlungen via PayPal empfangen möchtest, trage hier
-          deine paypal account email adresse ein.\r\nDu musst auch einen IPN konfigurieren
-          damit die Anmeldeseite über Zahlungen informiert ist."
+          deine paypal account email adresse ein."
         header: Zahlungs Einstellungen
-        ipn_url: Die URL für den IPN sollte %{url} sein

--- a/config/locales/views/convention_setup/event_configurations/payment_settings.en.yml
+++ b/config/locales/views/convention_setup/event_configurations/payment_settings.en.yml
@@ -6,6 +6,3 @@ en:
         header: Payment Settings
         description: |
           If you would like to receive payment via PayPal, enter your paypal account e-mail here.
-          You will also need to set up an IPN so that the registration website is informed of
-          payments.
-        ipn_url: The URL for the IPN should be %{url}

--- a/config/locales/views/convention_setup/event_configurations/payment_settings.fr.yml
+++ b/config/locales/views/convention_setup/event_configurations/payment_settings.fr.yml
@@ -4,7 +4,5 @@ fr:
     event_configurations:
       payment_settings:
         description: "Si vous voulez recevoir des paiement via PayPal, saisissez l'e-mail
-          du compte correspondant ici.\r\nVous devrez également créer un IPN(?) pour
-          que le site web d'inscription soit\r\ninformé des\r\npaiements."
+          du compte correspondant ici."
         header: Paramètres de paiement
-        ipn_url: L'URL de l'IPN(?) devra être %{url}


### PR DESCRIPTION
We have determined that we WILL receive IPN no matter whether
the paypal account has it set up or not (based on the data we
send to it).