### PR TITLE
Fix high long calculator for 2017

### DIFF
--- a/app/actions/sample_competition_creator.rb
+++ b/app/actions/sample_competition_creator.rb
@@ -12,7 +12,7 @@ class SampleCompetitionCreator
     name = "#{competition_type} #{Faker::Hipster.word}"
 
     case competition_type
-    when "Longest Time", "Shortest Time", "Shortest Time with Tiers", "Timed Multi-Lap", "High/Long", "High/Long Final IUF 2015", "High/Long Preliminary IUF 2015"
+    when "Longest Time", "Shortest Time", "Shortest Time with Tiers", "Timed Multi-Lap", "High/Long", "High/Long Final IUF 2015", "High/Long Preliminary IUF 2015", "High/Long Preliminary IUF 2017"
       Competition.create!(
         name: name,
         event: Event.first,

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -441,22 +441,11 @@ class Competition < ApplicationRecord
   end
 
   def high_long_event?
-    ["High/Long", "High/Long Preliminary IUF 2015", "High/Long Final IUF 2015"].include?(event_class)
+    ScoringClass.for(event_class, self)[:high_long_event?]
   end
 
   def distance_attempt_manager
-    case event_class
-    when "High/Long"
-      DistanceAttemptFinalManager
-    when "High/Long Preliminary IUF 2015"
-      DistanceAttemptPreliminaryManager
-    when "High/Long Final IUF 2015"
-      DistanceAttemptFinal_2015_Manager
-    when "High/Long Preliminary IUF 2017"
-      DistanceAttemptPreliminary2017Manager
-    else
-      raise NotImplementedError
-    end
+    @distance_attempt_manager ||= ScoringClass.for(event_class, self)[:distance_attempt_manager]
   end
 
   # ###########################

--- a/app/scoring_classes/scoring_class.rb
+++ b/app/scoring_classes/scoring_class.rb
@@ -106,7 +106,7 @@ class ScoringClass
         ),
         helper: StreetScoringClass.new(competition, false) # this interacts with the judge_score_calculator
       }
-    when "High/Long", "High/Long Preliminary IUF 2015", "High/Long Final IUF 2015"
+    when "High/Long", "High/Long Preliminary IUF 2015", "High/Long Final IUF 2015", "High/Long Preliminary IUF 2017"
       {
         calculator: DistanceResultCalculator.new,
         exporter: EnteredDataExporter::MaxDistance.new(competition),

--- a/app/scoring_classes/scoring_class.rb
+++ b/app/scoring_classes/scoring_class.rb
@@ -1,5 +1,16 @@
 class ScoringClass
-  def self.for(scoring_class, competition) # rubocop:disable Metrics/MethodLength
+  attr_reader :scoring_class, :competition
+
+  def initialize(scoring_class, competition)
+    @scoring_class = scoring_class
+    @competition = competition
+  end
+
+  def self.for(scoring_class, competition)
+    new(scoring_class, competition).to_hash
+  end
+
+  def to_hash # rubocop:disable Metrics/MethodLength
     case scoring_class
     when "Shortest Time with Tiers"
       {
@@ -106,12 +117,14 @@ class ScoringClass
         ),
         helper: StreetScoringClass.new(competition, false) # this interacts with the judge_score_calculator
       }
-    when "High/Long", "High/Long Preliminary IUF 2015", "High/Long Final IUF 2015", "High/Long Preliminary IUF 2017"
-      {
-        calculator: DistanceResultCalculator.new,
-        exporter: EnteredDataExporter::MaxDistance.new(competition),
-        helper: DistanceScoringClass.new(competition)
-      }
+    when "High/Long"
+      high_long_type(DistanceAttemptFinalManager)
+    when "High/Long Preliminary IUF 2015"
+      high_long_type(DistanceAttemptPreliminaryManager)
+    when "High/Long Final IUF 2015"
+      high_long_type(DistanceAttemptFinal_2015_Manager)
+    when "High/Long Preliminary IUF 2017"
+      high_long_type(DistanceAttemptPreliminary2017Manager)
     when "Overall Champion"
       {
         calculator: OverallChampionResultCalculator.new(competition.combined_competition, competition),
@@ -129,5 +142,15 @@ class ScoringClass
         helper: nil
       }
     end
+  end
+
+  def high_long_type(distance_attempt_manager)
+    {
+      calculator: DistanceResultCalculator.new,
+      exporter: EnteredDataExporter::MaxDistance.new(competition),
+      helper: DistanceScoringClass.new(competition),
+      high_long_event?: true,
+      distance_attempt_manager: distance_attempt_manager
+    }
   end
 end

--- a/app/views/example/competition_choices/high_long.html.haml
+++ b/app/views/example/competition_choices/high_long.html.haml
@@ -45,9 +45,9 @@
     to continue setting up your High jump according to the old rules.
 
   %p
-    - params = { "competition[scoring_class]" => "High/Long Preliminary IUF 2015", "competition[num_members_per_competitor]" => "One" }
+    - params = { "competition[scoring_class]" => "High/Long Preliminary IUF 2017", "competition[num_members_per_competitor]" => "One" }
     = link_to "Click here", new_event_competition_path(@event, params), class: "button"
-    to continue setting up your High jump according to the IUF 2015 High/Long Preliminary Rules.
+    to continue setting up your High jump according to the IUF 2017 High/Long Preliminary Rules.
 
   %p
     - params = { "competition[scoring_class]" => "High/Long Final IUF 2015", "competition[num_members_per_competitor]" => "One" }

--- a/spec/scoring_classes/scoring_class_spec.rb
+++ b/spec/scoring_classes/scoring_class_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe ScoringClass do
+  describe "scoring_helpers" do
+    Competition.scoring_classes.each do |scoring_class|
+      let(:competition) { FactoryGirl.build(:competition, scoring_class: scoring_class) }
+      it "has valid scoring_helper for #{scoring_class}" do
+        scoring_helper = ScoringClass.for(scoring_class, competition)[:helper]
+        expect(scoring_helper).not_to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Was incorrectly only 1/2 applied to the places within Competition where it needed to be applied.

Fixed that, and refactored to make it easier for future changes to NOT be missed like this.