### PR TITLE
No longer show 'No Age Group for..' when age group isn't found.

### DIFF
--- a/app/models/competitor.rb
+++ b/app/models/competitor.rb
@@ -243,7 +243,7 @@ class Competitor < ApplicationRecord
 
   def age_group_entry_description
     return unless members.any?
-    return "No Age Group for #{age}-#{gender}" if age_group_entry.nil?
+    return if age_group_entry.nil?
 
     age_group_entry.to_s
   end


### PR DESCRIPTION
prevents showing this incorrectly on the registration summary, when
age groups are not relevant (like: Group Freestyle)