### PR TITLE
Only use scores for 'eligible' competitors - Freestyle

### DIFF
--- a/app/models/judge.rb
+++ b/app/models/judge.rb
@@ -83,7 +83,8 @@ class Judge < ApplicationRecord
     if judge_type.event_class == "Standard Skill"
       standard_skill_scores.joins(:competitor).merge(Competitor.active)
     else
-      scores.joins(:competitor).merge(Competitor.active)
+      valid_competitors = competition.competitors.reject(&:ineligible?)
+      scores.joins(:competitor).merge(Competitor.where(id: valid_competitors))
     end
   end
 

--- a/spec/models/judge_spec.rb
+++ b/spec/models/judge_spec.rb
@@ -23,7 +23,8 @@ require 'spec_helper'
 describe Judge do
   describe "when the judge has scores" do
     let(:judge) { FactoryGirl.create(:judge) }
-    let!(:score) { FactoryGirl.create(:score, judge: judge) }
+    let(:competitor) { FactoryGirl.create(:event_competitor, competition: judge.competition) }
+    let!(:score) { FactoryGirl.create(:score, competitor: competitor, judge: judge) }
 
     it "cannot destroy the judge" do
       expect(judge.destroy).to eq(false)


### PR DESCRIPTION
This eliminates the scores for "ineligible" competitors within artistic scoring.