### PR TITLE
Add registrant data import/export

### DIFF
--- a/app/actions/exporters/registrant_exporter.rb
+++ b/app/actions/exporters/registrant_exporter.rb
@@ -32,7 +32,7 @@ class Exporters::RegistrantExporter
     result = []
     events.map do |event|
       result << "EV: #{event.name} - Signed Up (Y/N)"
-      result << "EV: #{event.name} - Best Time (none)"
+      result << "EV: #{event.name} - Best Time (#{event.best_time_format})"
 
       category_names = event.event_categories.map(&:name).join("/")
       result << "EV: #{event.name} - Category (#{category_names})"

--- a/app/actions/exporters/registrant_exporter.rb
+++ b/app/actions/exporters/registrant_exporter.rb
@@ -1,0 +1,81 @@
+# Export Registrant and Event-Sign-Up information
+class Exporters::RegistrantExporter
+  def headers
+    [
+      "ID",
+      "First Name",
+      "Last Name",
+      "Birthday (dd/mm/yy)",
+      "Sex (m/f)"
+    ] + event_headers
+  end
+
+  def rows
+    Registrant.all.map do |registrant|
+      [
+        registrant.bib_number.to_s,
+        registrant.first_name,
+        registrant.last_name,
+        registrant.birthday.strftime("%d/%m/%y"),
+        registrant.gender == "Male" ? "m" : "f"
+      ] + event_rows(registrant)
+    end
+  end
+
+  private
+
+  def events
+    @events ||= Event.all.order(:id).includes(:event_categories, :event_choices)
+  end
+
+  def event_headers
+    result = []
+    events.map do |event|
+      result << "EV: #{event.name} - Signed Up (Y/N)"
+      result << "EV: #{event.name} - Best Time (none)"
+
+      category_names = event.event_categories.map(&:name).join("/")
+      result << "EV: #{event.name} - Category (#{category_names})"
+
+      event.event_choices.each do |event_choice|
+        result << "EV: #{event.name} - Choice: #{event_choice.label}"
+      end
+    end
+
+    result
+  end
+
+  def event_rows(registrant)
+    result = []
+
+    events.map do |event|
+      resu = registrant.registrant_event_sign_ups.find{ |resup| resup.event == event }
+      if resu&.signed_up?
+        result << "Y"
+
+        rbt = registrant.registrant_best_times.find{|rbtime| rbtime.event == event }
+        if rbt
+          result << rbt.formatted_value
+        else
+          result << ""
+        end
+
+        result << resu.event_category.name
+        event.event_choices.each do |event_choice|
+          rc = registrant.registrant_choices.find{|rchoice| rchoice.event_choice == event_choice }
+          result << rc.value
+        end
+      else
+        result << "N"
+        result << "" # best time
+        result << "" # event category
+
+        event.event_choices.each do |_event_choice|
+          result << ""
+        end
+      end
+    end
+
+    result
+  end
+end

--- a/app/actions/importers/base_importer.rb
+++ b/app/actions/importers/base_importer.rb
@@ -1,8 +1,7 @@
 class Importers::BaseImporter
-  attr_accessor :competition, :user, :num_rows_processed, :errors
+  attr_accessor :user, :num_rows_processed, :errors
 
-  def initialize(competition, user)
-    @competition = competition
+  def initialize(user)
     @user = user
   end
 

--- a/app/actions/importers/competition_data_importer.rb
+++ b/app/actions/importers/competition_data_importer.rb
@@ -1,0 +1,8 @@
+class Importers::CompetitionDataImporter < Importers::BaseImporter
+  attr_accessor :competition
+
+  def initialize(competition, user)
+    super(user)
+    @competition = competition
+  end
+end

--- a/app/actions/importers/external_result_importer.rb
+++ b/app/actions/importers/external_result_importer.rb
@@ -1,4 +1,4 @@
-class Importers::ExternalResultImporter < Importers::BaseImporter
+class Importers::ExternalResultImporter < Importers::CompetitionDataImporter
   def process(file, processor)
     return false unless valid_file?(file)
 

--- a/app/actions/importers/heat_lane_lif_importer.rb
+++ b/app/actions/importers/heat_lane_lif_importer.rb
@@ -1,4 +1,4 @@
-class Importers::HeatLaneLifImporter < Importers::BaseImporter
+class Importers::HeatLaneLifImporter < Importers::CompetitionDataImporter
   def process(file, heat, processor)
     return false unless valid_file?(file)
 

--- a/app/actions/importers/import_result_importer.rb
+++ b/app/actions/importers/import_result_importer.rb
@@ -1,4 +1,4 @@
-class Importers::ImportResultImporter < Importers::BaseImporter
+class Importers::ImportResultImporter < Importers::CompetitionDataImporter
   def process(file, start_times, processor)
     return false unless valid_file?(file)
 

--- a/app/actions/importers/parsers/registrant_import.rb
+++ b/app/actions/importers/parsers/registrant_import.rb
@@ -1,0 +1,43 @@
+# CsvExtractor converts from file into array-of-arrays
+# Processor converts from array-of-arrays into array of hashes
+# {
+#   id: "1",
+#   first_name: "Bob",
+#   last_name: "Smith",
+#   birthday: "10/4/76",
+#   gender: "m",
+#   events: [
+#      {
+#        name: "100m",
+#        signed_up: true,
+#        best_time: "20.03",
+#        choices: [
+#          { "Team Name" => 100m" }
+#        ],
+#      }
+#   ]
+# }
+class Importers::Parsers::RegistrantImport
+  def extract_file(file)
+    arrays = Importers::CsvExtractor.new(file).extract_csv
+    [
+      {
+        id: "1",
+        first_name: "Bob",
+        last_name: "Smith",
+        birthday: "10/4/76",
+        gender: "m",
+        events: [
+          {
+            name: "100m",
+            signed_up: true,
+            best_time: "20.03",
+            choices: [
+              { "Team Name" => "100m" }
+            ]
+          }
+        ]
+      }
+    ]
+  end
+end

--- a/app/actions/importers/parsers/registrant_import.rb
+++ b/app/actions/importers/parsers/registrant_import.rb
@@ -87,9 +87,10 @@ class Importers::Parsers::RegistrantImport
   # }
   def event_data(element_finder)
     events.map do |event|
+      category_names = event.event_categories.map(&:name).join("/")
       event_hash = {
         name: event.name,
-        category: element_finder.find("EV: #{event.name} - Category (All)"),
+        category: element_finder.find("EV: #{event.name} - Category (#{category_names})"),
         signed_up: (element_finder.find("EV: #{event.name} - Signed Up (Y/N)") == "Y"),
         best_time: element_finder.find("EV: #{event.name} - Best Time (#{event.best_time_format})")
       }

--- a/app/actions/importers/parsers/registrant_import.rb
+++ b/app/actions/importers/parsers/registrant_import.rb
@@ -91,8 +91,7 @@ class Importers::Parsers::RegistrantImport
         name: event.name,
         category: element_finder.find("EV: #{event.name} - Category (All)"),
         signed_up: (element_finder.find("EV: #{event.name} - Signed Up (Y/N)") == "Y"),
-        best_time: element_finder.find("EV: #{event.name} - Best Time (#{event.best_time_format})"),
-        choices: []
+        best_time: element_finder.find("EV: #{event.name} - Best Time (#{event.best_time_format})")
       }
 
       choices = {}
@@ -100,7 +99,7 @@ class Importers::Parsers::RegistrantImport
         choices[event_choice.label] = element_finder.find("EV: #{event.name} - Choice: #{event_choice.label}")
       end
 
-      event_hash[:choices] << choices
+      event_hash[:choices] = choices
       event_hash
     end
   end

--- a/app/actions/importers/parsers/registrant_import.rb
+++ b/app/actions/importers/parsers/registrant_import.rb
@@ -18,6 +18,24 @@
 #   ]
 # }
 class Importers::Parsers::RegistrantImport
+  class ElementFinder
+    def initialize(headers, row)
+      @headers = headers
+      @row = row
+    end
+
+    def find(element_name)
+      target_index = @headers.find_index(element_name)
+      @row[target_index]
+    end
+  end
+
+  attr_reader :errors
+
+  def initialize
+    @errors = []
+  end
+
   def extract_file(file)
     arrays = Importers::CsvExtractor.new(file).extract_csv
     [
@@ -39,5 +57,58 @@ class Importers::Parsers::RegistrantImport
         ]
       }
     ]
+  end
+
+  def validate_headers
+    Event.all.each do |event|
+      unless element_finder.find("EV: #{event.name} - Signed Up (Y/N)")
+        @errors << "Unable to find event #{event.name}"
+      end
+    end
+  end
+
+  def convert_row(header, row)
+    element_finder = ElementFinder.new(header, row)
+    base_data = {
+      id: element_finder.find("ID"),
+      first_name: element_finder.find("First Name"),
+      last_name: element_finder.find("Last Name"),
+      birthday: element_finder.find("Birthday (dd/mm/yy)"),
+      gender: element_finder.find("Sex (m/f)"),
+      events: []
+    }
+    # EV: 100m - Signed Up (Y/N)
+    # EV: 100m - Category (All)
+    # EV: 100m - Best Time ((m)m:ss.xx)
+    # EV: 100m - Choice: Team Name
+
+    # {
+    #   name: "100m",
+    #   category: "All"
+    #   signed_up: true,
+    #   best_time: "20.03",
+    #   choices: [
+    #     { "Team Name" => "100m Team" }
+    #   ]
+    # }
+    Event.all.each do |event|
+      event_hash = {
+        name: event.name,
+        category: element_finder.find("EV: #{event.name} - Category (All)"),
+        signed_up: (element_finder.find("EV: #{event.name} - Signed Up (Y/N)") == "Y"),
+        best_time: element_finder.find("EV: #{event.name} - Best Time (#{event.best_time_format})"),
+        choices: []
+      }
+
+      choices = {}
+      event.event_choices.each do |event_choice|
+        choices[event_choice.label] = element_finder.find("EV: #{event.name} - Choice: #{event_choice.label}")
+      end
+
+      event_hash[:choices] << choices
+      base_data[:events] << event_hash
+    end
+
+    base_data
   end
 end

--- a/app/actions/importers/registrant_data_importer.rb
+++ b/app/actions/importers/registrant_data_importer.rb
@@ -113,7 +113,7 @@ class Importers::RegistrantDataImporter < Importers::BaseImporter
     event = Event.find_by!(name: event_hash[:name])
     resu = registrant.registrant_event_sign_ups.build(event: event)
     resu.signed_up = event_hash[:signed_up]
-    resu.event_category = event.event_categories.first
+    resu.event_category = event.event_categories.find{|event_category| event_category.name == event_hash[:category] }
     resu.save!
   end
 

--- a/app/actions/importers/registrant_data_importer.rb
+++ b/app/actions/importers/registrant_data_importer.rb
@@ -1,0 +1,125 @@
+# Import the registrant-sign-up and details
+class Importers::RegistrantDataImporter < Importers::BaseImporter
+  def process(file, processor)
+    return false unless valid_file?(file)
+
+    registrant_data = processor.extract_file(file)
+    self.num_rows_processed = 0
+    self.errors = nil
+    Registrant.transaction do
+      registrant_data.each do |registrant_hash|
+        # CsvExtractor converts from file into array-of-arrays
+        # Processor converts from array-of-arrays into array of hashes of form:
+        # {
+        #   id: "1",
+        #   first_name: "Bob",
+        #   last_name: "Smith",
+        #   birthday: "10/4/76",
+        #   gender: "m",
+        #   events: [
+        #      {
+        #        name: "100m",
+        #        signed_up: true,
+        #        best_time: "20.03",
+        #        choices: [
+        #          { "Team Name" => 100m" }
+        #        ],
+        #      }
+        #   ]
+        # }
+        # for each remaining column in the import, search for the matching Event
+        # format of column headers:
+        # Event: <name>
+        # Event Best Time: <name>
+        # Event Choice: <name>. Choice: <choice name>
+
+        #   If the column is empty, ensure the user is not-signed-up
+        #   else
+        #     If the event takes best times
+        #       if value is formatted with a ":", enter it as minutes/seconds.
+        #       if value is formatted with a ".", enter it as seconds/thousands
+
+        if build_and_save_imported_result(registrant_hash, @user)
+          self.num_rows_processed += 1
+        end
+      end
+    end
+  rescue ActiveRecord::RecordInvalid => invalid
+    @errors = invalid
+    return false
+  end
+
+  # Public: Create an Registrant object.
+  # Throws an exception if not valid
+  def build_and_save_imported_result(registrant_hash, user)
+    registrant = find_existing_registrant(registrant_hash)
+    registrant.gender = if registrant_hash[:gender] == "m"
+                          "Male"
+                        else
+                          "Female"
+                        end
+    registrant.user = user
+
+    set_event_sign_ups(registrant, registrant_hash[:events])
+    registrant.save!
+    # if we already have a registrant matching this name+birthday+gender
+    # else create a new registrant with this name+birthday+gender
+
+    # for each remaining column in the import, search for the matching Event
+    # format of column headers:
+    # Event: <name>
+    # Event Best Time: <name>
+    # Event Choice: <name>. Choice: <choice name>
+
+    Registrant.create!(user: user)
+  end
+
+  # finds existing registrant, or initializes a new one
+  def find_existing_registrant(registrant_hash)
+    existing_registrant(registrant_hash) || new_registrant(registrant_hash)
+  end
+
+  def existing_registrant(registrant_hash)
+    # case-insensitive search
+    Registrant
+      .where(Registrant.arel_table[:first_name].lower.matches(registrant_hash[:first_name].downcase))
+      .where(Registrant.arel_table[:last_name].lower.matches(registrant_hash[:last_name].downcase))
+      .where(birthday: parse_birthday(registrant_hash[:birthday])).first
+  end
+
+  def new_registrant(registrant_hash)
+    Registrant.new(
+      first_name: registrant_hash[:first_name],
+      last_name: registrant_hash[:last_name],
+      birthday: parse_birthday(registrant_hash[:birthday])
+    )
+  end
+
+  def set_event_sign_ups(registrant, events_hash)
+    events_hash.each do |event_hash|
+      set_event_sign_up(registrant, event_hash)
+    end
+  end
+
+  # {
+  #   name: "100m",
+  #   signed_up: true,
+  #   best_time: "20.03",
+  #   choices: [
+  #     { "Team Name" => 100m" }
+  #   ],
+  # }
+  def set_event_sign_up(registrant, event_hash)
+    event = Event.find_by!(name: event_hash[:name])
+    resu = registrant.registrant_event_sign_ups.build(event: event)
+    resu.signed_up = event_hash[:signed_up]
+    resu.event_category = event.event_categories.first
+    resu.save!
+  end
+
+  def parse_birthday(birthday, day_first: true)
+    fmt = day_first ? "%d/%m/%y" : "%m/%d/%y"
+
+    Date.strptime(birthday, fmt)
+  end
+end

--- a/app/actions/importers/swiss_result_importer.rb
+++ b/app/actions/importers/swiss_result_importer.rb
@@ -1,4 +1,4 @@
-class Importers::SwissResultImporter < Importers::BaseImporter
+class Importers::SwissResultImporter < Importers::CompetitionDataImporter
   # Create ImportResult records from a file.
   def process(file, heat, processor, heats: true)
     return false unless valid_file?(file)

--- a/app/actions/importers/two_attempt_entry_importer.rb
+++ b/app/actions/importers/two_attempt_entry_importer.rb
@@ -1,4 +1,4 @@
-class Importers::TwoAttemptEntryImporter < Importers::BaseImporter
+class Importers::TwoAttemptEntryImporter < Importers::CompetitionDataImporter
   def process(file, start_times, processor)
     return false unless valid_file?(file)
 

--- a/app/actions/importers/wave_updater.rb
+++ b/app/actions/importers/wave_updater.rb
@@ -1,4 +1,4 @@
-class Importers::WaveUpdater < Importers::BaseImporter
+class Importers::WaveUpdater < Importers::CompetitionDataImporter
   def process(file, processor)
     return false unless valid_file?(file)
 

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -5,6 +5,13 @@ class ExportController < ApplicationController
 
   def index; end
 
+  def download_registrants
+    exporter = Exporters::RegistrantExporter.new
+    headers = exporter.headers
+    data = exporter.rows
+    output_spreadsheet(headers, data, "download_registrants_#{Date.today}")
+  end
+
   def download_competitors_for_timers
     exporter = Exporters::AllCompetitors.new
     csv_string = CSV.generate do |csv|
@@ -23,7 +30,7 @@ class ExportController < ApplicationController
     exporter = Exporters::EventsExporter.new
     headers = exporter.headers
     data = exporter.rows
-    output_spreadsheet(headers, data, "download_events#{Date.today}")
+    output_spreadsheet(headers, data, "download_events_#{Date.today}")
   end
 
   def download_payment_details

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -2,6 +2,21 @@ class ImportsController < ApplicationController
   before_action :authenticate_user!
   before_action :authorize_action
 
+  def index; end
+
+  def import_registrants
+    file = params[:file]
+    importer = Importers::RegistrantDataImporter.new(current_user)
+    parser = Importers::Parsers::RegistrantImport.new
+
+    if importer.process(params[:file], parser)
+      flash[:notice] = "Import Successful"
+    else
+      flash[:alert] = "Import errors #{importer.errors}"
+    end
+    redirect_to imports_path
+  end
+
   def new; end
 
   def create

--- a/app/policies/export_policy.rb
+++ b/app/policies/export_policy.rb
@@ -1,6 +1,6 @@
 class ExportPolicy < ApplicationPolicy
   def index?
-    download_payment_details? || results?
+    download_payment_details? || results? || download_events?
   end
 
   def download_registrants?

--- a/app/policies/export_policy.rb
+++ b/app/policies/export_policy.rb
@@ -3,6 +3,10 @@ class ExportPolicy < ApplicationPolicy
     download_payment_details? || results?
   end
 
+  def download_registrants?
+    event_planner? || super_admin?
+  end
+
   def download_competitors_for_timers?
     user.has_role?(:race_official, :any) || competition_admin? || super_admin?
   end

--- a/app/policies/import_policy.rb
+++ b/app/policies/import_policy.rb
@@ -1,4 +1,12 @@
 class ImportPolicy < ApplicationPolicy
+  def index?
+    event_planner? || super_admin?
+  end
+
+  def import_registrants?
+    event_planner? || super_admin?
+  end
+
   def create?
     super_admin?
   end

--- a/app/views/export/index.html.haml
+++ b/app/views/export/index.html.haml
@@ -19,3 +19,8 @@
 
 - if policy(:export).results?
   = link_to "Download all results", export_results_path(format: :xls)
+  %br
+
+- if policy(:export).download_registrants?
+  = link_to "Download Registrants and Event Sign ups", export_download_registrants_path(format: :xls)
+  %br

--- a/app/views/imports/index.html.haml
+++ b/app/views/imports/index.html.haml
@@ -1,0 +1,9 @@
+%h1 Import Registrant Data & events
+
+%p
+  Note: The format of this CSV file MUST be the same as the "Export Registrants and data" from the
+  = link_to "Exports page", export_index_path
+
+= form_tag import_registrants_imports_path, method: :post, multipart: true do
+  = file_field_tag :file
+  = submit_tag

--- a/app/views/imports/index.html.haml
+++ b/app/views/imports/index.html.haml
@@ -5,5 +5,10 @@
   = link_to "Exports page", export_index_path
 
 = form_tag import_registrants_imports_path, method: :post, multipart: true do
-  = file_field_tag :file
-  = submit_tag
+  .row
+    .small-6.columns
+      = label_tag :file, "Registrants file"
+    .small-6.columns
+      = file_field_tag :file
+  .row
+    = submit_tag "Import Registrants"

--- a/app/views/nav_bar/_admin_set_three.html.haml
+++ b/app/views/nav_bar/_admin_set_three.html.haml
@@ -2,8 +2,8 @@
   %li= link_to 'Registrant Groups', registrant_group_types_path
 - if policy(:export).index?
   %li= link_to t('.export_data'), export_index_path
-- if policy(current_user).under_development?
-  %li= link_to  'Import Data', new_import_path
+- if policy(:import).index?
+  %li= link_to  'Import Data', imports_path
 - if policy(current_user).under_development?
   %li= link_to  'Multi-Tenant Research', research_competitions_path
 - if policy(@config).setup_convention?

--- a/config/locales/views/admin/permissions/index.en.yml
+++ b/config/locales/views/admin/permissions/index.en.yml
@@ -68,6 +68,7 @@ en:
           event_planner: |
             Able to view/review the event sign_ups.
             Able to SEARCH & MODIFY any registration.
+            Able to Bulk Import/Export Registration data (including event sign ups)
             Able to update bib number for registrants.
             Able to Add/Modify event choices, at all times.
             Able to view/send emails to all registrants

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,7 +99,11 @@ Rails.application.routes.draw do
       get :download_registrants
       get :results
     end
-    resource :import, only: %i[new create]
+    resources :imports, only: %i[index new create] do
+      collection do
+        post :import_registrants
+      end
+    end
 
     resources :standard_skill_entries, only: [:index]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,7 @@ Rails.application.routes.draw do
       get :download_summaries, controller: "/export_registrants"
       get :download_events
       get :download_competitors_for_timers
+      get :download_registrants
       get :results
     end
     resource :import, only: %i[new create]

--- a/spec/actions/exporters/registrant_exporter_spec.rb
+++ b/spec/actions/exporters/registrant_exporter_spec.rb
@@ -63,23 +63,40 @@ describe Exporters::RegistrantExporter do
       expect(rows.first).to eq(expected_row)
     end
 
-    context "with an event" do
+    context "with an event with choices" do
       let!(:event) { FactoryGirl.create(:event, best_time_format: "none", name: "100m") }
       let!(:event_choice) { FactoryGirl.create(:event_choice, event: event, label: "Team") }
 
       let!(:resu) { FactoryGirl.create(:registrant_event_sign_up, registrant: registrant, signed_up: true, event_category: event.event_categories.first) }
-      let!(:rc) { FactoryGirl.create(:registrant_choice, registrant: registrant, event_choice: event_choice, value: "My Team") }
 
-      let(:expected_row) do
-        [
-          "Y",
-          "All",
-          "",
-          "My Team"
-        ]
+      context "when registrant does not have the choice" do
+        let(:expected_row) do
+          [
+            "Y",
+            "All",
+            "",
+            ""
+          ]
+        end
+        it "includes the event sign up details" do
+          expect(rows.first).to include(*expected_row)
+        end
       end
-      it "includes the event sign up details" do
-        expect(rows.first).to include(*expected_row)
+
+      context "When registrant has the choice" do
+        let!(:rc) { FactoryGirl.create(:registrant_choice, registrant: registrant, event_choice: event_choice, value: "My Team") }
+
+        let(:expected_row) do
+          [
+            "Y",
+            "All",
+            "",
+            "My Team"
+          ]
+        end
+        it "includes the event sign up details" do
+          expect(rows.first).to include(*expected_row)
+        end
       end
     end
   end

--- a/spec/actions/exporters/registrant_exporter_spec.rb
+++ b/spec/actions/exporters/registrant_exporter_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe Exporters::RegistrantExporter do
+  describe "#headers" do
+    let(:headers) { described_class.new.headers }
+    let(:expected_headers) do
+      [
+        "ID",
+        "First Name",
+        "Last Name",
+        "Birthday (dd/mm/yy)",
+        "Sex (m/f)"
+      ]
+    end
+
+    it "describes the registrant headers" do
+      expect(headers).to eq(expected_headers)
+    end
+
+    context "with an event" do
+      let!(:event) { FactoryGirl.create(:event, best_time_format: "none", name: "100m") }
+      let!(:event_choice) { FactoryGirl.create(:event_choice, event: event, label: "Team") }
+
+      let(:expected_headers) do
+        [
+          "EV: 100m - Signed Up (Y/N)",
+          "EV: 100m - Category (All)",
+          "EV: 100m - Best Time (none)",
+          "EV: 100m - Choice: Team"
+        ]
+      end
+
+      it "describes the event headers" do
+        expect(headers).to include(*expected_headers)
+      end
+
+      context "with 2 categories" do
+        let!(:second_category) { FactoryGirl.create(:event_category, event: event, name: "Junior") }
+
+        it "has the 2 categories as header" do
+          expect(headers).to include("EV: 100m - Category (All/Junior)")
+        end
+      end
+    end
+  end
+
+  describe "#rows" do
+    let!(:registrant) { FactoryGirl.create(:competitor, birthday: Date.new(1998, 4, 20), gender: "Male") }
+
+    let(:rows) { described_class.new.rows }
+
+    let(:expected_row) do
+      [
+        registrant.bib_number.to_s,
+        registrant.first_name,
+        registrant.last_name,
+        "20/04/98",
+        "m"
+      ]
+    end
+
+    it "includes the base information" do
+      expect(rows.first).to eq(expected_row)
+    end
+
+    context "with an event" do
+      let!(:event) { FactoryGirl.create(:event, best_time_format: "none", name: "100m") }
+      let!(:event_choice) { FactoryGirl.create(:event_choice, event: event, label: "Team") }
+
+      let!(:resu) { FactoryGirl.create(:registrant_event_sign_up, registrant: registrant, signed_up: true, event_category: event.event_categories.first) }
+      let!(:rc) { FactoryGirl.create(:registrant_choice, registrant: registrant, event_choice: event_choice, value: "My Team") }
+
+      let(:expected_row) do
+        [
+          "Y",
+          "All",
+          "",
+          "My Team"
+        ]
+      end
+      it "includes the event sign up details" do
+        expect(rows.first).to include(*expected_row)
+      end
+    end
+  end
+end

--- a/spec/actions/importers/parsers/registrant_import_spec.rb
+++ b/spec/actions/importers/parsers/registrant_import_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Importers::Parsers::RegistrantImport do
+  describe "#validate_columns" do
+  end
+
+  describe "#convert_row" do
+    let(:registrant_headers) { ["ID", "First Name", "Last Name", "Birthday (dd/mm/yy)", "Sex (m/f)"] }
+    let(:registrant_row) { ["1", "Robin", "Dunlop", "20/05/20", "m"] }
+
+    context "with no events" do
+      it "creates the registrant hash" do
+        expect(described_class.new.convert_row(registrant_headers, registrant_row)).to include(
+          id: "1",
+          first_name: "Robin",
+          last_name: "Dunlop",
+          birthday: "20/05/20",
+          gender: "m"
+        )
+      end
+    end
+
+    context "with 1 event" do
+      let!(:event) { FactoryGirl.create(:event, name: "100m", best_time_format: "(m)m:ss.xx") }
+      let!(:event_choice) { FactoryGirl.create(:event_choice, event: event, cell_type: "text", label: "Team Name") }
+      let(:event_headers) { ["EV: 100m - Signed Up (Y/N)", "EV: 100m - Category (All)", "EV: 100m - Best Time ((m)m:ss.xx)", "EV: 100m - Choice: Team Name"] }
+      let(:event_row) { ["Y", "All", "20.03", "100m Team"] }
+
+      it "creates the event hash" do
+        expect(described_class.new.convert_row(registrant_headers + event_headers, registrant_row + event_row)).to include(
+          id: "1",
+          first_name: "Robin",
+          last_name: "Dunlop",
+          birthday: "20/05/20",
+          gender: "m",
+          events: [
+            {
+              name: "100m",
+              category: "All",
+              signed_up: true,
+              best_time: "20.03",
+              choices: [
+                { "Team Name" => "100m Team" }
+              ]
+            }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/actions/importers/parsers/registrant_import_spec.rb
+++ b/spec/actions/importers/parsers/registrant_import_spec.rb
@@ -39,9 +39,9 @@ describe Importers::Parsers::RegistrantImport do
               category: "All",
               signed_up: true,
               best_time: "20.03",
-              choices: [
-                { "Team Name" => "100m Team" }
-              ]
+              choices: {
+                "Team Name" => "100m Team"
+              }
             }
           ]
         )
@@ -71,9 +71,9 @@ describe Importers::Parsers::RegistrantImport do
             category: "All",
             signed_up: true,
             best_time: "20.03",
-            choices: [
-              { "Team Name" => "100m Team" }
-            ]
+            choices: {
+              "Team Name" => "100m Team"
+            }
           }
         ]
       )
@@ -89,9 +89,9 @@ describe Importers::Parsers::RegistrantImport do
             category: "All",
             signed_up: true,
             best_time: "12.33",
-            choices: [
-              { "Team Name" => "Best Team" }
-            ]
+            choices: {
+              "Team Name" => "Best Team"
+            }
           }
         ]
       )

--- a/spec/actions/importers/registrant_data_importer_spec.rb
+++ b/spec/actions/importers/registrant_data_importer_spec.rb
@@ -30,7 +30,7 @@ describe Importers::RegistrantDataImporter do
       end
 
       it "needs the birthday to be the same" do
-        modified_hash = reg_hash.merge(birthday: "21/5/88")
+        modified_hash = reg_hash.merge(birthday: "21/05/88")
         expect(importer.find_existing_registrant(modified_hash)).to be_new_record
       end
     end
@@ -39,8 +39,8 @@ describe Importers::RegistrantDataImporter do
   describe "#parse_birthday" do
     it "handles 98 and 2000 birthdays", :aggregate_failures do
       expect(importer.parse_birthday("10/28/91", day_first: false)).to eq(Date.new(1991, 10, 28))
-      expect(importer.parse_birthday("4/8/00", day_first: false)).to eq(Date.new(2000, 4, 8))
-      expect(importer.parse_birthday("12/6/01", day_first: false)).to eq(Date.new(2001, 12, 6))
+      expect(importer.parse_birthday("4/08/00", day_first: false)).to eq(Date.new(2000, 4, 8))
+      expect(importer.parse_birthday("12/06/01", day_first: false)).to eq(Date.new(2001, 12, 6))
       expect(importer.parse_birthday("4/14/07", day_first: false)).to eq(Date.new(2007, 4, 14))
     end
   end
@@ -53,9 +53,9 @@ describe Importers::RegistrantDataImporter do
         category: "All",
         signed_up: true,
         best_time: "20.03",
-        choices: [
-          { "Team Name" => "100m" }
-        ]
+        choices: {
+          "Team Name" => "Awesome Team"
+        }
       }
     end
 
@@ -72,23 +72,67 @@ describe Importers::RegistrantDataImporter do
         expect(resu.event_category).to eq(event.event_categories.first)
       end
 
-      context "when already signed up" do
+      context "when resu already exists" do
+        let!(:registrant_event_sign_up) { FactoryGirl.create(:registrant_event_sign_up, registrant: registrant, event: event, event_category: event.event_categories.first, signed_up: false) }
+
         it "does not create a new sign up" do
+          expect do
+            importer.set_event_sign_up(registrant, event_hash)
+          end.not_to change(RegistrantEventSignUp, :count)
         end
 
-        it "un-signs up, if necessary" # pending
+        it "signs up, if necessary" do
+          importer.set_event_sign_up(registrant, event_hash)
+          expect(registrant_event_sign_up.reload.signed_up).to be_truthy
+        end
       end
 
       context "with event choices" do
+        let!(:event_choice) { FactoryGirl.create(:event_choice, event: event, label: "Team Name") }
+
+        it "creates the registrant choice" do
+          expect do
+            importer.set_event_choice(registrant, event_hash)
+          end.to change(RegistrantChoice, :count).by(1)
+          expect(RegistrantChoice.last.value).to eq("Awesome Team")
+        end
+
+        context "when there is already a registrant choice" do
+          let!(:registrant_choice) { FactoryGirl.create(:registrant_choice, value: "Other Team", registrant: registrant, event_choice: event_choice) }
+
+          it "updates the registrant choice" do
+            expect do
+              importer.set_event_choice(registrant, event_hash)
+            end.not_to change(RegistrantChoice, :count)
+
+            expect(registrant_choice.reload.value).to eq("Awesome Team")
+          end
+        end
       end
     end
+    describe "with best time" do
+      let!(:event) { FactoryGirl.create(:event, name: "100m", best_time_format: "h:mm") }
 
-    context "with 2 events" do
+      it "creates a best time" do
+        expect do
+          importer.set_event_best_time(registrant, event_hash.merge(best_time: "1:20"))
+        end.to change(RegistrantBestTime, :count).by(1)
+
+        expect(RegistrantBestTime.last.event).to eq(event)
+        expect(RegistrantBestTime.last.registrant).to eq(registrant)
+        expect(RegistrantBestTime.last.value).to eq((60 + 20) * 60 * 100)
+      end
     end
   end
 
   describe "when importing a single row" do
-    let!(:event) { FactoryGirl.create(:event, name: "100m") }
+    before do
+      FactoryGirl.create(:wheel_size_20)
+      FactoryGirl.create(:wheel_size_24)
+    end
+
+    let!(:event) { FactoryGirl.create(:event, name: "100m", best_time_format: "(m)m:ss.xx") }
+    let!(:event_choice) { FactoryGirl.create(:event_choice, event: event, label: "Team Name") }
 
     let(:reg_hash) do
       {
@@ -102,10 +146,10 @@ describe Importers::RegistrantDataImporter do
             name: "100m",
             category: "All",
             signed_up: true,
-            best_time: "20.03",
-            choices: [
-              { "Team Name" => "100m" }
-            ]
+            best_time: "0:20.03",
+            choices: {
+              "Team Name" => "100m"
+            }
           }
         ]
       }
@@ -115,6 +159,8 @@ describe Importers::RegistrantDataImporter do
       expect do
         importer.build_and_save_imported_result(reg_hash, admin_user)
       end.to change(Registrant, :count).by(1)
+      expect(RegistrantChoice.count).to eq(1)
+      expect(RegistrantBestTime.count).to eq(1)
     end
   end
 end

--- a/spec/actions/importers/registrant_data_importer_spec.rb
+++ b/spec/actions/importers/registrant_data_importer_spec.rb
@@ -50,6 +50,7 @@ describe Importers::RegistrantDataImporter do
     let(:event_hash) do
       {
         name: "100m",
+        category: "All",
         signed_up: true,
         best_time: "20.03",
         choices: [
@@ -99,6 +100,7 @@ describe Importers::RegistrantDataImporter do
         events: [
           {
             name: "100m",
+            category: "All",
             signed_up: true,
             best_time: "20.03",
             choices: [

--- a/spec/actions/importers/registrant_data_importer_spec.rb
+++ b/spec/actions/importers/registrant_data_importer_spec.rb
@@ -1,0 +1,118 @@
+require 'spec_helper'
+
+describe Importers::RegistrantDataImporter do
+  let(:admin_user) { FactoryGirl.create(:super_admin_user) }
+  let(:importer) { described_class.new(admin_user) }
+
+  describe "#find_existing_registrant" do
+    let(:reg_hash) do
+      {
+        first_name: "Bob",
+        last_name: "Smith",
+        birthday: "20/01/07"
+      }
+    end
+
+    it "initializes one if none exist" do
+      expect(importer.find_existing_registrant(reg_hash)).to be_new_record
+    end
+
+    context "when one already exists" do
+      let!(:registrant) { FactoryGirl.create(:registrant, first_name: "Bob", last_name: "Smith", birthday: Date.new(2007, 0o1, 20)) }
+
+      it "returns the existing registrant" do
+        expect(importer.find_existing_registrant(reg_hash)).to eq(registrant)
+      end
+
+      it "returns different-case registrant name" do
+        modified_hash = reg_hash.merge(first_name: "bob")
+        expect(importer.find_existing_registrant(modified_hash)).to eq(registrant)
+      end
+
+      it "needs the birthday to be the same" do
+        modified_hash = reg_hash.merge(birthday: "21/5/88")
+        expect(importer.find_existing_registrant(modified_hash)).to be_new_record
+      end
+    end
+  end
+
+  describe "#parse_birthday" do
+    it "handles 98 and 2000 birthdays", :aggregate_failures do
+      expect(importer.parse_birthday("10/28/91", day_first: false)).to eq(Date.new(1991, 10, 28))
+      expect(importer.parse_birthday("4/8/00", day_first: false)).to eq(Date.new(2000, 4, 8))
+      expect(importer.parse_birthday("12/6/01", day_first: false)).to eq(Date.new(2001, 12, 6))
+      expect(importer.parse_birthday("4/14/07", day_first: false)).to eq(Date.new(2007, 4, 14))
+    end
+  end
+
+  describe "#set_event_sign_up" do
+    let!(:registrant) { FactoryGirl.create(:competitor) }
+    let(:event_hash) do
+      {
+        name: "100m",
+        signed_up: true,
+        best_time: "20.03",
+        choices: [
+          { "Team Name" => "100m" }
+        ]
+      }
+    end
+
+    context "with a single event" do
+      let!(:event) { FactoryGirl.create(:event, name: "100m") }
+
+      it "creates a registrant_event_sign_up" do
+        expect do
+          importer.set_event_sign_up(registrant, event_hash)
+        end.to change(RegistrantEventSignUp, :count).by(1)
+
+        resu = RegistrantEventSignUp.last
+        expect(resu).to be_signed_up
+        expect(resu.event_category).to eq(event.event_categories.first)
+      end
+
+      context "when already signed up" do
+        it "does not create a new sign up" do
+        end
+
+        it "un-signs up, if necessary" # pending
+      end
+
+      context "with event choices" do
+      end
+    end
+
+    context "with 2 events" do
+    end
+  end
+
+  describe "when importing a single row" do
+    let!(:event) { FactoryGirl.create(:event, name: "100m") }
+
+    let(:reg_hash) do
+      {
+        id: "1",
+        first_name: "Bob",
+        last_name: "Smith",
+        birthday: "10/4/76",
+        gender: "m",
+        events: [
+          {
+            name: "100m",
+            signed_up: true,
+            best_time: "20.03",
+            choices: [
+              { "Team Name" => "100m" }
+            ]
+          }
+        ]
+      }
+    end
+
+    it "creates a registrant" do
+      expect do
+        importer.build_and_save_imported_result(reg_hash, admin_user)
+      end.to change(Registrant, :count).by(1)
+    end
+  end
+end

--- a/spec/fixtures/registrants.csv
+++ b/spec/fixtures/registrants.csv
@@ -1,0 +1,3 @@
+ID,First Name,Last Name,Birthday (dd/mm/yy),Sex (m/f),EV: 100m - Signed Up (Y/N),EV: 100m - Category (All),EV: 100m - Best Time ((m)m:ss.xx),EV: 100m - Choice: Team Name
+1,Robin,Dunlop,20/05/82,m,Y,All,20.03,100m Team
+2,Scott,Wilton,28/02/95,m,Y,All,12.33,Best Team


### PR DESCRIPTION
Adds 2 functions
- Export all Registrant/Event Data to CSV
- Import all Registrant/Event Data from CSV.

Can be used to seed the system from external sources, and update it.

Recommended flow:
- Export the blank CSV,
- Fill in the CSV
- Import the CSV.