### PR TITLE
add Danish and Italian to list of translate-able languages.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,6 +30,8 @@
 //= require select2_locale_es
 //= require select2_locale_ko
 //= require select2_locale_ja
+//= require select2_locale_it
+//= require select2_locale_da
 // NOTE: not available select2_locale_ja
 //= require fancybox
 //= require cocoon

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module Workspace
 
     # These are the default list of available languages.
     # Note: this is overwritten in application_controller.rb once an EventConfiguration is loaded.
-    config.i18n.available_locales = %i[en fr de hu es ja, ko]
+    config.i18n.available_locales = %i[en fr de hu es ja ko it da]
 
     config.encoding = "utf-8"
 

--- a/config/locales/base.da.yml
+++ b/config/locales/base.da.yml
@@ -1,0 +1,3 @@
+---
+da:
+  language_name: Danish

--- a/config/locales/base.it.yml
+++ b/config/locales/base.it.yml
@@ -1,0 +1,3 @@
+---
+it:
+  language_name: Italian


### PR DESCRIPTION
Note: this does not add them to the list of languages available-for-use

Related to #563 

Once there are some texts translated on the "translation site", I will make these languages available for use in the production site.