### PR TITLE
219 improve sign up validations

### DIFF
--- a/app/forms/registrant_event_choices_form.rb
+++ b/app/forms/registrant_event_choices_form.rb
@@ -1,12 +1,13 @@
 # Helper class for dealing with displaying an event-sign-up form
 # displaying all of the various sundry choices
 class RegistrantEventChoicesForm
-  attr_reader :registrant, :event, :current_user
+  attr_reader :registrant, :event, :current_user, :config
 
-  def initialize(registrant, event, current_user)
+  def initialize(registrant, event, current_user, config)
     @registrant = registrant
     @event = event
     @current_user = current_user
+    @config = config
   end
 
   def registrant_event_sign_up
@@ -20,7 +21,7 @@ class RegistrantEventChoicesForm
   end
 
   def disabled_event?
-    if !Pundit.policy(current_user, current_user).under_development? && @config.can_only_drop_or_modify_events? && !registrant_event_sign_up.signed_up?
+    if !Pundit.policy(current_user, current_user).under_development? && config.can_only_drop_or_modify_events? && !registrant_event_sign_up.signed_up?
       return true
     end
 

--- a/app/forms/registrant_event_choices_form.rb
+++ b/app/forms/registrant_event_choices_form.rb
@@ -1,0 +1,79 @@
+# Helper class for dealing with displaying an event-sign-up form
+# displaying all of the various sundry choices
+class RegistrantEventChoicesForm
+  attr_reader :registrant, :event, :current_user
+
+  def initialize(registrant, event, current_user)
+    @registrant = registrant
+    @event = event
+    @current_user = current_user
+  end
+
+  def registrant_event_sign_up
+    registrant.registrant_event_sign_ups.each do |resu|
+      if resu.event_id == event.id
+        return resu
+      end
+    end
+
+    nil
+  end
+
+  def disabled_event?
+    if !Pundit.policy(current_user, current_user).under_development? && @config.can_only_drop_or_modify_events? && !registrant_event_sign_up.signed_up?
+      return true
+    end
+
+    event.artistic? && !Pundit.policy(current_user, current_user).add_artistic_events?
+  end
+
+  def paid_for?
+    event.has_cost? && registrant.paid_or_pending_expense_items.include?(event.expense_item)
+  end
+
+  def event_categories
+    list = []
+    event.event_categories.each do |cat|
+      list << [cat.name, cat.id]
+    end
+    list
+  end
+
+  def inaccessible_event_categories
+    disabled_list = []
+    event.event_categories.each do |cat|
+      unless cat.age_is_in_range(registrant.age)
+        disabled_list << cat.id
+      end
+    end
+    disabled_list
+  end
+
+  def event_choices_and_registrant_choices
+    results = []
+    event.event_choices.each do |choice|
+      found_rc = nil
+      registrant.registrant_choices.each do |rc|
+        next unless rc.event_choice_id == choice.id
+        found_rc = rc
+        results << [choice, found_rc]
+        break
+      end
+      unless found_rc
+        results << [choice, nil]
+      end
+    end
+
+    results
+  end
+
+  def best_time
+    @registrant.registrant_best_times.each do |bt|
+      if bt.event_id == event.id
+        return bt
+      end
+    end
+
+    nil
+  end
+end

--- a/app/models/registrant_event_sign_up.rb
+++ b/app/models/registrant_event_sign_up.rb
@@ -19,7 +19,7 @@
 #
 
 class RegistrantEventSignUp < ApplicationRecord
-  before_validation :select_category_if_only_one
+  before_validation :update_category_if_only_one
   validates :event, :registrant, presence: true
   # The following should be re-enabled? first double-check to see which conventions have violating data.
   # also ensure that flow still works with this. (do we have any events which do not have event_categories?)
@@ -70,9 +70,13 @@ class RegistrantEventSignUp < ApplicationRecord
 
   private
 
-  def select_category_if_only_one
-    if signed_up? && event.event_categories.size == 1
-      self.event_category = event.event_categories.first
+  def update_category_if_only_one
+    if event.event_categories.size == 1
+      if signed_up?
+        self.event_category = event.event_categories.first
+      else
+        self.event_category = nil
+      end
     end
   end
 

--- a/app/models/registrant_event_sign_up.rb
+++ b/app/models/registrant_event_sign_up.rb
@@ -19,6 +19,7 @@
 #
 
 class RegistrantEventSignUp < ApplicationRecord
+  before_validation :select_category_if_only_one
   validates :event, :registrant, presence: true
   # The following should be re-enabled? first double-check to see which conventions have violating data.
   # also ensure that flow still works with this. (do we have any events which do not have event_categories?)
@@ -69,6 +70,12 @@ class RegistrantEventSignUp < ApplicationRecord
 
   private
 
+  def select_category_if_only_one
+    if signed_up? && event.event_categories.size == 1
+      self.event_category = event.event_categories.first
+    end
+  end
+
   def auto_create_competitor
     if signed_up
       event_category.competitions_being_fed(registrant).each do |competition|
@@ -107,8 +114,10 @@ class RegistrantEventSignUp < ApplicationRecord
   end
 
   def category_chosen_when_signed_up
-    if signed_up && event_category.nil?
+    if (signed_up && event_category.nil?) || (!signed_up && event_category.present?)
       errors.add(:base, "Cannot sign up for #{event.name} without choosing a category")
+      errors.add(:signed_up, "")
+      errors.add(:event_category_id, "")
     end
   end
 

--- a/app/views/attending/_event.html.haml
+++ b/app/views/attending/_event.html.haml
@@ -1,4 +1,4 @@
-- form = RegistrantEventChoicesForm.new(registrant, event, current_user)
+- form = RegistrantEventChoicesForm.new(registrant, event, current_user, @config)
 %tr{class: "event #{form.disabled_event? ? 'disabled_event' : ''}" }
   = f.fields_for :registrant_event_sign_ups, form.registrant_event_sign_up do |resu|
     %td.event_choice

--- a/app/views/attending/_event.html.haml
+++ b/app/views/attending/_event.html.haml
@@ -1,79 +1,53 @@
-- @registrant = registrant
-- disabled_event = event.artistic? && !policy(current_user).add_artistic_events?
-- found_resu = nil
-- @registrant.registrant_event_sign_ups.each do |resu|
-  - if resu.event_id == event.id
-    - found_resu = resu
-- if !policy(current_user).under_development? && @config.can_only_drop_or_modify_events? && !found_resu.signed_up?
-  - disabled_event = true
-%tr{:class => "event #{disabled_event ? 'disabled_event' : ''}" }
-  = f.fields_for :registrant_event_sign_ups, found_resu do |resu|
+- form = RegistrantEventChoicesForm.new(registrant, event, current_user)
+%tr{class: "event #{form.disabled_event? ? 'disabled_event' : ''}" }
+  = f.fields_for :registrant_event_sign_ups, form.registrant_event_sign_up do |resu|
     %td.event_choice
-      - if disabled_event && resu.object.signed_up?
-        = link_to t(".drop_out_of_event"), drop_event_registrant_build_index_path(@registrant, event_id: event.id), data: { confirm: t(".drop_out_confirmation") }, class: "button alert tiny", method: :delete
+      - if form.disabled_event? && resu.object.signed_up?
+        = link_to t(".drop_out_of_event"), drop_event_registrant_build_index_path(registrant, event_id: event.id), data: { confirm: t(".drop_out_confirmation") }, class: "button alert tiny", method: :delete
       = resu.hidden_field :event_id
 
-      - if event.has_cost? && @registrant.paid_or_pending_expense_items.include?(event.expense_item)
+      - if form.paid_for?
         %span.label{ title: t(".paid_for_tooltip") }
           = t(".paid_for")
       - else
         = resu.input :signed_up, :class => "primary_checkbox", label: event.to_s
 
-      - if event.event_categories.size == 1
-        = resu.hidden_field :event_category_id, :value => event.event_categories.first.id
-
     - if !(event.event_categories.size == 1)
       %td.event_choice
-        = resu.label :event_category_id, t('.category')
-        - list = []
-        - disabled_list = []
-        - event.event_categories.each do |cat|
-          - list << [cat.name, cat.id]
-          - if !cat.age_is_in_range(registrant.age)
-            - disabled_list << cat.id
-        = resu.select :event_category_id, list, :disabled => disabled_list, :include_blank => true
+        = resu.input :event_category_id, collection: form.event_categories, as: :select , disabled: form.inaccessible_event_categories, include_blank: true, label: t('.category')
 
   - # Padding before EventChoices
-  - if event.category.max_number_of_event_choices != event.num_choices
+  - if category.max_number_of_event_choices != event.num_choices
     %td{:colspan => category.max_number_of_event_choices - event.num_choices}
 
   -# Event Choices
-  - event.event_choices.each do |choice|
+  - form.event_choices_and_registrant_choices.each do |choice, found_rc|
     %td.event_choice
-      - found_rc = nil
-      - rc = @registrant.registrant_choices.each do |rc|
-        - if rc.event_choice_id == choice.id
-          - found_rc = rc
-          - break
       = f.fields_for :registrant_choices, found_rc do |ec|
         = ec.hidden_field :event_choice_id
         - case ec.object.event_choice.cell_type
         - when "boolean"
-          = ec.input :value, as: :boolean, label: choice.label, :title => choice.tooltip
+          = ec.input :value, as: :boolean, label: choice.label, wrapper_html: { title: choice.tooltip }
         - when "text"
-          = ec.text_field :value, :placeholder => ec.object.event_choice.label, :title => choice.tooltip
+          = ec.input :value, as: :string, label: ec.object.event_choice.label, wrapper_html: {title: choice.tooltip }
         - when "multiple"
           = ec.label :value, choice.label, :title => choice.tooltip
           = ec.select :value, ec.object.event_choice.values, {:include_blank => true}, :title => choice.tooltip
         - when "best_time"
           = ec.text_field :value, :placeholder => ec.object.event_choice.label, :title => choice.tooltip.blank? ? choice.tooltip : "hh:mm:ss or mm:ss"
   - if event.best_time?
-    - found_bt = nil
-    - @registrant.registrant_best_times.each do |bt|
-      - if bt.event_id == event.id
-        - found_bt = bt
     %td
       .row
         .small-12.columns
           = t(".best_time")
-      = f.simple_fields_for :registrant_best_times, found_bt do |rbt|
+      = f.simple_fields_for :registrant_best_times, form.best_time do |rbt|
         = rbt.hidden_field :event_id
         .row
           .small-12.medium-6.columns
             = rbt.input :source_location, required: false
           .small-12.medium-6.columns
-            = rbt.input :formatted_value, required: false, placeholder: rbt.object.hint
+            = rbt.input :formatted_value, required: false, hint: "Format: #{rbt.object.hint}"
 
   - if event.accepts_music_uploads?
     %td
-      %a.music_help{:href => "#", :title => t(".upload_music_details") }= t(".upload_music")
+      .music_help{:href => "#", :title => t(".upload_music_details") }= t(".upload_music")

--- a/app/views/attending/_events.html.haml
+++ b/app/views/attending/_events.html.haml
@@ -13,4 +13,4 @@
       %table.events
         - category.events.each do |event|
           - next unless event.visible?
-          = render :partial => "/attending/event", :locals => {:f => f, :registrant => @registrant, :category => category}, :object => event
+          = render partial: "/attending/event", locals: {f: f, registrant: @registrant, category: category, event: event}, object: event

--- a/spec/actions/choices_validator_spec.rb
+++ b/spec/actions/choices_validator_spec.rb
@@ -88,7 +88,7 @@ describe ChoicesValidator do
       end
       it "should be invalid if we only check off the second_choice" do
         FactoryGirl.create(:registrant_choice, event_choice: @ec2, value: "1", registrant: registrant)
-        FactoryGirl.create(:registrant_event_sign_up, event: @ev, event_category: @ec1, signed_up: false, registrant: registrant)
+        FactoryGirl.create(:registrant_event_sign_up, event: @ev, signed_up: false, registrant: registrant)
         registrant.reload
         expect(registrant.valid?).to eq(false)
       end
@@ -160,14 +160,14 @@ describe ChoicesValidator do
         expect(registrant.valid?).to eq(true)
       end
       it "should be valid if we don't choose the event, and we don't fill in the event_choice" do
-        FactoryGirl.create(:registrant_event_sign_up, event: @ev, event_category: @ec1, signed_up: false, registrant: registrant)
+        FactoryGirl.create(:registrant_event_sign_up, event: @ev, signed_up: false, registrant: registrant)
         FactoryGirl.create(:registrant_choice, event_choice: @ec2, value: "", registrant: registrant)
         registrant.reload
         expect(registrant.valid?).to eq(true)
       end
       it "should be invalid if we fill in only the second_choice" do
         FactoryGirl.create(:registrant_choice, event_choice: @ec2, value: "goodbye", registrant: registrant)
-        FactoryGirl.create(:registrant_event_sign_up, event: @ev, event_category: @ec1, signed_up: false, registrant: registrant)
+        FactoryGirl.create(:registrant_event_sign_up, event: @ev, signed_up: false, registrant: registrant)
         registrant.reload
         expect(registrant.valid?).to eq(false)
       end

--- a/spec/actions/importers/registrant_data_importer_spec.rb
+++ b/spec/actions/importers/registrant_data_importer_spec.rb
@@ -73,7 +73,7 @@ describe Importers::RegistrantDataImporter do
       end
 
       context "when resu already exists" do
-        let!(:registrant_event_sign_up) { FactoryGirl.create(:registrant_event_sign_up, registrant: registrant, event: event, event_category: event.event_categories.first, signed_up: false) }
+        let!(:registrant_event_sign_up) { FactoryGirl.create(:registrant_event_sign_up, registrant: registrant, event: event, signed_up: false) }
 
         it "does not create a new sign up" do
           expect do

--- a/spec/factories/registrant_event_sign_ups.rb
+++ b/spec/factories/registrant_event_sign_ups.rb
@@ -28,7 +28,7 @@ FactoryGirl.define do
     signed_up true
 
     before(:create) do |resu|
-      if resu.event.nil?
+      if resu.event.nil? && resu.signed_up?
         if resu.event_category.nil?
           ev = FactoryGirl.create(:event)
           resu.event_category = ev.event_categories.first

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -129,6 +129,7 @@ describe Event do
     end
     it "will not count entries which are not selected" do
       @ec.signed_up = false
+      @ec.event_category = nil
       @ec.save
       expect(@ev.num_signed_up_registrants).to eq(0)
     end

--- a/spec/models/registrant_event_sign_up_spec.rb
+++ b/spec/models/registrant_event_sign_up_spec.rb
@@ -26,10 +26,6 @@ describe RegistrantEventSignUp do
   it "is valid from FactoryGirl" do
     expect(re.valid?).to eq(true)
   end
-  it "requires an event_category" do
-    re.event_category = nil
-    expect(re.valid?).to eq(false)
-  end
 
   it "requires a registrant" do
     re.registrant = nil
@@ -54,7 +50,7 @@ describe RegistrantEventSignUp do
 
       it "when I un-sign-up, it removes the registrant_expense_item" do
         expect do
-          @registrant_event_sign_up.update(signed_up: false)
+          @registrant_event_sign_up.update(signed_up: false, event_category: nil)
         end.to change(RegistrantExpenseItem, :count).by(-1)
       end
     end
@@ -122,7 +118,7 @@ describe "when a competition exists before a sign-up" do
   end
 
   it "adds the competition on change of state" do
-    @re = FactoryGirl.create(:registrant_event_sign_up, event_category: event_category, signed_up: false)
+    @re = FactoryGirl.create(:registrant_event_sign_up, event: event_category.event, signed_up: false)
     expect do
       expect(@re.save).to be_truthy
     end.to change(Competitor, :count).by(0)
@@ -141,7 +137,7 @@ describe "when a competition exists before a sign-up" do
     end
 
     it "doesn't add the competitor on change of state" do
-      @re = FactoryGirl.create(:registrant_event_sign_up, event_category: event_category, signed_up: false)
+      @re = FactoryGirl.create(:registrant_event_sign_up, event: event_category.event, signed_up: false)
       expect(@re.registrant.gender).to eq("Male")
 
       @re.signed_up = true


### PR DESCRIPTION
Resolves #219 

Prevents choosing the checkbox for an event without also choosing the Event Category (if more than 1 event category exists).

Note: this does NOT prevent users from typing into some of the "choice" fields while still having NOT chosen the event...mostly because fixing the existing data for that would be more work.