### PR TITLE
Show column-count errors on imports

### DIFF
--- a/app/actions/importers/external_result_importer.rb
+++ b/app/actions/importers/external_result_importer.rb
@@ -13,6 +13,8 @@ class Importers::ExternalResultImporter < Importers::CompetitionDataImporter
       raw_data.each do |raw|
         if build_and_save_imported_result(processor.process_row(raw), @user, @competition)
           self.num_rows_processed += 1
+        else
+          raise ActiveRecord::Rollback
         end
       end
     end
@@ -31,5 +33,8 @@ class Importers::ExternalResultImporter < Importers::CompetitionDataImporter
       entered_at: DateTime.current,
       entered_by: user
     )
+  rescue ActiveRecord::RecordNotFound
+    @errors << "Unable to find registrant (#{row_hash})"
+    return false
   end
 end

--- a/app/actions/importers/parsers/chip.rb
+++ b/app/actions/importers/parsers/chip.rb
@@ -16,6 +16,14 @@ class Importers::Parsers::Chip < Importers::Parsers::Base
     raw_data.drop(1)
   end
 
+  def validate_contents
+    min_column = [bib_number_column_number.to_i, time_column_number.to_i, lap_column_number.to_i].max
+
+    if file_contents.first.count < (min_column + 1)
+      @errors << "Not enough columns. Are you sure this is a semicolon-separated file?"
+    end
+  end
+
   def process_row(row)
     chip_hash = convert_timing_csv_to_hash(row)
     {

--- a/app/actions/importers/parsers/csv.rb
+++ b/app/actions/importers/parsers/csv.rb
@@ -10,6 +10,12 @@ class Importers::Parsers::Csv < Importers::Parsers::Base
     Importers::CsvExtractor.new(file).extract_csv
   end
 
+  def validate_contents
+    if file_contents.first.count < 5
+      @errors << "Not enough columns. Are you sure this is the right format? (comma-separated)"
+    end
+  end
+
   def process_row(row)
     time_entry = row[4]
 

--- a/app/actions/importers/parsers/external_result_csv.rb
+++ b/app/actions/importers/parsers/external_result_csv.rb
@@ -3,6 +3,12 @@ class Importers::Parsers::ExternalResultCsv < Importers::Parsers::Base
     Importers::CsvExtractor.new(file).extract_csv
   end
 
+  def validate_contents
+    if file_contents.first.count < 2 # column 3 is optional
+      @errors << "Not enough columns. Are you sure this is a comma-separated file?"
+    end
+  end
+
   def process_row(raw)
     {
       bib_number: raw[0],

--- a/app/actions/importers/parsers/lif.rb
+++ b/app/actions/importers/parsers/lif.rb
@@ -4,6 +4,12 @@ class Importers::Parsers::Lif < Importers::Parsers::Base
     data.drop(1) # drop header row
   end
 
+  def validate_contents
+    if file_contents.first.count < 7
+      @errors << "Not enough columns. Are you sure this is a comma-separated file?"
+    end
+  end
+
   def process_row(raw)
     lif_hash = convert_lif_to_hash(raw)
 

--- a/app/actions/importers/parsers/swiss.rb
+++ b/app/actions/importers/parsers/swiss.rb
@@ -3,6 +3,12 @@ class Importers::Parsers::Swiss < Importers::Parsers::Base
     Importers::CsvExtractor.new(file, separator: "\t").extract_csv
   end
 
+  def validate_contents
+    if file_contents.first.count < 4
+      @errors << "Not enough columns. Are you sure this is a tab-separated file?"
+    end
+  end
+
   # Convert a file formatted like:
   # 3 00:00:13.973  277 1 Monika Sveistrup  "0-10 20"" Female, 20"" Wheel"  Female          00:00:00.186
   # 5 00:00:14.302  660 2 Eva Maria Prader  "0-10 20"" Female, 20"" Wheel"  Female          00:00:00.515

--- a/app/actions/importers/parsers/two_attempt_csv.rb
+++ b/app/actions/importers/parsers/two_attempt_csv.rb
@@ -3,6 +3,12 @@ class Importers::Parsers::TwoAttemptCsv < Importers::Parsers::Base
     Importers::CsvExtractor.new(file).extract_csv
   end
 
+  def validate_contents
+    if file_contents.first.count < 9
+      @errors << "Not enough columns. Are you sure this is a comma-separated file?"
+    end
+  end
+
   def process_row(raw)
     # 101,1,30,0,,10,45,0,
     # 102,2,30,239,DQ,11,0,0,

--- a/app/actions/importers/parsers/two_attempt_slalom.rb
+++ b/app/actions/importers/parsers/two_attempt_slalom.rb
@@ -4,6 +4,12 @@ class Importers::Parsers::TwoAttemptSlalom < Importers::Parsers::Base
     Importers::CsvExtractor.new(file, separator: ';').extract_csv
   end
 
+  def validate_contents
+    if file_contents.first.count < 5
+      @errors << "Not enough columns. Are you sure this is a semicolon-separated file?"
+    end
+  end
+
   # Example data
   # 30;Smith;Ramona;19,64;19,40;Switzerland;23;w;IUF-Slalom
   # 65;Rondeau;Antoine;24,66;disq;France;22;m;IUF-Slalom

--- a/app/actions/importers/parsers/wave.rb
+++ b/app/actions/importers/parsers/wave.rb
@@ -4,6 +4,12 @@ class Importers::Parsers::Wave < Importers::Parsers::Base
     contents.drop(1) # skip header row
   end
 
+  def validate_contents
+    if file_contents.first.count < 2
+      @errors << "Not enough columns. Are you sure this is a comma-separated file?"
+    end
+  end
+
   def process_row(row)
     return nil if row[0].nil? && row[1].nil?
 

--- a/app/actions/importers/registrant_data_importer.rb
+++ b/app/actions/importers/registrant_data_importer.rb
@@ -11,6 +11,7 @@ class Importers::RegistrantDataImporter < Importers::BaseImporter
     @errors = []
     Registrant.transaction do
       registrant_data.each do |registrant_hash|
+        row_hash = processor.process_row(registrant_hash)
         # CsvExtractor converts from file into array-of-arrays
         # Processor converts from array-of-arrays into array of hashes of form:
         # {
@@ -43,7 +44,7 @@ class Importers::RegistrantDataImporter < Importers::BaseImporter
         #       if value is formatted with a ".", enter it as seconds/thousands
 
         begin
-          if build_and_save_imported_result(registrant_hash, @user)
+          if build_and_save_imported_result(row_hash, @user)
             self.num_rows_processed += 1
           end
         rescue ActiveRecord::RecordInvalid => invalid

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -11,7 +11,7 @@ class ImportsController < ApplicationController
     if importer.process(parser)
       flash[:notice] = "Import Successful"
     else
-      flash[:alert] = "#{importer.num_rows_processed} rows imported. Some Import errors: #{importer.errors[0..10]}"
+      flash[:alert] = "#{importer.num_rows_processed} rows imported. Some Import errors: #{importer.errors.first(100)}..."
     end
     redirect_to imports_path
   end

--- a/spec/actions/importers/external_result_importer_spec.rb
+++ b/spec/actions/importers/external_result_importer_spec.rb
@@ -32,4 +32,12 @@ describe Importers::ExternalResultImporter do
     end.to change(ExternalResult, :count).by(1)
     expect(importer.num_rows_processed).to eq(1)
   end
+
+  it "Can process external result when registrant does not exist" do
+    expect do
+      expect(importer.process(processor)).to be_falsy
+    end.to change(ExternalResult, :count).by(0)
+    expect(importer.num_rows_processed).to eq(0)
+    expect(importer.errors).to eq("Unable to find registrant ({:bib_number=>\"101\", :points=>\"1.2\", :details=>nil, :status=>\"active\"})")
+  end
 end

--- a/spec/actions/importers/parsers/chip_spec.rb
+++ b/spec/actions/importers/parsers/chip_spec.rb
@@ -14,6 +14,10 @@ describe Importers::Parsers::Chip do
     expect(importer.extract_file).to eq([["101", "fake", "0:1:34.39", "2"]])
   end
 
+  it "has valid headers" do
+    expect(importer).to be_valid_file
+  end
+
   it "creates a dq competitor" do
     read_input = importer.process_row(["101", "fake", "0:1:34.39", "2"])
     expect(read_input[:bib_number]).to eq(101)

--- a/spec/actions/importers/parsers/csv_spec.rb
+++ b/spec/actions/importers/parsers/csv_spec.rb
@@ -12,6 +12,10 @@ describe Importers::Parsers::Csv do
       expect(importer.extract_file).to eq([["101", "1", "2", "300", "0"]])
     end
 
+    it "has valid headers" do
+      expect(importer).to be_valid_file
+    end
+
     it "returns competitor data" do
       input_data = importer.process_row(["101", "1", "2", "300", "0"])
 

--- a/spec/actions/importers/parsers/external_result_csv_spec.rb
+++ b/spec/actions/importers/parsers/external_result_csv_spec.rb
@@ -16,6 +16,10 @@ describe Importers::Parsers::ExternalResultCsv do
     expect(input_data[3]).to eq(["104", "62.36747621"])
   end
 
+  it "has valid headers" do
+    expect(importer).to be_valid_file
+  end
+
   it "can convert a row" do
     result = importer.process_row(["101", "27.60616904"])
 

--- a/spec/actions/importers/parsers/lif_spec.rb
+++ b/spec/actions/importers/parsers/lif_spec.rb
@@ -11,6 +11,11 @@ describe Importers::Parsers::Lif do
     expect(input_data[7]).to eq(["8", nil, "8", nil, nil, nil, "3:04.36", nil, "29.163", nil, nil, nil, nil, nil, nil])
   end
 
+  it "has valid headers" do
+    importer = described_class.new(sample_input)
+    expect(importer).to be_valid_file
+  end
+
   let(:up) { described_class.new }
 
   it "can convert a lif hash to data" do

--- a/spec/actions/importers/parsers/swiss_spec.rb
+++ b/spec/actions/importers/parsers/swiss_spec.rb
@@ -15,6 +15,10 @@ describe Importers::Parsers::Swiss do
         ]
       )
     end
+
+    it "Has valid headers" do
+      expect(importer).to be_valid_file
+    end
   end
 
   it "can parse a simple time", :aggregate_failures do

--- a/spec/actions/importers/parsers/two_attempt_csv_spec.rb
+++ b/spec/actions/importers/parsers/two_attempt_csv_spec.rb
@@ -16,6 +16,10 @@ describe Importers::Parsers::TwoAttemptCsv do
     )
   end
 
+  it "has valid headers" do
+    expect(importer).to be_valid_file
+  end
+
   it "returns first row result", :aggregate_failures do
     input_data = importer.process_row(["101", "1", "30", "0", nil, "10", "45", "0"])
 

--- a/spec/actions/importers/parsers/two_attempt_slalom_spec.rb
+++ b/spec/actions/importers/parsers/two_attempt_slalom_spec.rb
@@ -1,6 +1,22 @@
 require 'spec_helper'
 
 describe Importers::Parsers::TwoAttemptSlalom do
+  let(:iuf_two_attempt_data_file_name) { fixture_path + '/sample_iuf_two_attempt.txt' }
+  let(:iuf_two_attempt_data_file) { Rack::Test::UploadedFile.new(iuf_two_attempt_data_file_name, "text/plain") }
+
+  it "extracts the file contents" do
+    expect(described_class.new(iuf_two_attempt_data_file).extract_file).to eq(
+      [
+        ["30", "Hürzeler", "Ramona", "19,64", "19,40", "Switzerland", "23", "w", "IUF-Slalom"]
+      ]
+    )
+  end
+
+  it "has valid headers" do
+    importer = described_class.new(iuf_two_attempt_data_file)
+    expect(importer).to be_valid_file
+  end
+
   describe "when importing IUF-style data" do
     it "can process a normal single line", :aggregate_failures do
       obj = described_class.new

--- a/spec/actions/importers/parsers/two_attempt_slalom_spec.rb
+++ b/spec/actions/importers/parsers/two_attempt_slalom_spec.rb
@@ -7,7 +7,7 @@ describe Importers::Parsers::TwoAttemptSlalom do
   it "extracts the file contents" do
     expect(described_class.new(iuf_two_attempt_data_file).extract_file).to eq(
       [
-        ["30", "Hürzeler", "Ramona", "19,64", "19,40", "Switzerland", "23", "w", "IUF-Slalom"]
+        ["30", "Hurzeler", "Ramona", "19,64", "19,40", "Switzerland", "23", "w", "IUF-Slalom"]
       ]
     )
   end

--- a/spec/actions/importers/parsers/wave_spec.rb
+++ b/spec/actions/importers/parsers/wave_spec.rb
@@ -15,6 +15,11 @@ describe Importers::Parsers::Wave do
     )
   end
 
+  it "has valid headers" do
+    importer = described_class.new(wave_data_file)
+    expect(importer).to be_valid_file
+  end
+
   it "converts contents to hash" do
     expect(described_class.new.process_row(["101", "1"])).to eq(bib_number: "101", wave: "1")
   end

--- a/spec/fixtures/sample_iuf_two_attempt.txt
+++ b/spec/fixtures/sample_iuf_two_attempt.txt
@@ -1,0 +1,1 @@
+30;Hürzeler;Ramona;19,64;19,40;Switzerland;23;w;IUF-Slalom

--- a/spec/fixtures/sample_iuf_two_attempt.txt
+++ b/spec/fixtures/sample_iuf_two_attempt.txt
@@ -1,1 +1,1 @@
-30;Hürzeler;Ramona;19,64;19,40;Switzerland;23;w;IUF-Slalom
+30;Hurzeler;Ramona;19,64;19,40;Switzerland;23;w;IUF-Slalom


### PR DESCRIPTION
If you try to import a file which has too few columns (usually due to incorrect file format), provide a better error message

Also fixes the Registrant Import process, which was broken.