### PR TITLE
Sell lodging

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -52,6 +52,7 @@
 //= require jquery.are-you-sure
 //= require jquery.placeholder
 //= require lane_assignment
+//= require lodging_adder
 //= require payments
 //= require registrants
 //= require reorder_rows

--- a/app/assets/javascripts/date_picker.js.coffee.erb
+++ b/app/assets/javascripts/date_picker.js.coffee.erb
@@ -1,6 +1,5 @@
 $ ->
-  # this needs to be in a loop or else the pickers don't work well on the Important Dates page
-  $(".datepicker").each (_, el) =>
+  create_date_picker = (el) ->
     $(el).datetimepicker(
       timepicker: false,
       format: "Y/m/d",
@@ -8,6 +7,14 @@ $ ->
       scrollTime: false,
       scrollInput: false,
       defaultDate: '<%= EventConfiguration.singleton.start_date.try(:strftime, "%Y/%m/%d") %>'
-      )
+    )
+
+  # this needs to be in a loop or else the pickers don't work well on the Important Dates page
+  $(".datepicker").each (_, el) =>
+    create_date_picker(el)
 
   $('.datetimepicker').datetimepicker();
+
+  $(document).on "cocoon:after-insert", (e, insertedItem) =>
+    $(insertedItem).find(".datepicker").each (_, el) =>
+      create_date_picker(el)

--- a/app/assets/javascripts/lodging_adder.js
+++ b/app/assets/javascripts/lodging_adder.js
@@ -1,0 +1,15 @@
+$(document).ready(function() {
+  $('#lodging_days').on('cocoon:after-insert', function(e, insertedItem) {
+    var num_children = insertedItem.parent().children("tr").length;
+    if (num_children > 1) {
+      var previous_child = $(insertedItem.parent().children("tr")[num_children - 2])
+      var previous_value = previous_child.find("input").val();
+      var values = previous_value.split("/");
+      var new_day = parseInt(values[2]) + 1;
+      var new_full_date = values[0] + "/" + values[1] + "/" + new_day;
+      $(insertedItem.find("input")[0]).val(new_full_date);
+    } else {
+      console.log("No previous child");
+    }
+  });
+});

--- a/app/controllers/convention_setup/lodging_room_options_controller.rb
+++ b/app/controllers/convention_setup/lodging_room_options_controller.rb
@@ -1,0 +1,45 @@
+class ConventionSetup::LodgingRoomOptionsController < ConventionSetup::BaseConventionSetupController
+  before_action :load_lodging_room_option
+  before_action :authorize_setup
+
+  before_action :set_breadcrumbs
+
+  respond_to :html
+
+  # GET /convention_setup/lodging_room_option/:id/edit
+  def edit
+    add_breadcrumb "Edit Lodging Room Option"
+  end
+
+  # PUT /convention_setup/lodging_room_option/1
+  def update
+    respond_to do |format|
+      if @lodging_room_option.update_attributes(lodging_room_option_params)
+        format.html { redirect_to convention_setup_lodging_room_option_path(@lodging_room_option), notice: 'Lodging Room Option was successfully updated.' }
+      else
+        format.html { render action: "edit" }
+      end
+    end
+  end
+
+  private
+
+  def load_lodging_room_option
+    @lodging_room_option = LodgingRoomOption.find(params[:id])
+  end
+
+  def authorize_setup
+    authorize @config, :setup_convention?
+  end
+
+  def set_breadcrumbs
+    add_breadcrumb "Setup Lodging", convention_setup_lodgings_path
+    add_breadcrumb "#{@lodging} Room Types", convention_setup_lodging_path(@lodging_room_option.lodging_room_type.lodging) if @lodging_room_option&.lodging_room_type&.lodging
+    add_breadcrumb "#{@lodging_room_type} Room Options", convention_setup_lodging_room_type_path(@lodging_room_option.lodging_room_type) if @lodging_room_option&.lodging_room_type
+  end
+
+  def lodging_room_option_params
+    params.require(:lodging_room_option).permit(:name, :price,
+                                                lodging_days_attributes: %i[id _destroy date_offered])
+  end
+end

--- a/app/controllers/convention_setup/lodging_room_types_controller.rb
+++ b/app/controllers/convention_setup/lodging_room_types_controller.rb
@@ -1,0 +1,44 @@
+class ConventionSetup::LodgingRoomTypesController < ConventionSetup::BaseConventionSetupController
+  before_action :load_lodging_room_type, except: %i[new]
+  before_action :authorize_setup
+
+  before_action :set_breadcrumbs
+
+  respond_to :html
+
+  # GET /convention_setup/lodging_types/:id/edit
+  def edit
+    add_breadcrumb "Edit Lodging Type"
+  end
+
+  # PUT /convention_setup/lodging_types/1
+  def update
+    respond_to do |format|
+      if @lodging_room_type.update_attributes(lodging_room_type_params)
+        format.html { redirect_to convention_setup_lodging_room_type_path(@lodging_room_type), notice: 'Lodging Room Type was successfully updated.' }
+      else
+        format.html { render action: "edit" }
+      end
+    end
+  end
+
+  private
+
+  def load_lodging_room_type
+    @lodging_room_type = LodgingRoomType.find(params[:id])
+  end
+
+  def authorize_setup
+    authorize @config, :setup_convention?
+  end
+
+  def set_breadcrumbs
+    add_breadcrumb "Setup Lodging", convention_setup_lodgings_path
+    add_breadcrumb "#{@lodging} Room Types", convention_setup_lodging_path(@lodging_room_type.lodging) if @lodging_room_type&.lodging
+  end
+
+  def lodging_room_type_params
+    params.require(:lodging_room_type).permit(:name, :description,
+                                              lodging_room_options_attributes: %i[id _destroy name price])
+  end
+end

--- a/app/controllers/convention_setup/lodging_room_types_controller.rb
+++ b/app/controllers/convention_setup/lodging_room_types_controller.rb
@@ -34,11 +34,12 @@ class ConventionSetup::LodgingRoomTypesController < ConventionSetup::BaseConvent
 
   def set_breadcrumbs
     add_breadcrumb "Setup Lodging", convention_setup_lodgings_path
+    add_breadcrumb @lodging_room_type.lodging.to_s, convention_setup_lodging_path(@lodging_room_type.lodging) if @lodging_room_type&.lodging
     add_breadcrumb "#{@lodging} Room Types", convention_setup_lodging_path(@lodging_room_type.lodging) if @lodging_room_type&.lodging
   end
 
   def lodging_room_type_params
-    params.require(:lodging_room_type).permit(:name, :description,
+    params.require(:lodging_room_type).permit(:name, :description, :maximum_available, :visible,
                                               lodging_room_options_attributes: %i[id _destroy name price])
   end
 end

--- a/app/controllers/convention_setup/lodgings_controller.rb
+++ b/app/controllers/convention_setup/lodgings_controller.rb
@@ -34,6 +34,10 @@ class ConventionSetup::LodgingsController < ConventionSetup::BaseConventionSetup
     end
   end
 
+  def show
+    add_breadcrumb @lodging.to_s, convention_setup_lodging_path(@lodging)
+  end
+
   # PUT /convention_setup/lodgings/1
   def update
     respond_to do |format|

--- a/app/controllers/convention_setup/lodgings_controller.rb
+++ b/app/controllers/convention_setup/lodgings_controller.rb
@@ -27,9 +27,8 @@ class ConventionSetup::LodgingsController < ConventionSetup::BaseConventionSetup
       if @lodging.save
         format.html { redirect_to convention_setup_lodgings_path, notice: 'Lodging was successfully created.' }
       else
-        @lodgings = Lodging.all
         flash.now[:alert] = "Unable to create lodging. #{@lodging.errors.full_messages.join(', ')}"
-        format.html { render action: "index" }
+        format.html { render action: "new" }
       end
     end
   end

--- a/app/controllers/convention_setup/lodgings_controller.rb
+++ b/app/controllers/convention_setup/lodgings_controller.rb
@@ -1,0 +1,76 @@
+class ConventionSetup::LodgingsController < ConventionSetup::BaseConventionSetupController
+  before_action :load_lodging, except: %i[index new create]
+  before_action :authorize_setup
+
+  before_action :set_breadcrumbs
+
+  respond_to :html
+
+  # GET /convention_setup/lodgings
+  def index
+    @lodgings = Lodging.all
+  end
+
+  def new
+    @lodging = Lodging.new
+  end
+
+  # GET /convention_setup/lodgings/1/edit
+  def edit
+    add_breadcrumb "Edit Lodging"
+  end
+
+  # POST /convention_setup/lodgings
+  def create
+    @lodging = Lodging.new(lodging_params)
+    respond_to do |format|
+      if @lodging.save
+        format.html { redirect_to convention_setup_lodgings_path, notice: 'Lodging was successfully created.' }
+      else
+        @lodgings = Lodging.all
+        flash.now[:alert] = "Unable to create lodging. #{@lodging.errors.full_messages.join(', ')}"
+        format.html { render action: "index" }
+      end
+    end
+  end
+
+  # PUT /convention_setup/lodgings/1
+  def update
+    respond_to do |format|
+      if @lodging.update_attributes(lodging_params)
+        format.html { redirect_to convention_setup_lodgings_path, notice: 'Lodging was successfully updated.' }
+      else
+        format.html { render action: "edit" }
+      end
+    end
+  end
+
+  # DELETE /convention_setup/lodgings/1
+  def destroy
+    if @lodging.destroy
+      flash[:notice] = "Lodging deleted"
+    else
+      flash[:alert] = "Unable to delete lodging"
+    end
+    redirect_to convention_setup_lodgings_path
+  end
+
+  private
+
+  def load_lodging
+    @lodging = Lodging.find(params[:id])
+  end
+
+  def authorize_setup
+    authorize @config, :setup_convention?
+  end
+
+  def set_breadcrumbs
+    add_breadcrumb "Setup Lodging", convention_setup_lodgings_path
+  end
+
+  def lodging_params
+    params.require(:lodging).permit(:name, :description,
+                                    lodging_room_types_attributes: %i[id _destroy name description visible maximum_available])
+  end
+end

--- a/app/controllers/lodging_packages_controller.rb
+++ b/app/controllers/lodging_packages_controller.rb
@@ -1,0 +1,23 @@
+class LodgingPackagesController < ApplicationController
+  before_action :load_registrant
+
+  # /:registrant_id/lodging_packages/:lodging_package_id
+  def destroy
+    authorize @registrant, :lodging?
+
+    lodging_package = LodgingPackage.find(params[:id])
+    package = @registrant.registrant_expense_items.find_by(line_item: lodging_package)
+    if package&.destroy
+      flash[:notice] = "Lodging Removed"
+    else
+      flash[:alert] = "Error removing lodging"
+    end
+    redirect_to registrant_build_path(@registrant, "lodging")
+  end
+
+  private
+
+  def load_registrant
+    @registrant = Registrant.find_by(bib_number: params[:registrant_id])
+  end
+end

--- a/app/controllers/lodging_packages_controller.rb
+++ b/app/controllers/lodging_packages_controller.rb
@@ -7,7 +7,7 @@ class LodgingPackagesController < ApplicationController
 
     lodging_package = LodgingPackage.find(params[:id])
     package = @registrant.registrant_expense_items.find_by(line_item: lodging_package)
-    if package&.destroy
+    if package&.destroy && lodging_package.destroy
       flash[:notice] = "Lodging Removed"
     else
       flash[:alert] = "Error removing lodging"

--- a/app/controllers/lodgings_controller.rb
+++ b/app/controllers/lodgings_controller.rb
@@ -1,0 +1,42 @@
+class LodgingsController < ApplicationController
+  before_action :load_registrant
+
+  def create
+    authorize @registrant, :lodging?
+
+    form = LodgingForm.new(lodging_params.merge(registrant_id: @registrant.id))
+    if form.save
+      flash[:notice] = "Lodging Added"
+    else
+      flash[:alert] = "Error adding lodging. #{form.errors.full_messages.join(', ')}"
+    end
+    redirect_to registrant_build_path(@registrant, "lodging")
+  end
+
+  # /:registrant_id/lodgings/:lodging_package_id
+  # where id: lodging_type to be deleted
+  def destroy
+    authorize @registrant, :lodging?
+
+    form = LodgingForm.new(
+      lodging_room_option_id: params[:id],
+      registrant_id: @registrant.id
+    )
+    if form.destroy
+      flash[:notice] = "Lodging Removed"
+    else
+      flash[:alert] = "Error removing lodging #{form.errors.full_messages.join(', ')}"
+    end
+    redirect_to registrant_build_path(@registrant, "lodging")
+  end
+
+  private
+
+  def load_registrant
+    @registrant = Registrant.find_by(bib_number: params[:registrant_id])
+  end
+
+  def lodging_params
+    params.require(:lodging_form).permit(:lodging_room_option_id, :first_day, :last_day)
+  end
+end

--- a/app/controllers/lodgings_controller.rb
+++ b/app/controllers/lodgings_controller.rb
@@ -13,23 +13,6 @@ class LodgingsController < ApplicationController
     redirect_to registrant_build_path(@registrant, "lodging")
   end
 
-  # /:registrant_id/lodgings/:lodging_package_id
-  # where id: lodging_type to be deleted
-  def destroy
-    authorize @registrant, :lodging?
-
-    form = LodgingForm.new(
-      lodging_room_option_id: params[:id],
-      registrant_id: @registrant.id
-    )
-    if form.destroy
-      flash[:notice] = "Lodging Removed"
-    else
-      flash[:alert] = "Error removing lodging #{form.errors.full_messages.join(', ')}"
-    end
-    redirect_to registrant_build_path(@registrant, "lodging")
-  end
-
   private
 
   def load_registrant

--- a/app/controllers/lodgings_controller.rb
+++ b/app/controllers/lodgings_controller.rb
@@ -37,6 +37,6 @@ class LodgingsController < ApplicationController
   end
 
   def lodging_params
-    params.require(:lodging_form).permit(:lodging_room_option_id, :first_day, :last_day)
+    params.require(:lodging_form).permit(:lodging_room_option_id, :check_in_day, :check_out_day)
   end
 end

--- a/app/controllers/payment_summary/lodgings_controller.rb
+++ b/app/controllers/payment_summary/lodgings_controller.rb
@@ -1,0 +1,21 @@
+module PaymentSummary
+  class LodgingsController < ApplicationController
+    before_action :authorize_action
+
+    def show
+      @lodging = Lodging.find(params[:id])
+      set_breadcrumbs
+    end
+
+    private
+
+    def set_breadcrumbs
+      add_payment_summary_breadcrumb
+      add_breadcrumb "#{@lodging} Items"
+    end
+
+    def authorize_action
+      authorize current_user, :manage_all_payments?
+    end
+  end
+end

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -63,6 +63,7 @@ class PaymentsController < ApplicationController
     add_payment_summary_breadcrumb
     authorize Payment.new
     @expense_groups = ExpenseGroup.includes(:translations)
+    @lodgings = Lodging.ordered.all
   end
 
   # GET /payments/1

--- a/app/controllers/registrants/build_controller.rb
+++ b/app/controllers/registrants/build_controller.rb
@@ -9,7 +9,7 @@ class Registrants::BuildController < ApplicationController
   before_action :load_categories, only: %i[show update add_events]
   layout "wizard"
 
-  ALL_STEPS = %i[add_name add_events set_wheel_sizes add_volunteers add_contact_details expenses].freeze
+  ALL_STEPS = %i[add_name add_events set_wheel_sizes add_volunteers add_contact_details lodging expenses].freeze
 
   rescue_from Wicked::Wizard::InvalidStepError, with: :step_not_found
 
@@ -40,6 +40,9 @@ class Registrants::BuildController < ApplicationController
     when :add_events
       skip_step unless @registrant.competitor?
     when :add_volunteers # rubocop:disable Lint/EmptyWhen
+    when :lodging
+      @selected_lodging = LodgingForm.selected_for(@registrant)
+      @paid_lodging = LodgingForm.paid_for(@registrant)
     end
 
     render_wizard
@@ -58,7 +61,7 @@ class Registrants::BuildController < ApplicationController
     end
     @registrant.status = 'active' if step == steps.last
 
-    @registrant.update_attributes(registrant_params) unless wizard_value(step) == :expenses
+    @registrant.update_attributes(registrant_params) unless (wizard_value(step) == :lodging) || (wizard_value(step) == :expenses)
     render_wizard @registrant
   end
 

--- a/app/forms/lodging_form.rb
+++ b/app/forms/lodging_form.rb
@@ -1,0 +1,122 @@
+class LodgingForm
+  include ActiveModel::Model
+
+  attr_accessor :lodging_room_option_id, :registrant_id
+  attr_accessor :first_day, :last_day
+
+  validates :lodging_room_option, :registrant, :first_day, :last_day, presence: true
+  validate :days_are_available
+  validate :all_desired_days_exist
+
+  # create all of the associated registrant_expense_items for the given selection
+  def save
+    return false unless valid?
+    success = true
+
+    Lodging.transaction do
+      package = LodgingPackage.new(
+        lodging_room_type: lodging_room_type,
+        lodging_room_option: lodging_room_option,
+        total_cost: lodging_room_option.price * days_to_book.count
+      )
+      days_to_book.each do |day|
+        package.lodging_package_days.build(
+          lodging_day: day
+        )
+      end
+
+      success &&= package.save
+
+      # success &&= registrant.registrant_expense_items.build(
+      #   line_item: package,
+      #   system_managed: true,
+      # )
+      unless success
+        errors.add(:base, "Unable to save items. Are you trying to buy it a 2nd time?")
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    success
+  end
+
+  # Return a set of LodgingForm objects for the lodging currently selected for this registrant
+  def self.selected_for(registrant)
+    registrant.registrant_expense_items.none
+    # lodging_selected_from_set(registrant.owing_expense_items)
+  end
+
+  def self.lodging_selected_from_set(expense_items_scope)
+    LodgingRoomType.includes(lodging_room_options: :lodging_days).map do |lodging_room_type|
+      expense_items = lodging_room_type.lodging_days.map(&:expense_item)
+      found_expense_items = expense_items_scope & expense_items
+
+      next if found_expense_items.none?
+
+      selected_lodging_days = lodging_room_type.lodging_days.select do |lodging_day|
+        found_expense_items.any?{|expense_item| expense_item == lodging_day.expense_item }
+      end
+      first_day = selected_lodging_days.first
+      last_day = selected_lodging_days.last
+
+      LodgingForm.new(
+        lodging_room_type_id: lodging_room_type.id,
+        first_day: first_day.date_offered.strftime("%Y/%m/%d"),
+        last_day: last_day.date_offered.strftime("%Y/%m/%d")
+      )
+    end.compact
+  end
+
+  def self.paid_for(registrant)
+    registrant.payment_details.none
+    # lodging_selected_from_set(registrant.paid_expense_items)
+  end
+
+  def lodging_room_type
+    return nil if lodging_room_option.nil?
+
+    lodging_room_option.lodging_room_type
+  end
+
+  def lodging_room_option
+    return nil if lodging_room_option_id.blank?
+
+    LodgingRoomOption.find(lodging_room_option_id)
+  end
+
+  private
+
+  def days_are_available
+    return false # XXX
+    days_to_book.each do |day|
+      if day.expense_item.maximum_reached?
+        errors.add(:base, "#{day} Unable to be booked")
+      end
+    end
+  end
+
+  def all_desired_days_exist
+    return if first_day.blank? || last_day.blank?
+    if days_to_book.first&.date_offered != Date.parse(first_day)
+      errors.add(:base, "#{first_day} Unable to be booked. Out of range?")
+    end
+    if days_to_book.last&.date_offered != Date.parse(last_day)
+      errors.add(:base, "#{last_day} Unable to be booked. Out of range?")
+    end
+  end
+
+  def registrant
+    Registrant.find(registrant_id)
+  end
+
+  # find the LodgingDay objects based on user input
+  def days_to_book
+    return LodgingDay.none if lodging_room_option.nil?
+
+    lodging_room_option.lodging_days.where(
+      LodgingDay.arel_table[:date_offered].gteq(first_day)
+    ).where(
+      LodgingDay.arel_table[:date_offered].lteq(last_day)
+    )
+  end
+end

--- a/app/forms/lodging_form.rb
+++ b/app/forms/lodging_form.rb
@@ -2,9 +2,9 @@ class LodgingForm
   include ActiveModel::Model
 
   attr_accessor :lodging_room_option_id, :registrant_id
-  attr_accessor :first_day, :last_day
+  attr_accessor :check_in_day, :check_out_day
 
-  validates :lodging_room_option, :registrant, :first_day, :last_day, presence: true
+  validates :lodging_room_option, :registrant, :check_in_day, :check_out_day, presence: true
   validate :all_desired_days_exist
 
   # create all of the associated registrant_expense_items for the given selection
@@ -70,12 +70,12 @@ class LodgingForm
   private
 
   def all_desired_days_exist
-    return if first_day.blank? || last_day.blank?
-    if days_to_book.first&.date_offered != Date.parse(first_day)
-      errors.add(:base, "#{first_day} Unable to be booked. Out of range?")
+    return if check_in_day.blank? || check_out_day.blank?
+    if days_to_book.first&.date_offered != Date.parse(check_in_day)
+      errors.add(:base, "#{check_in_day} Unable to be booked. Out of range?")
     end
-    if days_to_book.last&.date_offered != Date.parse(last_day)
-      errors.add(:base, "#{last_day} Unable to be booked. Out of range?")
+    if days_to_book.last&.date_offered != (Date.parse(check_out_day) - 1.day)
+      errors.add(:base, "#{check_out_day} Unable to be booked. Out of range?")
     end
   end
 
@@ -88,9 +88,9 @@ class LodgingForm
     return LodgingDay.none if lodging_room_option.nil?
 
     lodging_room_option.lodging_days.where(
-      LodgingDay.arel_table[:date_offered].gteq(first_day)
+      LodgingDay.arel_table[:date_offered].gteq(check_in_day)
     ).where(
-      LodgingDay.arel_table[:date_offered].lteq(last_day)
+      LodgingDay.arel_table[:date_offered].lt(check_out_day)
     )
   end
 end

--- a/app/forms/lodging_form.rb
+++ b/app/forms/lodging_form.rb
@@ -26,6 +26,7 @@ class LodgingForm
 
       unless package.save
         errors.add(:base, "Unable to save items. #{package.errors.full_messages.join(', ')}")
+        success = false
         raise ActiveRecord::Rollback
       end
 
@@ -39,6 +40,7 @@ class LodgingForm
 
       unless new_rei.save
         errors.add(:base, "Unable to save items. #{new_rei.errors.full_messages.join(', ')}")
+        success = false
         raise ActiveRecord::Rollback
       end
     end

--- a/app/forms/lodging_form.rb
+++ b/app/forms/lodging_form.rb
@@ -27,11 +27,15 @@ class LodgingForm
 
       success &&= package.save
 
-      success &&= registrant.registrant_expense_items.create(
+      new_rei = registrant.registrant_expense_items.build(
         line_item: package,
         system_managed: true
       )
+
+      success &&= new_rei.save
+
       unless success
+        # Add error messages from new_rei?
         errors.add(:base, "Unable to save items. Are you trying to buy it a 2nd time?")
         raise ActiveRecord::Rollback
       end

--- a/app/models/event_configuration.rb
+++ b/app/models/event_configuration.rb
@@ -339,6 +339,12 @@ class EventConfiguration < ApplicationRecord
     organization_membership_type == "usa"
   end
 
+  def has_lodging?
+    return @has_lodging if defined?(@has_lodging)
+
+    @has_lodging = LodgingDay.any?
+  end
+
   def has_expenses?
     return @has_expenses if defined?(@has_expenses)
 

--- a/app/models/lodging.rb
+++ b/app/models/lodging.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: lodgings
+#
+#  id          :integer          not null, primary key
+#  name        :string           not null
+#  position    :integer
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+class Lodging < ApplicationRecord
+  validates :name, presence: true
+  validates :name, uniqueness: true
+
+  has_many :lodging_room_types, inverse_of: :lodging, dependent: :restrict_with_error
+  has_many :lodging_days, through: :lodging_types
+
+  accepts_nested_attributes_for :lodging_room_types, allow_destroy: true
+  validates_uniqueness :lodging_room_types, attribute_name: :name
+
+  acts_as_restful_list
+
+  scope :ordered, -> { order(:position) }
+
+  def to_s
+    name
+  end
+end

--- a/app/models/lodging.rb
+++ b/app/models/lodging.rb
@@ -15,6 +15,7 @@ class Lodging < ApplicationRecord
   validates :name, uniqueness: true
 
   has_many :lodging_room_types, inverse_of: :lodging, dependent: :restrict_with_error
+  has_many :lodging_room_options, through: :lodging_room_types
   has_many :lodging_days, through: :lodging_types
 
   accepts_nested_attributes_for :lodging_room_types, allow_destroy: true

--- a/app/models/lodging_day.rb
+++ b/app/models/lodging_day.rb
@@ -18,5 +18,7 @@ class LodgingDay < ApplicationRecord
 
   belongs_to :lodging_room_option, inverse_of: :lodging_days
 
+  scope :ordered, -> { order(:date_offered) }
+
   delegate :to_s, to: :date_offered
 end

--- a/app/models/lodging_day.rb
+++ b/app/models/lodging_day.rb
@@ -15,6 +15,7 @@
 
 class LodgingDay < ApplicationRecord
   validates :date_offered, uniqueness: { scope: [:lodging_room_option_id] }
+  validates :date_offered, presence: true
 
   belongs_to :lodging_room_option, inverse_of: :lodging_days
 

--- a/app/models/lodging_day.rb
+++ b/app/models/lodging_day.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: lodging_days
+#
+#  id                     :integer          not null, primary key
+#  lodging_room_option_id :integer          not null
+#  date_offered           :date             not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_lodging_days_on_lodging_room_option_id  (lodging_room_option_id)
+#
+
+class LodgingDay < ApplicationRecord
+  validates :date_offered, uniqueness: { scope: [:lodging_room_option_id] }
+
+  belongs_to :lodging_room_option, inverse_of: :lodging_days
+
+  delegate :to_s, to: :date_offered
+end

--- a/app/models/lodging_package.rb
+++ b/app/models/lodging_package.rb
@@ -60,8 +60,10 @@ class LodgingPackage < ApplicationRecord
     0
   end
 
-  def to_s
-    LodgingPackagePresenter.new(self).to_s
+  delegate :to_s, :location, :check_in_day, :check_out_day, to: :presenter
+
+  def presenter
+    LodgingPackagePresenter.new(self)
   end
 
   def status

--- a/app/models/lodging_package.rb
+++ b/app/models/lodging_package.rb
@@ -25,8 +25,17 @@ class LodgingPackage < ApplicationRecord
   validates :total_cost, presence: true
   monetize :total_cost_cents
 
-  def can_create_registrant_expense_item?(_registrant_expense_item)
-    []
+  def can_create_registrant_expense_item?(registrant_expense_item)
+    errors = []
+
+    existing_packages = registrant_expense_item.registrant.all_expense_items.select{ |line_item| line_item.is_a?(LodgingPackage) }
+    lodging_package_days.each do |lodging_package_day|
+      if existing_packages.flat_map(&:lodging_package_days).map(&:date_offered).include?(lodging_package_day.date_offered)
+        errors << "Unable to add the same day (#{lodging_package_day.date_offered}) twice"
+      end
+    end
+
+    errors
   end
 
   def has_custom_cost?
@@ -35,7 +44,7 @@ class LodgingPackage < ApplicationRecord
 
   def has_details?; end
 
-  # alias_attribute :cost, :total_cost
+  alias_attribute :cost, :total_cost
 
   def tax
     0

--- a/app/models/lodging_package.rb
+++ b/app/models/lodging_package.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: lodging_packages
+#
+#  id                     :integer          not null, primary key
+#  lodging_room_type_id   :integer          not null
+#  lodging_room_option_id :integer          not null
+#  total_cost_cents       :integer          not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_lodging_packages_on_lodging_room_option_id  (lodging_room_option_id)
+#  index_lodging_packages_on_lodging_room_type_id    (lodging_room_type_id)
+#
+
+class LodgingPackage < ApplicationRecord
+  belongs_to :lodging_room_type
+  belongs_to :lodging_room_option
+  has_many :lodging_package_days, dependent: :destroy
+
+  validates :lodging_room_type, :lodging_room_option, presence: true
+  validates :total_cost, presence: true
+  monetize :total_cost_cents
+end

--- a/app/models/lodging_package.rb
+++ b/app/models/lodging_package.rb
@@ -19,8 +19,25 @@ class LodgingPackage < ApplicationRecord
   belongs_to :lodging_room_type
   belongs_to :lodging_room_option
   has_many :lodging_package_days, dependent: :destroy
+  has_many :registrant_expense_items, as: :line_item, inverse_of: :line_item, dependent: :restrict_with_exception
 
   validates :lodging_room_type, :lodging_room_option, presence: true
   validates :total_cost, presence: true
   monetize :total_cost_cents
+
+  def can_create_registrant_expense_item?(_registrant_expense_item)
+    []
+  end
+
+  def has_custom_cost?
+    false
+  end
+
+  def has_details?; end
+
+  # alias_attribute :cost, :total_cost
+
+  def tax
+    0
+  end
 end

--- a/app/models/lodging_package.rb
+++ b/app/models/lodging_package.rb
@@ -20,18 +20,28 @@ class LodgingPackage < ApplicationRecord
   belongs_to :lodging_room_option
   has_many :lodging_package_days, dependent: :destroy
   has_many :registrant_expense_items, as: :line_item, inverse_of: :line_item, dependent: :restrict_with_exception
+  has_many :payment_details, as: :line_item, dependent: :restrict_with_exception
 
   validates :lodging_room_type, :lodging_room_option, presence: true
   validates :total_cost, presence: true
   monetize :total_cost_cents
 
+  # Check to see that a new entry can be created
   def can_create_registrant_expense_item?(registrant_expense_item)
     errors = []
 
-    existing_packages = registrant_expense_item.registrant.all_expense_items.select{ |line_item| line_item.is_a?(LodgingPackage) }
+    # Check to see if the registrant has already booked a Lodging for the same day as they are trying to book
+    existing_packages = registrant_expense_item.registrant.all_line_items.select{ |line_item| line_item.is_a?(LodgingPackage) }
     lodging_package_days.each do |lodging_package_day|
       if existing_packages.flat_map(&:lodging_package_days).map(&:date_offered).include?(lodging_package_day.date_offered)
         errors << "Unable to add the same day (#{lodging_package_day.date_offered}) twice"
+      end
+    end
+
+    # Check to see if any of the lodging_days that they are trying to book are full.
+    lodging_package_days.each do |lodging_package_day|
+      if lodging_room_type.maximum_reached?(lodging_package_day.lodging_day)
+        errors << "#{lodging_package_day} Unable to be booked. None Left"
       end
     end
 
@@ -48,5 +58,37 @@ class LodgingPackage < ApplicationRecord
 
   def tax
     0
+  end
+
+  def to_s
+    LodgingPackagePresenter.new(self).to_s
+  end
+
+  def status
+    if registrant_expense_items.any?
+      "Selected"
+    elsif payment_details.any?
+      "Sold"
+    else
+      "Error"
+    end
+  end
+
+  def registrant
+    associated_entry&.registrant
+  end
+
+  def date_of_last_activity
+    associated_entry&.updated_at
+  end
+
+  private
+
+  def associated_entry
+    if registrant_expense_items.any?
+      registrant_expense_items.first
+    elsif payment_details.any?
+      payment_details.first
+    end
   end
 end

--- a/app/models/lodging_package_day.rb
+++ b/app/models/lodging_package_day.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: lodging_package_days
+#
+#  id                 :integer          not null, primary key
+#  lodging_package_id :integer          not null
+#  lodging_day_id     :integer          not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
+# Indexes
+#
+#  index_lodging_package_days_on_lodging_day_id      (lodging_day_id)
+#  index_lodging_package_days_on_lodging_package_id  (lodging_package_id)
+#  lodging_package_unique                            (lodging_package_id,lodging_day_id) UNIQUE
+#
+
+class LodgingPackageDay < ApplicationRecord
+  validates :lodging_package, :lodging_day, presence: true
+
+  belongs_to :lodging_package, inverse_of: :lodging_package_days
+  belongs_to :lodging_day
+end

--- a/app/models/lodging_package_day.rb
+++ b/app/models/lodging_package_day.rb
@@ -21,5 +21,5 @@ class LodgingPackageDay < ApplicationRecord
   belongs_to :lodging_package, inverse_of: :lodging_package_days
   belongs_to :lodging_day
 
-  delegate :date_offered, to: :lodging_day
+  delegate :date_offered, :to_s, to: :lodging_day
 end

--- a/app/models/lodging_package_day.rb
+++ b/app/models/lodging_package_day.rb
@@ -20,4 +20,6 @@ class LodgingPackageDay < ApplicationRecord
 
   belongs_to :lodging_package, inverse_of: :lodging_package_days
   belongs_to :lodging_day
+
+  delegate :date_offered, to: :lodging_day
 end

--- a/app/models/lodging_room_option.rb
+++ b/app/models/lodging_room_option.rb
@@ -21,10 +21,10 @@ class LodgingRoomOption < ApplicationRecord
 
   belongs_to :lodging_room_type, inverse_of: :lodging_room_options
   has_many :lodging_days, dependent: :destroy
+  has_many :lodging_packages, dependent: :restrict_with_exception
 
   acts_as_restful_list scope: :lodging_room_type
   accepts_nested_attributes_for :lodging_days, allow_destroy: true
-  # validates_uniqueness :lodging_days, attribute_name: :date_offered
 
   scope :ordered, -> { order(:position) }
 
@@ -32,5 +32,59 @@ class LodgingRoomOption < ApplicationRecord
 
   def to_s
     name
+  end
+
+  # for SimpleForm element on new_lodging
+  def to_label
+    "#{lodging_room_type} - #{self}"
+  end
+
+  def num_selected_items(lodging_day)
+    num_unpaid(lodging_day, include_incomplete_registrants: true) + num_paid(lodging_day)
+  end
+
+  def num_paid(lodging_day)
+    paid_items(lodging_day).count
+  end
+
+  def num_unpaid(lodging_day, include_incomplete_registrants: false)
+    unpaid_items(lodging_day, include_incomplete_registrants: include_incomplete_registrants).count
+  end
+
+  # how much have we received for the paid items
+  def total_amount_paid(lodging_day)
+    Money.new(paid_items(lodging_day).map(&:cost).inject(:+))
+  end
+
+  def num_pending(lodging_day)
+    pending_items(lodging_day).count
+  end
+
+  def paid_items(lodging_day)
+    PaymentDetail.paid.where(refunded: false).where(line_item: lodging_packages_for_day(lodging_day))
+  end
+
+  def refunded_items(lodging_day)
+    PaymentDetail.paid.where(refunded: true).where(line_item: lodging_packages_for_day(lodging_day))
+  end
+
+  def pending_items(lodging_day)
+    PaymentDetail.offline_pending.where(line_item: lodging_packages_for_day(lodging_day))
+  end
+
+  # Items which are unpaid.
+  # Note: Free items which are associated with Paid Registrants are considered Paid/Free.
+  def unpaid_items(lodging_day, include_incomplete_registrants: false)
+    registrant_expense_items = RegistrantExpenseItem.where(line_item: lodging_packages_for_day(lodging_day))
+    reis = if include_incomplete_registrants
+             registrant_expense_items.includes(:registrant).joins(:registrant).merge(Registrant.active_or_incomplete)
+           else
+             registrant_expense_items.includes(:registrant).joins(:registrant).merge(Registrant.active)
+           end
+    reis.free.reject{ |rei| rei.registrant.reg_paid? } + reis.where(free: false)
+  end
+
+  def lodging_packages_for_day(lodging_day)
+    lodging_packages.joins(lodging_package_days: :lodging_day).merge(LodgingDay.where(id: lodging_day.id))
   end
 end

--- a/app/models/lodging_room_option.rb
+++ b/app/models/lodging_room_option.rb
@@ -1,0 +1,36 @@
+# == Schema Information
+#
+# Table name: lodging_room_options
+#
+#  id                   :integer          not null, primary key
+#  lodging_room_type_id :integer          not null
+#  position             :integer
+#  name                 :string           not null
+#  price_cents          :integer          default(0), not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
+# Indexes
+#
+#  index_lodging_room_options_on_lodging_room_type_id  (lodging_room_type_id)
+#
+
+class LodgingRoomOption < ApplicationRecord
+  validates :name, presence: true
+  validates :name, uniqueness: { scope: [:lodging_room_type_id] }
+
+  belongs_to :lodging_room_type, inverse_of: :lodging_room_options
+  has_many :lodging_days, dependent: :destroy
+
+  acts_as_restful_list scope: :lodging_room_type
+  accepts_nested_attributes_for :lodging_days, allow_destroy: true
+  # validates_uniqueness :lodging_days, attribute_name: :date_offered
+
+  scope :ordered, -> { order(:position) }
+
+  monetize :price_cents
+
+  def to_s
+    name
+  end
+end

--- a/app/models/lodging_room_type.rb
+++ b/app/models/lodging_room_type.rb
@@ -1,0 +1,35 @@
+# == Schema Information
+#
+# Table name: lodging_room_types
+#
+#  id                :integer          not null, primary key
+#  lodging_id        :integer          not null
+#  position          :integer
+#  name              :string           not null
+#  description       :text
+#  visible           :boolean          default(TRUE), not null
+#  maximum_available :integer
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+# Indexes
+#
+#  index_lodging_room_types_on_lodging_id  (lodging_id)
+#
+
+class LodgingRoomType < ApplicationRecord
+  validates :name, presence: true
+  validates :name, uniqueness: { scope: [:lodging_id] }
+
+  belongs_to :lodging, inverse_of: :lodging_room_types
+  has_many :lodging_room_options, dependent: :destroy
+  accepts_nested_attributes_for :lodging_room_options, allow_destroy: true
+
+  acts_as_restful_list scope: :lodging
+
+  scope :ordered, -> { order(:position) }
+
+  def to_s
+    name
+  end
+end

--- a/app/models/lodging_room_type.rb
+++ b/app/models/lodging_room_type.rb
@@ -23,6 +23,8 @@ class LodgingRoomType < ApplicationRecord
 
   belongs_to :lodging, inverse_of: :lodging_room_types
   has_many :lodging_room_options, dependent: :destroy
+  has_many :lodging_packages, inverse_of: :lodging_room_type
+
   accepts_nested_attributes_for :lodging_room_options, allow_destroy: true
 
   acts_as_restful_list scope: :lodging
@@ -31,5 +33,22 @@ class LodgingRoomType < ApplicationRecord
 
   def to_s
     name
+  end
+
+  def num_selected_items(lodging_day)
+    lodging_room_options.map do |lodging_room_option|
+      lodging_room_option.num_selected_items(lodging_day)
+    end.sum
+  end
+
+  def maximum_reached?(lodging_day)
+    return false unless has_limits?
+
+    num_selected_items(lodging_day) >= maximum_available
+  end
+
+  def has_limits?
+    return true if maximum_available&.positive?
+    false
   end
 end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -109,7 +109,7 @@ class Payment < ApplicationRecord
 
   def self.total_refunded_amount
     total = 0.to_money
-    PaymentDetail.refunded.includes(:payment).each do |payment_detail|
+    PaymentDetail.refunded.includes(:payment, refund_detail: :refund).each do |payment_detail|
       total += payment_detail.cost
     end
     total
@@ -117,7 +117,7 @@ class Payment < ApplicationRecord
 
   def self.total_received
     total = 0.to_money
-    Payment.includes(payment_details: [:refund_detail]).completed.each do |payment|
+    Payment.includes(payment_details: [refund_detail: :refund]).completed.each do |payment|
       total += payment.total_amount
     end
     total

--- a/app/models/registrant.rb
+++ b/app/models/registrant.rb
@@ -55,7 +55,7 @@ class Registrant < ApplicationRecord
     has_many :registrant_best_times, inverse_of: :registrant
     has_many :registrant_choices, inverse_of: :registrant
     has_many :registrant_event_sign_ups, inverse_of: :registrant
-    has_many :registrant_expense_items, -> { includes(line_item: [:translations, expense_group: :translations]) }, autosave: true
+    has_many :registrant_expense_items, autosave: true
     has_many :payment_details, -> {includes :payment}
     has_many :additional_registrant_accesses
     has_many :registrant_group_members

--- a/app/models/registrant_type.rb
+++ b/app/models/registrant_type.rb
@@ -1,4 +1,4 @@
-class RegistrantType
+module RegistrantType
   TYPES = ['competitor', 'noncompetitor', 'spectator'].freeze
 
   def self.for(registrant_type)

--- a/app/models/registrant_type/competitor.rb
+++ b/app/models/registrant_type/competitor.rb
@@ -1,4 +1,4 @@
-class RegistrantType
+module RegistrantType
   class Competitor
     INITIAL = 1
     MAXIMUM = 1999

--- a/app/models/registrant_type/noncompetitor.rb
+++ b/app/models/registrant_type/noncompetitor.rb
@@ -1,4 +1,4 @@
-class RegistrantType
+module RegistrantType
   class Noncompetitor
     INITIAL = 2001
     MAXIMUM = 9999

--- a/app/models/registrant_type/spectator.rb
+++ b/app/models/registrant_type/spectator.rb
@@ -1,4 +1,4 @@
-class RegistrantType
+module RegistrantType
   class Spectator
     INITIAL = 2001
     MAXIMUM = 9999

--- a/app/policies/registrant_policy.rb
+++ b/app/policies/registrant_policy.rb
@@ -52,6 +52,8 @@ class RegistrantPolicy < ApplicationPolicy
   end
 
   def lodging?
+    # Temporarily only allow privileged users to see the lodging pages
+    return false unless user.has_any_role?
     update? && config.has_lodging?
   end
 

--- a/app/policies/registrant_policy.rb
+++ b/app/policies/registrant_policy.rb
@@ -51,6 +51,10 @@ class RegistrantPolicy < ApplicationPolicy
     update?
   end
 
+  def lodging?
+    update? && config.has_lodging?
+  end
+
   def expenses?
     update? && config.has_expenses?
   end
@@ -61,7 +65,7 @@ class RegistrantPolicy < ApplicationPolicy
 
   # is there any action to which I am able to update?
   def update_any_data?
-    add_name? || add_events? || set_wheel_sizes? || add_volunteers? || add_contact_details? || expenses?
+    add_name? || add_events? || set_wheel_sizes? || add_volunteers? || add_contact_details? || lodging? || expenses?
   end
 
   # can I update any of my registration data?

--- a/app/presenters/lodging_package_presenter.rb
+++ b/app/presenters/lodging_package_presenter.rb
@@ -1,0 +1,35 @@
+class LodgingPackagePresenter
+  include ApplicationHelper
+
+  attr_reader :lodging_package
+
+  def initialize(lodging_package)
+    @lodging_package = lodging_package
+  end
+
+  def first_day
+    date = lodging_package.lodging_package_days.map(&:date_offered).sort.first
+    output_entry(date)
+  end
+
+  def last_day
+    date = lodging_package.lodging_package_days.map(&:date_offered).sort.last
+    output_entry(date)
+  end
+
+  private
+
+  def output_range(start_date, end_date)
+    if start_date == end_date
+      output_entry(start_date)
+    else
+      "#{output_entry(start_date)} - #{output_entry(end_date)}"
+    end
+  end
+
+  def output_entry(date)
+    return "none" if date.blank?
+
+    I18n.l(date, format: :lodging_date_format)
+  end
+end

--- a/app/presenters/lodging_package_presenter.rb
+++ b/app/presenters/lodging_package_presenter.rb
@@ -17,6 +17,14 @@ class LodgingPackagePresenter
     output_entry(date)
   end
 
+  def location
+    "#{lodging_package.lodging_room_type} - #{lodging_package.lodging_room_option}"
+  end
+
+  def to_s
+    "#{location} - #{first_day}-#{last_day}"
+  end
+
   private
 
   def output_range(start_date, end_date)

--- a/app/presenters/lodging_package_presenter.rb
+++ b/app/presenters/lodging_package_presenter.rb
@@ -7,13 +7,13 @@ class LodgingPackagePresenter
     @lodging_package = lodging_package
   end
 
-  def first_day
+  def check_in_day
     date = lodging_package.lodging_package_days.map(&:date_offered).sort.first
     output_entry(date)
   end
 
-  def last_day
-    date = lodging_package.lodging_package_days.map(&:date_offered).sort.last
+  def check_out_day
+    date = lodging_package.lodging_package_days.map(&:date_offered).sort.last + 1.day
     output_entry(date)
   end
 
@@ -22,7 +22,7 @@ class LodgingPackagePresenter
   end
 
   def to_s
-    "#{location} - #{first_day}-#{last_day}"
+    "#{location} - #{check_in_day}-#{check_out_day}"
   end
 
   private

--- a/app/presenters/lodging_package_presenter.rb
+++ b/app/presenters/lodging_package_presenter.rb
@@ -18,7 +18,11 @@ class LodgingPackagePresenter
   end
 
   def location
-    "#{lodging_package.lodging_room_type} - #{lodging_package.lodging_room_option}"
+    [
+      lodging_package.lodging_room_type.lodging,
+      lodging_package.lodging_room_type,
+      lodging_package.lodging_room_option
+    ].join(" - ")
   end
 
   def to_s

--- a/app/presenters/lodging_room_option_presenter.rb
+++ b/app/presenters/lodging_room_option_presenter.rb
@@ -22,11 +22,11 @@ class LodgingRoomOptionPresenter
         current_date = day.date_offered
       else
         # non-consecutive days
-        output << output_range(first_date, current_date)
+        output << output_range(first_date, current_date + 1.day)
         first_date = current_date = day.date_offered
       end
     end
-    output << output_range(first_date, current_date)
+    output << output_range(first_date, current_date + 1.day)
     output.join(", ")
   end
 
@@ -34,7 +34,7 @@ class LodgingRoomOptionPresenter
 
   def output_range(start_date, end_date)
     if start_date == end_date
-      output_entry(start_date)
+      output_range(start_date, start_date + 1.day)
     else
       "#{output_entry(start_date)} - #{output_entry(end_date)}"
     end

--- a/app/presenters/lodging_room_option_presenter.rb
+++ b/app/presenters/lodging_room_option_presenter.rb
@@ -13,7 +13,7 @@ class LodgingRoomOptionPresenter
     first_date = nil
     current_date = nil
     output = []
-    lodging_room_option.lodging_days.each do |day|
+    lodging_room_option.lodging_days.ordered.each do |day|
       if first_date.nil?
         # beginning of a range
         first_date = current_date = day.date_offered

--- a/app/presenters/lodging_room_option_presenter.rb
+++ b/app/presenters/lodging_room_option_presenter.rb
@@ -1,0 +1,46 @@
+class LodgingRoomOptionPresenter
+  include ApplicationHelper
+
+  attr_reader :lodging_room_option
+
+  def initialize(lodging_room_option)
+    @lodging_room_option = lodging_room_option
+  end
+
+  def days_available
+    return "none" if lodging_room_option.lodging_days.none?
+
+    first_date = nil
+    current_date = nil
+    output = []
+    lodging_room_option.lodging_days.each do |day|
+      if first_date.nil?
+        # beginning of a range
+        first_date = current_date = day.date_offered
+      elsif (current_date + 1.day) == day.date_offered
+        # consecutive days, increment current range
+        current_date = day.date_offered
+      else
+        # non-consecutive days
+        output << output_range(first_date, current_date)
+        first_date = current_date = day.date_offered
+      end
+    end
+    output << output_range(first_date, current_date)
+    output.join(", ")
+  end
+
+  private
+
+  def output_range(start_date, end_date)
+    if start_date == end_date
+      output_entry(start_date)
+    else
+      "#{output_entry(start_date)} - #{output_entry(end_date)}"
+    end
+  end
+
+  def output_entry(date)
+    I18n.l(date, format: :lodging_date_format)
+  end
+end

--- a/app/views/convention_setup/lodging_room_options/_form.html.haml
+++ b/app/views/convention_setup/lodging_room_options/_form.html.haml
@@ -11,6 +11,9 @@
       = f.simple_fields_for :lodging_days do |member_f|
         = render "lodging_day_fields", f: member_f
 
-  = link_to_add_association 'add new room option', f, :lodging_days, { data: { association_insertion_node: "#lodging_days", association_insertion_method: "append" } }
+  = link_to_add_association 'add new room option', f, :lodging_days, { data: { association_insertion_node: "#lodging_days", association_insertion_method: "append" }, class: "button secondary" }
 
-  = f.button :submit
+  %hr
+    .row
+      .small-12.columns.text-center
+        = f.button :submit

--- a/app/views/convention_setup/lodging_room_options/_form.html.haml
+++ b/app/views/convention_setup/lodging_room_options/_form.html.haml
@@ -1,0 +1,16 @@
+= simple_form_for([:convention_setup, @lodging_room_option]) do |f|
+  = render partial: "/shared/error_messages", object: @lodging_room_option
+  = f.input :name
+  = f.input :price
+  %table
+    %thead
+      %tr
+        %th Date Offered
+        %th
+    %tbody#lodging_days
+      = f.simple_fields_for :lodging_days do |member_f|
+        = render "lodging_day_fields", f: member_f
+
+  = link_to_add_association 'add new room option', f, :lodging_days, { data: { association_insertion_node: "#lodging_days", association_insertion_method: "append" } }
+
+  = f.button :submit

--- a/app/views/convention_setup/lodging_room_options/_lodging_day_fields.html.haml
+++ b/app/views/convention_setup/lodging_room_options/_lodging_day_fields.html.haml
@@ -1,3 +1,3 @@
 %tr.nested-fields
-  %td= f.input :date_offered
+  %td= f.input :date_offered, as: :date_picker
   %td= link_to_remove_association t("delete"), f, { data: { confirm: t("are_you_sure") } }

--- a/app/views/convention_setup/lodging_room_options/_lodging_day_fields.html.haml
+++ b/app/views/convention_setup/lodging_room_options/_lodging_day_fields.html.haml
@@ -1,0 +1,3 @@
+%tr.nested-fields
+  %td= f.input :date_offered
+  %td= link_to_remove_association t("delete"), f, { data: { confirm: t("are_you_sure") } }

--- a/app/views/convention_setup/lodging_room_options/edit.html.haml
+++ b/app/views/convention_setup/lodging_room_options/edit.html.haml
@@ -1,0 +1,2 @@
+%h1 Edit - #{@lodging_room_option}
+= render 'form'

--- a/app/views/convention_setup/lodging_room_options/show.html.haml
+++ b/app/views/convention_setup/lodging_room_options/show.html.haml
@@ -9,7 +9,7 @@
   - @lodging_room_option.lodging_days.each do |lodging_day|
     %tr
       %td= lodging_day.date_offered
-      %td= link_to t("manage"), edit_convention_setup_lodging_room_option_path(@lodging_room_option)
+      %td= link_to "Manage", edit_convention_setup_lodging_room_option_path(@lodging_room_option)
 %br
 
-= link_to "New Lodging Day (via lodging_room_options#edit)", edit_convention_setup_lodging_room_option_path(@lodging_room_option)
+= link_to "New Lodging Day (via lodging_room_options#edit)", edit_convention_setup_lodging_room_option_path(@lodging_room_option), class: "button"

--- a/app/views/convention_setup/lodging_room_options/show.html.haml
+++ b/app/views/convention_setup/lodging_room_options/show.html.haml
@@ -1,0 +1,15 @@
+%h1 #{@lodging_room_option} - Days Available
+
+%p What options for the #{@lodging_room_option} Room
+
+%table
+  %tr
+    %th= LodgingDay.human_attribute_name(:date_offered)
+    %th
+  - @lodging_room_option.lodging_days.each do |lodging_day|
+    %tr
+      %td= lodging_day.date_offered
+      %td= link_to t("manage"), edit_convention_setup_lodging_room_option_path(@lodging_room_option)
+%br
+
+= link_to "New Lodging Day (via lodging_room_options#edit)", edit_convention_setup_lodging_room_option_path(@lodging_room_option)

--- a/app/views/convention_setup/lodging_room_types/_form.html.haml
+++ b/app/views/convention_setup/lodging_room_types/_form.html.haml
@@ -17,6 +17,9 @@
       = f.simple_fields_for :lodging_room_options do |member_f|
         = render "lodging_room_option_fields", f: member_f
 
-  = link_to_add_association 'add new room option', f, :lodging_room_options, { data: { association_insertion_node: "#lodging_room_options", association_insertion_method: "append" } }
+  = link_to_add_association 'add new room option', f, :lodging_room_options, { data: { association_insertion_node: "#lodging_room_options", association_insertion_method: "append" }, class: "button secondary" }
 
-  = f.button :submit
+  %hr
+    .row
+      .small-12.columns.text-center
+        = f.button :submit

--- a/app/views/convention_setup/lodging_room_types/_form.html.haml
+++ b/app/views/convention_setup/lodging_room_types/_form.html.haml
@@ -2,6 +2,11 @@
   = render partial: "/shared/error_messages", object: @lodging_room_type
   = f.input :name
   = f.input :description
+  = f.input :visible
+  = label_tag :limit_quantities_available
+  = check_box_tag :limit_quantities_available, nil, f.object.has_limits?, class: 'js--inputEnable', data: { targets: 'js--inputConditional' }
+  = f.input :maximum_available, input_html: { class: 'js--inputConditional' }
+
   %table
     %thead
       %tr

--- a/app/views/convention_setup/lodging_room_types/_form.html.haml
+++ b/app/views/convention_setup/lodging_room_types/_form.html.haml
@@ -1,0 +1,17 @@
+= simple_form_for([:convention_setup, @lodging_room_type]) do |f|
+  = render partial: "/shared/error_messages", object: @lodging_room_type
+  = f.input :name
+  = f.input :description
+  %table
+    %thead
+      %tr
+        %th Room Option Name
+        %th Room Option Price
+        %th
+    %tbody#lodging_room_options
+      = f.simple_fields_for :lodging_room_options do |member_f|
+        = render "lodging_room_option_fields", f: member_f
+
+  = link_to_add_association 'add new room option', f, :lodging_room_options, { data: { association_insertion_node: "#lodging_room_options", association_insertion_method: "append" } }
+
+  = f.button :submit

--- a/app/views/convention_setup/lodging_room_types/_lodging_room_option_fields.html.haml
+++ b/app/views/convention_setup/lodging_room_types/_lodging_room_option_fields.html.haml
@@ -1,0 +1,4 @@
+%tr.nested-fields
+  %td= f.input :name
+  %td= f.input :price
+  %td= link_to_remove_association t("delete"), f, { data: { confirm: t("are_you_sure") } }

--- a/app/views/convention_setup/lodging_room_types/edit.html.haml
+++ b/app/views/convention_setup/lodging_room_types/edit.html.haml
@@ -1,0 +1,2 @@
+%h1 Edit - #{@lodging_room_type}
+= render 'form'

--- a/app/views/convention_setup/lodging_room_types/edit.html.haml
+++ b/app/views/convention_setup/lodging_room_types/edit.html.haml
@@ -1,2 +1,3 @@
 %h1 Edit - #{@lodging_room_type}
-= render 'form'
+%fieldset.form__fieldset
+  = render 'form'

--- a/app/views/convention_setup/lodging_room_types/show.html.haml
+++ b/app/views/convention_setup/lodging_room_types/show.html.haml
@@ -17,4 +17,4 @@
       %td= link_to t("delete"), convention_setup_lodging_room_option_path(lodging_room_option), method: :delete, data: { confirm: t("are_you_sure") }
 %br
 
-= link_to "New Lodging Option Type (via lodging_room_type#edit)", edit_convention_setup_lodging_room_type_path(@lodging_room_type)
+= link_to "New Lodging Option Type (via lodging_room_type#edit)", edit_convention_setup_lodging_room_type_path(@lodging_room_type), class: "button"

--- a/app/views/convention_setup/lodging_room_types/show.html.haml
+++ b/app/views/convention_setup/lodging_room_types/show.html.haml
@@ -1,0 +1,20 @@
+%h1 #{@lodging_room_type} - Room Options
+
+%p What options for the #{@lodging_room_type} Room
+
+%table
+  %tr
+    %th= LodgingRoomOption.human_attribute_name(:name)
+    %th= LodgingRoomOption.human_attribute_name(:price)
+    %th
+    %th
+  - @lodging_room_type.lodging_room_options.each do |lodging_room_option|
+    %tr
+      %td= link_to lodging_room_option.name, convention_setup_lodging_room_option_path(lodging_room_option)
+      %td= lodging_room_option.name
+      %td= lodging_room_option.price
+      %td= link_to t("edit"), edit_convention_setup_lodging_room_option_path(lodging_room_option)
+      %td= link_to t("delete"), convention_setup_lodging_room_option_path(lodging_room_option), method: :delete, data: { confirm: t("are_you_sure") }
+%br
+
+= link_to "New Lodging Option Type (via lodging_room_type#edit)", edit_convention_setup_lodging_room_type_path(@lodging_room_type)

--- a/app/views/convention_setup/lodgings/_form.html.haml
+++ b/app/views/convention_setup/lodgings/_form.html.haml
@@ -12,6 +12,9 @@
       = f.simple_fields_for :lodging_room_types do |member_f|
         = render "lodging_room_type_fields", f: member_f
 
-  = link_to_add_association 'add new room type', f, :lodging_room_types, { data: { association_insertion_node: "#lodging_room_types", association_insertion_method: "append" } }
+  = link_to_add_association 'add new room type', f, :lodging_room_types, { data: { association_insertion_node: "#lodging_room_types", association_insertion_method: "append" }, class: "button secondary" }
 
-  = f.button :submit
+  %hr
+  .row
+    .small-12.columns.text-center
+      = f.button :submit

--- a/app/views/convention_setup/lodgings/_form.html.haml
+++ b/app/views/convention_setup/lodgings/_form.html.haml
@@ -1,0 +1,17 @@
+= simple_form_for([:convention_setup, @lodging]) do |f|
+  = render partial: "/shared/error_messages", object: @lodging
+  = f.input :name
+  = f.input :description
+  %table
+    %thead
+      %tr
+        %th Room Type Name
+        %th Room Type Description
+        %th
+    %tbody#lodging_room_types
+      = f.simple_fields_for :lodging_room_types do |member_f|
+        = render "lodging_room_type_fields", f: member_f
+
+  = link_to_add_association 'add new room type', f, :lodging_room_types, { data: { association_insertion_node: "#lodging_room_types", association_insertion_method: "append" } }
+
+  = f.button :submit

--- a/app/views/convention_setup/lodgings/_lodging_room_type_fields.html.haml
+++ b/app/views/convention_setup/lodgings/_lodging_room_type_fields.html.haml
@@ -1,0 +1,4 @@
+%tr.nested-fields
+  %td= f.input :name
+  %td= f.input :description
+  %td= link_to_remove_association t("delete"), f, { data: { confirm: t("are_you_sure") } }

--- a/app/views/convention_setup/lodgings/edit.html.haml
+++ b/app/views/convention_setup/lodgings/edit.html.haml
@@ -1,0 +1,4 @@
+%h1 Edit Lodging
+
+%fieldset.form__fieldset
+  = render 'form'

--- a/app/views/convention_setup/lodgings/index.html.haml
+++ b/app/views/convention_setup/lodgings/index.html.haml
@@ -20,4 +20,4 @@
       %td= link_to t("delete"), convention_setup_lodging_path(lodging), method: :delete, data: { confirm: t("are_you_sure") }
 %br
 
-= link_to "New Lodging", new_convention_setup_lodging_path
+= link_to "New Lodging", new_convention_setup_lodging_path, class: "button"

--- a/app/views/convention_setup/lodgings/index.html.haml
+++ b/app/views/convention_setup/lodgings/index.html.haml
@@ -1,0 +1,21 @@
+%h1 Lodgings
+
+%p Choose the entries to sell for lodging
+
+%table
+  %tr
+    %th= Lodging.human_attribute_name(:name)
+    %th= Lodging.human_attribute_name(:description)
+    %th
+    %th
+  - @lodgings.each do |lodging|
+    %tr
+      %td= link_to lodging.name, convention_setup_lodging_path(lodging)
+      %td= lodging.name
+      %td= lodging.description
+      %td= lodging.lodging_room_types.map(&:to_s).join(", ")
+      %td= link_to t("edit"), edit_convention_setup_lodging_path(lodging)
+      %td= link_to t("delete"), convention_setup_lodging_path(lodging), method: :delete, data: { confirm: t("are_you_sure") }
+%br
+
+= link_to "New Lodging", new_convention_setup_lodging_path

--- a/app/views/convention_setup/lodgings/index.html.haml
+++ b/app/views/convention_setup/lodgings/index.html.haml
@@ -1,6 +1,8 @@
 %h1 Lodgings
 
-%p Choose the entries to sell for lodging
+%p Using this system, you can sell a limited number of lodging rooms/options.
+
+%p This is different than the "Items for Sale" system because it allows a user to specify the days that they want to book the lodging, and creates a single LodgingPackage for them to pay for. It also manages the limited number of lodging rooms available at each Lodging location.
 
 %table
   %tr

--- a/app/views/convention_setup/lodgings/new.html.haml
+++ b/app/views/convention_setup/lodgings/new.html.haml
@@ -1,0 +1,3 @@
+%fieldset.form__fieldset
+  %h3 New Lodging
+  = render 'form'

--- a/app/views/convention_setup/lodgings/show.html.haml
+++ b/app/views/convention_setup/lodgings/show.html.haml
@@ -1,0 +1,21 @@
+%h1 #{@lodging} - Room Types
+
+%p What types of rooms are available at #{@lodging}
+
+%table
+  %tr
+    %th= LodgingRoomType.human_attribute_name(:name)
+    %th= LodgingRoomType.human_attribute_name(:description)
+    %th
+    %th
+  - @lodging.lodging_room_types.each do |lodging_room_type|
+    %tr
+      %td= link_to lodging_room_type.name, convention_setup_lodging_room_type_path(lodging_room_type)
+      %td= lodging_room_type.name
+      %td= lodging_room_type.description
+      %td= lodging_room_type.lodging_room_options.map(&:to_s).join(", ")
+      %td= link_to t("edit"), edit_convention_setup_lodging_room_type_path(lodging_room_type)
+      %td= link_to t("delete"), convention_setup_lodging_room_type_path(lodging_room_type), method: :delete, data: { confirm: t("are_you_sure") }
+%br
+
+= link_to "New Lodging Room Type (via lodging#edit)", edit_convention_setup_lodging_path(@lodging)

--- a/app/views/convention_setup/lodgings/show.html.haml
+++ b/app/views/convention_setup/lodgings/show.html.haml
@@ -18,4 +18,4 @@
       %td= link_to t("delete"), convention_setup_lodging_room_type_path(lodging_room_type), method: :delete, data: { confirm: t("are_you_sure") }
 %br
 
-= link_to "New Lodging Room Type (via lodging#edit)", edit_convention_setup_lodging_path(@lodging)
+= link_to "New Lodging Room Type (via lodging#edit)", edit_convention_setup_lodging_path(@lodging), class: "button"

--- a/app/views/layouts/convention_setup.html.haml
+++ b/app/views/layouts/convention_setup.html.haml
@@ -12,6 +12,7 @@
         %ul
           %li= link_to t('.registration_costs'), registration_costs_path
           %li= link_to t('.items_for_sale'), expense_groups_path
+          %li= link_to t('.lodging_for_sale'), convention_setup_lodgings_path
           %li= link_to CouponCode.model_name.human(count: 2), coupon_codes_path
           %li= link_to t('.payment_settings'), payment_settings_event_configuration_path
       %li= link_to t('.registration_questions'), registration_questions_event_configuration_path

--- a/app/views/payment_summary/lodgings/show.html.haml
+++ b/app/views/payment_summary/lodgings/show.html.haml
@@ -1,0 +1,42 @@
+%table.sortable
+  %legend Packages Selected/Sold
+  %thead
+    %tr
+      %th Lodging Room Type
+      %th Room Option
+      %th Registrant
+      %th Status
+      %th Date of last activity
+  %tbody
+    - @lodging.lodging_room_types.includes(lodging_packages: [:lodging_room_option, :lodging_package_days]).each do |lodging_room_type|
+      - lodging_room_type.lodging_packages.each do |package|
+        %tr
+          %td= LodgingPackagePresenter.new(package).to_s
+          %td= package.lodging_room_option
+          %td= link_to package.registrant, registrant_path(package.registrant.bib_number)
+          %td= package.status
+          %td= package.date_of_last_activity
+
+- @lodging.lodging_room_types.includes(lodging_packages: [:lodging_room_option, :lodging_package_days]).each do |lodging_room_type|
+  %table.sortable
+    %legend #{lodging_room_type} selections
+    %thead
+      %tr
+        %th Date
+        %th Room Option
+        %th Num Paid
+        %th Total Amount Paid
+        %th Num Pending
+        %th Num Unpaid
+    %tbody
+      - lodging_room_type.lodging_room_options.each do |option|
+        - option.lodging_days.each do |lodging_day|
+          %tr
+            %td= lodging_day
+            %td= option
+            %td= option.num_paid(lodging_day)
+            %td= print_formatted_currency(option.total_amount_paid(lodging_day))
+            %td= option.num_pending(lodging_day)
+            %td= option.num_unpaid(lodging_day)
+  %hr
+

--- a/app/views/payments/summary.html.haml
+++ b/app/views/payments/summary.html.haml
@@ -43,6 +43,13 @@
       - @expense_groups.each do |expense_group|
         %tr
           %td= link_to expense_group, payment_summary_expense_group_path(expense_group)
+    %thead
+      %tr
+        %th= Lodging.model_name.human
+    %tbody
+      - @lodgings.each do |lodging|
+        %tr
+          %td= link_to lodging, payment_summary_lodging_path(lodging)
 %hr
   %table
     - cache [Payment, Refund] do

--- a/app/views/registrants/build/_existing_lodging.html.haml
+++ b/app/views/registrants/build/_existing_lodging.html.haml
@@ -15,11 +15,10 @@
         %td Paid
 
     - @selected_lodging.each do |lodging_package|
-      - presenter = LodgingPackagePresenter.new(lodging_package)
       %tr
-        %td= presenter.location
-        %td= presenter.check_in_day
-        %td= presenter.check_out_day
+        %td= lodging_package.location
+        %td= lodging_package.check_in_day
+        %td= lodging_package.check_out_day
         %td
           = link_to "Delete", registrant_lodging_package_path(@registrant.bib_number, lodging_package), data: { confirm: t("are_you_sure"), method: :delete }
 

--- a/app/views/registrants/build/_existing_lodging.html.haml
+++ b/app/views/registrants/build/_existing_lodging.html.haml
@@ -14,11 +14,12 @@
         %td= lodging_form.last_day
         %td Paid
 
-    - @selected_lodging.each do |lodging_form|
+    - @selected_lodging.each do |lodging_package|
+      - presenter = LodgingPackagePresenter.new(lodging_package)
       %tr
-        %td= lodging_form.lodging_type
-        %td= lodging_form.first_day
-        %td= lodging_form.last_day
+        %td= lodging_package.lodging_room_type
+        %td= presenter.first_day
+        %td= presenter.last_day
         %td
-          = link_to "Delete", registrant_lodging_path(@registrant.bib_number, lodging_form.lodging_type), data: { confirm: t("are_you_sure"), method: :delete }
+          = link_to "Delete", registrant_lodging_package_path(@registrant.bib_number, lodging_package), data: { confirm: t("are_you_sure"), method: :delete }
 

--- a/app/views/registrants/build/_existing_lodging.html.haml
+++ b/app/views/registrants/build/_existing_lodging.html.haml
@@ -3,23 +3,23 @@
   %thead
     %tr
       %th Lodging Type
-      %th First day
-      %th Last day
+      %th Check-In
+      %th Check-Out
       %th
   %tbody
-    - @paid_lodging.each do |lodging_form|
+    - @paid_lodging.each do |lodging_package|
       %tr
-        %td= lodging_form.lodging_type
-        %td= lodging_form.first_day
-        %td= lodging_form.last_day
+        %td= lodging_package.location
+        %td= lodging_package.check_in_day
+        %td= lodging_package.check_out_day
         %td Paid
 
     - @selected_lodging.each do |lodging_package|
       - presenter = LodgingPackagePresenter.new(lodging_package)
       %tr
         %td= presenter.location
-        %td= presenter.first_day
-        %td= presenter.last_day
+        %td= presenter.check_in_day
+        %td= presenter.check_out_day
         %td
           = link_to "Delete", registrant_lodging_package_path(@registrant.bib_number, lodging_package), data: { confirm: t("are_you_sure"), method: :delete }
 

--- a/app/views/registrants/build/_existing_lodging.html.haml
+++ b/app/views/registrants/build/_existing_lodging.html.haml
@@ -1,0 +1,24 @@
+#{@registrant}'s chosen Lodging
+%table
+  %thead
+    %tr
+      %th Lodging Type
+      %th First day
+      %th Last day
+      %th
+  %tbody
+    - @paid_lodging.each do |lodging_form|
+      %tr
+        %td= lodging_form.lodging_type
+        %td= lodging_form.first_day
+        %td= lodging_form.last_day
+        %td Paid
+
+    - @selected_lodging.each do |lodging_form|
+      %tr
+        %td= lodging_form.lodging_type
+        %td= lodging_form.first_day
+        %td= lodging_form.last_day
+        %td
+          = link_to "Delete", registrant_lodging_path(@registrant.bib_number, lodging_form.lodging_type), data: { confirm: t("are_you_sure"), method: :delete }
+

--- a/app/views/registrants/build/_existing_lodging.html.haml
+++ b/app/views/registrants/build/_existing_lodging.html.haml
@@ -17,7 +17,7 @@
     - @selected_lodging.each do |lodging_package|
       - presenter = LodgingPackagePresenter.new(lodging_package)
       %tr
-        %td= lodging_package.lodging_room_type
+        %td= presenter.location
         %td= presenter.first_day
         %td= presenter.last_day
         %td

--- a/app/views/registrants/build/_new_lodging.html.haml
+++ b/app/views/registrants/build/_new_lodging.html.haml
@@ -1,12 +1,11 @@
 - if LodgingRoomType.any?
-  %fieldset.small-12.medium-6.large-4.columns
-    %legend Available Lodging
+  %h1 Available Lodging options
 
-
-    - Lodging.all.each do |lodging|
-      %h4= lodging
+  - Lodging.ordered.all.each do |lodging|
+    %fieldset.small-12.medium-6.large-4.columns
+      %legend= lodging
       %p= lodging.description
-      - lodging.lodging_room_types.each do |lodging_room_type|
+      - lodging.lodging_room_types.ordered.each do |lodging_room_type|
         %h5= lodging_room_type.name
         %p= lodging_room_type.description
         %table
@@ -16,7 +15,7 @@
               %th Days Available
               %th Price Per Day
           %tbody
-            - lodging_room_type.lodging_room_options.each do |lodging_room_option|
+            - lodging_room_type.lodging_room_options.ordered.each do |lodging_room_option|
               - pres = LodgingRoomOptionPresenter.new(lodging_room_option)
               %tr
                 %td= lodging_room_option.name
@@ -29,7 +28,7 @@
     = simple_form_for(LodgingForm.new, url: registrant_lodgings_path(@registrant)) do |f|
       .row
         .small-12.medium-4.columns
-          = f.input :lodging_room_option_id, collection: LodgingRoomOption.all
+          = f.input :lodging_room_option_id, collection: Lodging.ordered.all, as: :grouped_select, group_method: :lodging_room_options
         .small-12.medium-4.columns
           = f.input :first_day, input_html: { class: "datepicker" }
         .small-12.medium-4.columns

--- a/app/views/registrants/build/_new_lodging.html.haml
+++ b/app/views/registrants/build/_new_lodging.html.haml
@@ -30,8 +30,8 @@
         .small-12.medium-4.columns
           = f.input :lodging_room_option_id, collection: Lodging.ordered.all, as: :grouped_select, group_method: :lodging_room_options
         .small-12.medium-4.columns
-          = f.input :first_day, input_html: { class: "datepicker" }
+          = f.input :check_in_day, input_html: { class: "datepicker" }
         .small-12.medium-4.columns
-          = f.input :last_day, input_html: { class: "datepicker" }
+          = f.input :check_out_day, input_html: { class: "datepicker" }
       .row
         = f.submit "Add Lodging", class: "button"

--- a/app/views/registrants/build/_new_lodging.html.haml
+++ b/app/views/registrants/build/_new_lodging.html.haml
@@ -1,0 +1,38 @@
+- if LodgingRoomType.any?
+  %fieldset.small-12.medium-6.large-4.columns
+    %legend Available Lodging
+
+
+    - Lodging.all.each do |lodging|
+      %h4= lodging
+      %p= lodging.description
+      - lodging.lodging_room_types.each do |lodging_room_type|
+        %h5= lodging_room_type.name
+        %p= lodging_room_type.description
+        %table
+          %thead
+            %tr
+              %th Lodging Type
+              %th Days Available
+              %th Price Per Day
+          %tbody
+            - lodging_room_type.lodging_room_options.each do |lodging_room_option|
+              - pres = LodgingRoomOptionPresenter.new(lodging_room_option)
+              %tr
+                %td= lodging_room_option.name
+                %td= pres.days_available
+                %td= lodging_room_option.price
+
+  %hr
+  %fieldset.small-12.medium-6.large-4.columns
+    %legend Add Lodging
+    = simple_form_for(LodgingForm.new, url: registrant_lodgings_path(@registrant)) do |f|
+      .row
+        .small-12.medium-4.columns
+          = f.input :lodging_room_option_id, collection: LodgingRoomOption.all
+        .small-12.medium-4.columns
+          = f.input :first_day, input_html: { class: "datepicker" }
+        .small-12.medium-4.columns
+          = f.input :last_day, input_html: { class: "datepicker" }
+      .row
+        = f.submit "Add Lodging", class: "button"

--- a/app/views/registrants/build/_new_lodging.html.haml
+++ b/app/views/registrants/build/_new_lodging.html.haml
@@ -1,29 +1,35 @@
 - if LodgingRoomType.any?
   %h1 Available Lodging options
+  %hr
 
   - Lodging.ordered.all.each do |lodging|
-    %fieldset.small-12.medium-6.large-4.columns
-      %legend= lodging
-      %p= lodging.description
-      - lodging.lodging_room_types.ordered.each do |lodging_room_type|
-        %h5= lodging_room_type.name
-        %p= lodging_room_type.description
+    .row
+      .small-12.text-center
+        %h2= lodging
+        %p= lodging.description
+
+        %h3 Room Types:
         %table
           %thead
             %tr
-              %th Lodging Type
-              %th Days Available
+              %th Room Option
+              %th Description
               %th Price Per Day
           %tbody
-            - lodging_room_type.lodging_room_options.ordered.each do |lodging_room_option|
-              - pres = LodgingRoomOptionPresenter.new(lodging_room_option)
-              %tr
-                %td= lodging_room_option.name
-                %td= pres.days_available
-                %td= lodging_room_option.price
+            - lodging.lodging_room_types.ordered.each do |lodging_room_type|
+              - lodging_room_type.lodging_room_options.ordered.each do |lodging_room_option|
+                - pres = LodgingRoomOptionPresenter.new(lodging_room_option)
+                %tr
+                  %td
+                    = lodging_room_option.to_label
+                  %td
+                    = lodging_room_type.description
+                    %br
+                    Available: #{pres.days_available}
+                  %td= print_formatted_currency(lodging_room_option.price)
+    %hr
 
-  %hr
-  %fieldset.small-12.medium-6.large-4.columns
+  %fieldset.small-12.large-6.columns
     %legend Add Lodging
     = simple_form_for(LodgingForm.new, url: registrant_lodgings_path(@registrant)) do |f|
       .row

--- a/app/views/registrants/build/lodging.html.haml
+++ b/app/views/registrants/build/lodging.html.haml
@@ -1,0 +1,7 @@
+= render partial: "/shared/error_messages", object: @registrant
+
+= render partial: "new_lodging"
+= render partial: "existing_lodging", locals: { registrant: @registrant }
+
+= form_for(@registrant, url: wizard_path, method: :put) do |f|
+  = render partial: "/registrants/form_actions", locals: {f: f}

--- a/config/locales/base.en.yml
+++ b/config/locales/base.en.yml
@@ -11,6 +11,7 @@ en:
   date:
     formats:
       registration_date_format: "%b %d, %Y"
+      lodging_date_format: "%b %d, %Y"
     order:
     - :month
     - :day
@@ -36,6 +37,7 @@ en:
     add_events: Events
     add_name: Name
     add_volunteers: Volunteers
+    lodging: Lodging
     expenses: Expenses
     music: Music
     set_wheel_sizes: Wheel Sizes

--- a/config/locales/views/layouts/convention_setup.en.yml
+++ b/config/locales/views/layouts/convention_setup.en.yml
@@ -14,6 +14,7 @@ en:
       date_deadlines: Important Dates
       organization_membership: Organization Membership
       items_for_sale: Items for Sale
+      lodging_for_sale: Lodging for Sale
       payment_settings: Payment Settings
       volunteer_settings: Volunteer Settings
       manage_translations: Translate Convention Settings

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -429,7 +429,8 @@ Rails.application.routes.draw do
         post :copy_to_noncompetitor
       end
       resources :registrant_expense_items, only: %i[create destroy]
-      resources :lodgings, only: %i[create destroy]
+      resources :lodgings, only: %i[create]
+      resources :lodging_packages, only: %(destroy)
       resources :standard_skill_routines, only: [:create]
       member do
         get :payments, to: "payments#registrant_payments"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,6 +150,7 @@ Rails.application.routes.draw do
           get :details
         end
       end
+      resources :lodgings, only: %i[show]
     end
 
     resources :payments, except: %i[index edit update destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -302,6 +302,15 @@ Rails.application.routes.draw do
           post :update_row_order, on: :collection
         end
       end
+
+      resources :lodgings do
+        resources :lodging_room_types, shallow: true, except: %i[index new create destroy] do
+          resources :lodging_room_options, shallow: true, except: %i[index new create destroy] do
+            resources :lodging_days, shallow: true, except: %i[index new create destroy]
+          end
+        end
+      end
+
       resources :event_choices, except: %i[index create new show]
       resources :event_categories, except: %i[index create new show]
 
@@ -420,6 +429,7 @@ Rails.application.routes.draw do
         post :copy_to_noncompetitor
       end
       resources :registrant_expense_items, only: %i[create destroy]
+      resources :lodgings, only: %i[create destroy]
       resources :standard_skill_routines, only: [:create]
       member do
         get :payments, to: "payments#registrant_payments"

--- a/db/migrate/20171216234324_add_lodging_models.rb
+++ b/db/migrate/20171216234324_add_lodging_models.rb
@@ -1,0 +1,34 @@
+class AddLodgingModels < ActiveRecord::Migration[5.1]
+  def change
+    create_table :lodgings do |t|
+      t.integer :position
+      t.string :name, null: false
+      t.text :description
+      t.timestamps
+    end
+
+    create_table :lodging_room_types do |t|
+      t.integer :lodging_id, null: false, index: true
+      t.integer :position
+      t.string :name, null: false
+      t.text :description
+      t.boolean :visible, null: false, default: true
+      t.integer :maximum_available
+      t.timestamps
+    end
+
+    create_table :lodging_room_options do |t|
+      t.integer :lodging_room_type_id, null: false, index: true
+      t.integer :position
+      t.string :name, null: false
+      t.integer :price_cents, null: false, default: 0
+      t.timestamps
+    end
+
+    create_table :lodging_days do |t|
+      t.integer :lodging_room_option_id, null: false, index: true
+      t.date :date_offered, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171220184931_add_lodging_package.rb
+++ b/db/migrate/20171220184931_add_lodging_package.rb
@@ -1,0 +1,18 @@
+class AddLodgingPackage < ActiveRecord::Migration[5.1]
+  def change
+    create_table :lodging_packages do |t|
+      t.integer :lodging_room_type_id, null: false, index: true
+      t.integer :lodging_room_option_id, null: false, index: true
+      t.integer :total_cost_cents, null: false
+      t.timestamps
+    end
+
+    create_table :lodging_package_days do |t|
+      t.integer :lodging_package_id, null: false, index: true
+      t.integer :lodging_day_id, null: false, index: true
+      t.timestamps
+    end
+
+    add_index :lodging_package_days, %i[lodging_package_id lodging_day_id], unique: true, name: "lodging_package_unique"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -607,6 +607,64 @@ ActiveRecord::Schema.define(version: 20171221025728) do
     t.index ["competition_id"], name: "index_lane_assignments_on_competition_id"
   end
 
+  create_table "lodging_days", force: :cascade do |t|
+    t.integer "lodging_room_option_id", null: false
+    t.date "date_offered", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["lodging_room_option_id"], name: "index_lodging_days_on_lodging_room_option_id"
+  end
+
+  create_table "lodging_package_days", force: :cascade do |t|
+    t.integer "lodging_package_id", null: false
+    t.integer "lodging_day_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["lodging_day_id"], name: "index_lodging_package_days_on_lodging_day_id"
+    t.index ["lodging_package_id", "lodging_day_id"], name: "lodging_package_unique", unique: true
+    t.index ["lodging_package_id"], name: "index_lodging_package_days_on_lodging_package_id"
+  end
+
+  create_table "lodging_packages", force: :cascade do |t|
+    t.integer "lodging_room_type_id", null: false
+    t.integer "lodging_room_option_id", null: false
+    t.integer "total_cost_cents", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["lodging_room_option_id"], name: "index_lodging_packages_on_lodging_room_option_id"
+    t.index ["lodging_room_type_id"], name: "index_lodging_packages_on_lodging_room_type_id"
+  end
+
+  create_table "lodging_room_options", force: :cascade do |t|
+    t.integer "lodging_room_type_id", null: false
+    t.integer "position"
+    t.string "name", null: false
+    t.integer "price_cents", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["lodging_room_type_id"], name: "index_lodging_room_options_on_lodging_room_type_id"
+  end
+
+  create_table "lodging_room_types", force: :cascade do |t|
+    t.integer "lodging_id", null: false
+    t.integer "position"
+    t.string "name", null: false
+    t.text "description"
+    t.boolean "visible", default: true, null: false
+    t.integer "maximum_available"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["lodging_id"], name: "index_lodging_room_types_on_lodging_id"
+  end
+
+  create_table "lodgings", force: :cascade do |t|
+    t.integer "position"
+    t.string "name", null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "mass_emails", id: :serial, force: :cascade do |t|
     t.integer "sent_by_id", null: false
     t.datetime "sent_at"

--- a/spec/controllers/convention_setup/lodging_room_options_controller_spec.rb
+++ b/spec/controllers/convention_setup/lodging_room_options_controller_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe ConventionSetup::LodgingRoomOptionsController do
+  before do
+    user = FactoryGirl.create(:convention_admin_user)
+    sign_in user
+  end
+
+  # describe "GET new" do
+  #   it "renders" do
+  #     lodging = FactoryGirl.create(:lodging_room_type)
+  #     get :new, params: { lodging_room_type_id: lodging_room_type.id }
+  #     expect(response).to be_success
+  #   end
+  # end
+
+  describe "GET edit" do
+    it "shows the form" do
+      lodging_room_option = FactoryGirl.create(:lodging_room_option)
+      get :edit, params: { id: lodging_room_option.id }
+      expect(response).to be_success
+
+      assert_select "form", action: edit_convention_setup_lodging_room_option_path(lodging_room_option), method: "put" do
+        assert_select "input#lodging_room_option_name", name: "lodging_room_option[name]"
+      end
+    end
+  end
+
+  describe "GET show" do
+    let(:lodging_room_option) { FactoryGirl.create(:lodging_room_option) }
+    let!(:lodging_day) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option) }
+
+    it "shows the lodging_room_option" do
+      get :show, params: { id: lodging_room_option.id }
+      expect(response).to be_success
+    end
+  end
+
+  # describe "POST create" do
+  #   describe "with valid params" do
+  #     let(:lodging_room_type) { FactoryGirl.create(:lodging_room_type) }
+  #     let(:valid_attributes) { FactoryGirl.attributes_for(:lodging_room_option) }
+
+  #     it "creates a new Lodging" do
+  #       expect do
+  #         post :create, params: { lodging_room_type_id: lodging_room_type.id, lodging_room_option: valid_attributes }
+  #       end.to change(LodgingRoomOption, :count).by(1)
+  #     end
+  #   end
+  # end
+
+  describe "PUT update" do
+    let!(:lodging_room_option) { FactoryGirl.create(:lodging_room_option) }
+    let(:new_valid_attributes) { FactoryGirl.attributes_for(:lodging_room_option) }
+
+    it "updates the coupon code" do
+      put :update, params: { id: lodging_room_option.to_param, lodging_room_option: new_valid_attributes }
+      expect(lodging_room_option.reload.name).to eq(new_valid_attributes[:name])
+    end
+  end
+
+  # describe "DELETE destroy" do
+  #   let!(:lodging_room_option) { FactoryGirl.create(:lodging_room_option) }
+
+  #   it "deletes the object" do
+  #     expect do
+  #       delete :destroy, params: { id: lodging_room_option.to_param }
+  #     end.to change(LodgingRoomOption, :count).by(-1)
+  #   end
+  # end
+end

--- a/spec/controllers/convention_setup/lodging_room_types_controller_spec.rb
+++ b/spec/controllers/convention_setup/lodging_room_types_controller_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe ConventionSetup::LodgingRoomTypesController do
+  before do
+    user = FactoryGirl.create(:convention_admin_user)
+    sign_in user
+  end
+
+  # describe "GET new" do
+  #   it "renders" do
+  #     lodging = FactoryGirl.create(:lodging)
+  #     get :new, params: { lodging_id: lodging.id }
+  #     expect(response).to be_success
+  #   end
+  # end
+
+  describe "GET edit" do
+    it "shows the lodging form" do
+      lodging_room_type = FactoryGirl.create(:lodging_room_type)
+      get :edit, params: { id: lodging_room_type.id }
+      expect(response).to be_success
+
+      assert_select "form", action: edit_convention_setup_lodging_room_type_path(lodging_room_type), method: "put" do
+        assert_select "input#lodging_room_type_name", name: "lodging_room_type[name]"
+      end
+    end
+  end
+
+  describe "GET show" do
+    let(:lodging_room_type) { FactoryGirl.create(:lodging_room_type) }
+    let!(:lodging_room_option) { FactoryGirl.create(:lodging_room_option, lodging_room_type: lodging_room_type) }
+
+    it "shows the lodging_room_type" do
+      get :show, params: { id: lodging_room_type.id }
+      expect(response).to be_success
+    end
+  end
+
+  # describe "POST create" do
+  #   describe "with valid params" do
+  #     let(:lodging) { FactoryGirl.create(:lodging) }
+  #     let(:valid_attributes) { FactoryGirl.attributes_for(:lodging_room_type) }
+
+  #     it "creates a new Lodging" do
+  #       expect do
+  #         post :create, params: { lodging_id: lodging.id, lodging_room_type: valid_attributes }
+  #       end.to change(LodgingRoomType, :count).by(1)
+  #     end
+  #   end
+  # end
+
+  describe "PUT update" do
+    let!(:lodging_room_type) { FactoryGirl.create(:lodging_room_type) }
+    let(:new_valid_attributes) { FactoryGirl.attributes_for(:lodging_room_type) }
+
+    it "updates the coupon code" do
+      put :update, params: { id: lodging_room_type.to_param, lodging_room_type: new_valid_attributes }
+      expect(lodging_room_type.reload.name).to eq(new_valid_attributes[:name])
+    end
+  end
+
+  # describe "DELETE destroy" do
+  #   let!(:lodging_room_type) { FactoryGirl.create(:lodging_room_type) }
+
+  #   it "deletes the object" do
+  #     expect do
+  #       delete :destroy, params: { id: lodging_room_type.to_param }
+  #     end.to change(LodgingRoomType, :count).by(-1)
+  #   end
+  # end
+end

--- a/spec/controllers/convention_setup/lodgings_controller_spec.rb
+++ b/spec/controllers/convention_setup/lodgings_controller_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+describe ConventionSetup::LodgingsController do
+  before do
+    user = FactoryGirl.create(:convention_admin_user)
+    sign_in user
+  end
+
+  describe "as a normal user" do
+    before do
+      @user = FactoryGirl.create(:user)
+      sign_in @user
+    end
+
+    it "Cannot read summary" do
+      get :index
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "GET index" do
+    it "shows all lodgings" do
+      lodging = FactoryGirl.create(:lodging)
+      get :index
+      expect(response).to be_success
+
+      assert_select "td", lodging.name
+    end
+  end
+
+  describe "GET new" do
+    it "renders" do
+      get :new
+      expect(response).to be_success
+    end
+  end
+
+  describe "GET edit" do
+    it "shows the lodging form" do
+      lodging = FactoryGirl.create(:lodging)
+      get :edit, params: { id: lodging.id }
+      expect(response).to be_success
+
+      assert_select "form", action: edit_convention_setup_lodging_path(lodging), method: "put" do
+        assert_select "input#lodging_name", name: "lodging[name]"
+      end
+    end
+  end
+
+  describe "POST create" do
+    describe "with valid params" do
+      let(:valid_attributes) { FactoryGirl.attributes_for(:lodging) }
+
+      it "creates a new Lodging" do
+        expect do
+          post :create, params: { lodging: valid_attributes }
+        end.to change(Lodging, :count).by(1)
+      end
+    end
+  end
+
+  describe "GET show" do
+    let(:lodging) { FactoryGirl.create(:lodging) }
+    let!(:lodging_room_type) { FactoryGirl.create(:lodging_room_type, lodging: lodging) }
+
+    it "shows the lodging" do
+      get :show, params: { id: lodging.id }
+      expect(response).to be_success
+    end
+  end
+
+  describe "PUT update" do
+    let!(:lodging) { FactoryGirl.create(:lodging) }
+    let(:new_valid_attributes) { FactoryGirl.attributes_for(:lodging) }
+
+    it "updates the coupon code" do
+      put :update, params: { id: lodging.to_param, lodging: new_valid_attributes }
+      expect(lodging.reload.name).to eq(new_valid_attributes[:name])
+    end
+  end
+
+  describe "DELETE destroy" do
+    let!(:lodging) { FactoryGirl.create(:lodging) }
+
+    it "deletes the object" do
+      expect do
+        delete :destroy, params: { id: lodging.to_param }
+      end.to change(Lodging, :count).by(-1)
+    end
+  end
+end

--- a/spec/controllers/lodging_packages_controller_spec.rb
+++ b/spec/controllers/lodging_packages_controller_spec.rb
@@ -1,13 +1,18 @@
 # == Schema Information
 #
-# Table name: lodgings
+# Table name: lodging_packages
 #
-#  id          :integer          not null, primary key
-#  position    :integer
-#  name        :string           not null
-#  description :text
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
+#  id                     :integer          not null, primary key
+#  lodging_room_type_id   :integer          not null
+#  lodging_room_option_id :integer          not null
+#  total_cost_cents       :integer          not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_lodging_packages_on_lodging_room_option_id  (lodging_room_option_id)
+#  index_lodging_packages_on_lodging_room_type_id    (lodging_room_type_id)
 #
 
 require 'spec_helper'
@@ -30,6 +35,12 @@ describe LodgingPackagesController do
         expect do
           delete :destroy, params: { registrant_id: competitor.bib_number, id: lodging_package.id}
         end.to change(RegistrantExpenseItem, :count).by(-1)
+      end
+
+      it "removes the lodging_package too" do
+        expect do
+          delete :destroy, params: { registrant_id: competitor.bib_number, id: lodging_package.id}
+        end.to change(LodgingPackage, :count).by(-1)
       end
     end
   end

--- a/spec/controllers/lodging_packages_controller_spec.rb
+++ b/spec/controllers/lodging_packages_controller_spec.rb
@@ -1,0 +1,36 @@
+# == Schema Information
+#
+# Table name: lodgings
+#
+#  id          :integer          not null, primary key
+#  position    :integer
+#  name        :string           not null
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+require 'spec_helper'
+
+describe LodgingPackagesController do
+  before(:each) do
+    @user = FactoryGirl.create(:super_admin_user)
+    sign_in @user
+  end
+  let(:competitor) { FactoryGirl.create(:competitor) }
+  let!(:lodging_day) { FactoryGirl.create(:lodging_day) }
+
+  describe "DELETE #destroy" do
+    let(:lodging_package) { FactoryGirl.create(:lodging_package) }
+
+    context "with a lodging expense item" do
+      let!(:registrant_expense_item) { FactoryGirl.create(:registrant_expense_item, line_item: lodging_package, registrant: competitor) }
+
+      it "removes the registrant expense item" do
+        expect do
+          delete :destroy, params: { registrant_id: competitor.bib_number, id: lodging_package.id}
+        end.to change(RegistrantExpenseItem, :count).by(-1)
+      end
+    end
+  end
+end

--- a/spec/controllers/lodgings_controller_spec.rb
+++ b/spec/controllers/lodgings_controller_spec.rb
@@ -24,8 +24,8 @@ describe LodgingsController do
     let(:params) do
       {
         lodging_room_option_id: lodging_day.lodging_room_option_id,
-        first_day: lodging_day.date_offered.strftime("%Y/%m/%d"),
-        last_day: lodging_day.date_offered.strftime("%Y/%m/%d")
+        check_in_day: lodging_day.date_offered.strftime("%Y/%m/%d"),
+        check_out_day: (lodging_day.date_offered + 1.day).strftime("%Y/%m/%d")
       }
     end
 

--- a/spec/controllers/lodgings_controller_spec.rb
+++ b/spec/controllers/lodgings_controller_spec.rb
@@ -1,0 +1,50 @@
+# == Schema Information
+#
+# Table name: lodgings
+#
+#  id          :integer          not null, primary key
+#  position    :integer
+#  name        :string           not null
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+require 'spec_helper'
+
+describe LodgingsController do
+  before(:each) do
+    @user = FactoryGirl.create(:super_admin_user)
+    sign_in @user
+  end
+  let(:competitor) { FactoryGirl.create(:competitor) }
+  let!(:lodging_day) { FactoryGirl.create(:lodging_day) }
+
+  describe "POST #create" do
+    let(:params) do
+      {
+        lodging_room_type_id: lodging_day.lodging_room_option.lodging_room_type_id,
+        first_day: lodging_day.date_offered.strftime("%Y/%m/%d"),
+        last_day: lodging_day.date_offered.strftime("%Y/%m/%d")
+      }
+    end
+
+    it "creates a new registrant expense item" do
+      expect do
+        post :create, params: { registrant_id: comptitor.bib_number, lodging_form: params }
+      end.to change(RegistrantExpenseItem, :count).by(1)
+    end
+  end
+
+  describe "DELETE #destroy" do
+    context "with a lodging expense item" do
+      let!(:registrant_expense_item) { FactoryGirl.create(:registrant_expense_item, expense_item: lodging_day.expense_item, registrant: competitor) }
+
+      it "removes the registrant expense item" do
+        expect do
+          delete :destroy, params: { registrant_id: competitor.bib_number, id: lodging_day.lodging_type.id}
+        end.to change(RegistrantExpenseItem, :count).by(-1)
+      end
+    end
+  end
+end

--- a/spec/controllers/lodgings_controller_spec.rb
+++ b/spec/controllers/lodgings_controller_spec.rb
@@ -23,7 +23,7 @@ describe LodgingsController do
   describe "POST #create" do
     let(:params) do
       {
-        lodging_room_type_id: lodging_day.lodging_room_option.lodging_room_type_id,
+        lodging_room_option_id: lodging_day.lodging_room_option_id,
         first_day: lodging_day.date_offered.strftime("%Y/%m/%d"),
         last_day: lodging_day.date_offered.strftime("%Y/%m/%d")
       }
@@ -31,20 +31,8 @@ describe LodgingsController do
 
     it "creates a new registrant expense item" do
       expect do
-        post :create, params: { registrant_id: comptitor.bib_number, lodging_form: params }
+        post :create, params: { registrant_id: competitor.bib_number, lodging_form: params }
       end.to change(RegistrantExpenseItem, :count).by(1)
-    end
-  end
-
-  describe "DELETE #destroy" do
-    context "with a lodging expense item" do
-      let!(:registrant_expense_item) { FactoryGirl.create(:registrant_expense_item, expense_item: lodging_day.expense_item, registrant: competitor) }
-
-      it "removes the registrant expense item" do
-        expect do
-          delete :destroy, params: { registrant_id: competitor.bib_number, id: lodging_day.lodging_type.id}
-        end.to change(RegistrantExpenseItem, :count).by(-1)
-      end
     end
   end
 end

--- a/spec/controllers/registrants/build_controller_spec.rb
+++ b/spec/controllers/registrants/build_controller_spec.rb
@@ -52,6 +52,18 @@ describe Registrants::BuildController do
       end
     end
 
+    context "viewing the lodging page" do
+      let(:registrant) { FactoryGirl.create(:competitor, status: "contact_details", user: user) }
+      let(:lodging_day) { FactoryGirl.create(:lodging_day) }
+
+      it "displays the add-lodging form" do
+        get :show, params: { registrant_id: registrant.to_param, id: "lodging" }
+        assert_select "fieldset" do
+          assert_select "legend", text: "Add Lodging"
+        end
+      end
+    end
+
     context "viewing the expenses page" do
       let(:registrant) { FactoryGirl.create(:competitor, status: "contact_details", user: user) }
       let!(:group) { FactoryGirl.create(:expense_group) }

--- a/spec/controllers/registrants/build_controller_spec.rb
+++ b/spec/controllers/registrants/build_controller_spec.rb
@@ -53,6 +53,7 @@ describe Registrants::BuildController do
     end
 
     context "viewing the lodging page" do
+      let(:user) { FactoryGirl.create(:super_admin_user) }
       let(:registrant) { FactoryGirl.create(:competitor, status: "contact_details", user: user) }
       let!(:lodging_day) { FactoryGirl.create(:lodging_day) }
 

--- a/spec/controllers/registrants/build_controller_spec.rb
+++ b/spec/controllers/registrants/build_controller_spec.rb
@@ -54,7 +54,7 @@ describe Registrants::BuildController do
 
     context "viewing the lodging page" do
       let(:registrant) { FactoryGirl.create(:competitor, status: "contact_details", user: user) }
-      let(:lodging_day) { FactoryGirl.create(:lodging_day) }
+      let!(:lodging_day) { FactoryGirl.create(:lodging_day) }
 
       it "displays the add-lodging form" do
         get :show, params: { registrant_id: registrant.to_param, id: "lodging" }

--- a/spec/factories/lodging_days.rb
+++ b/spec/factories/lodging_days.rb
@@ -1,0 +1,21 @@
+FactoryGirl.define do
+  factory :lodging_day do
+    lodging_room_option # FactoryBot
+    sequence(:date_offered) { |n| (10 + n).days.from_now }
+  end
+end
+
+# == Schema Information
+#
+# Table name: lodging_days
+#
+#  id                     :integer          not null, primary key
+#  lodging_room_option_id :integer          not null
+#  date_offered           :date             not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_lodging_days_on_lodging_room_option_id  (lodging_room_option_id)
+#

--- a/spec/factories/lodging_package_days.rb
+++ b/spec/factories/lodging_package_days.rb
@@ -1,0 +1,23 @@
+FactoryGirl.define do
+  factory :lodging_package_day do
+    lodging_package
+    lodging_day
+  end
+end
+
+# == Schema Information
+#
+# Table name: lodging_package_days
+#
+#  id                 :integer          not null, primary key
+#  lodging_package_id :integer          not null
+#  lodging_day_id     :integer          not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
+# Indexes
+#
+#  index_lodging_package_days_on_lodging_day_id      (lodging_day_id)
+#  index_lodging_package_days_on_lodging_package_id  (lodging_package_id)
+#  lodging_package_unique                            (lodging_package_id,lodging_day_id) UNIQUE
+#

--- a/spec/factories/lodging_packages.rb
+++ b/spec/factories/lodging_packages.rb
@@ -1,0 +1,24 @@
+FactoryGirl.define do
+  factory :lodging_package do
+    lodging_room_type
+    lodging_room_option
+    total_cost 120.30
+  end
+end
+
+# == Schema Information
+#
+# Table name: lodging_packages
+#
+#  id                     :integer          not null, primary key
+#  lodging_room_type_id   :integer          not null
+#  lodging_room_option_id :integer          not null
+#  total_cost_cents       :integer          not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_lodging_packages_on_lodging_room_option_id  (lodging_room_option_id)
+#  index_lodging_packages_on_lodging_room_type_id    (lodging_room_type_id)
+#

--- a/spec/factories/lodging_room_options.rb
+++ b/spec/factories/lodging_room_options.rb
@@ -1,0 +1,25 @@
+FactoryGirl.define do
+  factory :lodging_room_option do
+    lodging_room_type # FactoryGirl
+    sequence(:name) { |n| "Small Room #{n}" }
+    sequence(:price) { |n| 1000 + n }
+    sequence(:position) { |n| n }
+  end
+end
+
+# == Schema Information
+#
+# Table name: lodging_room_options
+#
+#  id                   :integer          not null, primary key
+#  lodging_room_type_id :integer          not null
+#  position             :integer
+#  name                 :string           not null
+#  price_cents          :integer          default(0), not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
+# Indexes
+#
+#  index_lodging_room_options_on_lodging_room_type_id  (lodging_room_type_id)
+#

--- a/spec/factories/lodging_room_types.rb
+++ b/spec/factories/lodging_room_types.rb
@@ -1,0 +1,27 @@
+FactoryGirl.define do
+  factory :lodging_room_type do
+    lodging # FactoryGirl
+    sequence(:name) { |n| "Small Room #{n}" }
+    sequence(:description) { |n| "lodging type description #{n}" }
+    sequence(:position) { |n| n }
+  end
+end
+
+# == Schema Information
+#
+# Table name: lodging_room_types
+#
+#  id                :integer          not null, primary key
+#  lodging_id        :integer          not null
+#  position          :integer
+#  name              :string           not null
+#  description       :text
+#  visible           :boolean          default(TRUE), not null
+#  maximum_available :integer
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+# Indexes
+#
+#  index_lodging_room_types_on_lodging_id  (lodging_id)
+#

--- a/spec/factories/lodgings.rb
+++ b/spec/factories/lodgings.rb
@@ -1,0 +1,19 @@
+FactoryGirl.define do
+  factory :lodging do
+    sequence(:name) { |n| "the Lodging #{n}" }
+    sequence(:description) { |n| "lodging description #{n}" }
+    sequence(:position) { |n| n }
+  end
+end
+
+# == Schema Information
+#
+# Table name: lodgings
+#
+#  id          :integer          not null, primary key
+#  name        :string           not null
+#  position    :integer
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#

--- a/spec/forms/lodging_form_spec.rb
+++ b/spec/forms/lodging_form_spec.rb
@@ -24,7 +24,7 @@ describe LodgingForm do
         it "creates registrant_expense_items" do
           expect do
             form.save
-          end.to change(RegistrantExpenseItem, :count).by(3)
+          end.to change(RegistrantExpenseItem, :count).by(1)
         end
       end
 
@@ -176,27 +176,28 @@ describe LodgingForm do
     #   end
     # end
 
-    # describe "#selected_for" do
-    #   context "with no selected elements" do
-    #     it "returns a blank array" do
-    #       expect(described_class.selected_for(competitor)).to eq([])
-    #     end
-    #   end
+    describe "#selected_for" do
+      context "with no selected elements" do
+        it "returns a blank array" do
+          expect(described_class.selected_for(competitor)).to eq([])
+        end
+      end
 
-    #   context "with a single selected element" do
-    #     let!(:lodging_day1) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 12, 28)) }
-    #     let(:expense_item) { lodging_day1.expense_item }
-    #     let!(:registrant_expense_item) { FactoryGirl.create(:registrant_expense_item, registrant: competitor, expense_item: expense_item)}
+      context "with a single selected element" do
+        let!(:lodging_day) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 12, 28)) }
+        let(:package) { FactoryGirl.create(:lodging_package, lodging_room_option: lodging_room_option, lodging_room_type: lodging_room_option.lodging_room_type) }
+        let!(:package_day) { FactoryGirl.create(:lodging_package_day, lodging_package: package, lodging_day: lodging_day) }
+        let!(:registrant_expense_item) { FactoryGirl.create(:registrant_expense_item, registrant: competitor, line_item: package)}
 
-    #     it "returns a single element array" do
-    #       competitor.reload
-    #       forms = described_class.selected_for(competitor)
+        it "returns a single element array" do
+          competitor.reload
+          packages = described_class.selected_for(competitor)
 
-    #       expect(forms.count).to eq(1)
-    #       expect(forms.first.lodging_room_type_id).to eq(lodging_room_type.id)
-    #       expect(forms.first.first_day).to eq("2017/12/28")
-    #       expect(forms.first.last_day).to eq("2017/12/28")
-    #     end
-    #   end
+          expect(packages.count).to eq(1)
+          expect(packages.first.lodging_room_type_id).to eq(lodging_room_type.id)
+          expect(packages.first).to eq(package)
+        end
+      end
+    end
   end
 end

--- a/spec/forms/lodging_form_spec.rb
+++ b/spec/forms/lodging_form_spec.rb
@@ -17,8 +17,8 @@ describe LodgingForm do
           {
             registrant_id: competitor.id,
             lodging_room_option_id: lodging_room_option.id,
-            first_day: lodging_day1.date_offered.strftime("%Y/%m/%d"),
-            last_day: lodging_day3.date_offered.strftime("%Y/%m/%d")
+            check_in_day: lodging_day1.date_offered.strftime("%Y/%m/%d"),
+            check_out_day: (lodging_day3.date_offered + 1.day).strftime("%Y/%m/%d")
           }
         end
         it "creates registrant_expense_items" do
@@ -33,8 +33,8 @@ describe LodgingForm do
           {
             registrant_id: competitor.id,
             lodging_room_option_id: lodging_room_option.id,
-            first_day: lodging_day1.date_offered.strftime("%Y/%m/%d"),
-            last_day: lodging_day1.date_offered.strftime("%Y/%m/%d")
+            check_in_day: lodging_day1.date_offered.strftime("%Y/%m/%d"),
+            check_out_day: (lodging_day1.date_offered + 1.day).strftime("%Y/%m/%d")
           }
         end
         it "creates only a single registrant_expense_item" do
@@ -50,8 +50,8 @@ describe LodgingForm do
           {
             registrant_id: competitor.id,
             lodging_room_option_id: lodging_room_option.id,
-            first_day: target_date,
-            last_day: lodging_day1.date_offered.strftime("%Y/%m/%d")
+            check_in_day: target_date,
+            check_out_day: (lodging_day1.date_offered + 1.day).strftime("%Y/%m/%d")
           }
         end
 
@@ -68,8 +68,8 @@ describe LodgingForm do
           {
             registrant_id: competitor.id,
             lodging_room_option_id: lodging_room_option.id,
-            first_day: target_date,
-            last_day: target_date_end
+            check_in_day: target_date,
+            check_out_day: target_date_end
           }
         end
 
@@ -92,8 +92,8 @@ describe LodgingForm do
         {
           registrant_id: competitor.id,
           lodging_room_option_id: lodging_room_option.id,
-          first_day: lodging_day.date_offered.strftime("%Y/%m/%d"),
-          last_day: lodging_day.date_offered.strftime("%Y/%m/%d")
+          check_in_day: lodging_day.date_offered.strftime("%Y/%m/%d"),
+          check_out_day: (lodging_day.date_offered + 1.day).strftime("%Y/%m/%d")
         }
       end
 
@@ -106,27 +106,27 @@ describe LodgingForm do
             [
               "Lodging room option can't be blank",
               "2017/12/14 Unable to be booked. Out of range?",
-              "2017/12/14 Unable to be booked. Out of range?"
+              "2017/12/15 Unable to be booked. Out of range?"
             ]
           )
         end
       end
 
       context "without a start date" do
-        let(:params) { base_params.merge(first_day: "") }
+        let(:params) { base_params.merge(check_in_day: "") }
 
         it "returns an error message" do
           expect(form.save).to be_falsy
-          expect(form.errors.full_messages).to eq(["First day can't be blank"])
+          expect(form.errors.full_messages).to eq(["Check in day can't be blank"])
         end
       end
 
       context "without a end date" do
-        let(:params) { base_params.merge(last_day: "") }
+        let(:params) { base_params.merge(check_out_day: "") }
 
         it "returns an error message" do
           expect(form.save).to be_falsy
-          expect(form.errors.full_messages).to eq(["Last day can't be blank"])
+          expect(form.errors.full_messages).to eq(["Check out day can't be blank"])
         end
       end
     end
@@ -141,8 +141,8 @@ describe LodgingForm do
     #       {
     #         registrant_id: competitor.id,
     #         lodging_room_option_id: lodging_room_option.id,
-    #         first_day: lodging_day.date_offered.strftime("%Y/%m/%d"),
-    #         last_day: lodging_day.date_offered.strftime("%Y/%m/%d")
+    #         check_in_day: lodging_day.date_offered.strftime("%Y/%m/%d"),
+    #         check_out_day: lodging_day.date_offered.strftime("%Y/%m/%d")
     #       }
     #     end
     #     context "when that day is fully bought" do

--- a/spec/forms/lodging_form_spec.rb
+++ b/spec/forms/lodging_form_spec.rb
@@ -1,0 +1,202 @@
+require 'spec_helper'
+
+describe LodgingForm do
+  let(:competitor) { FactoryGirl.create(:competitor) }
+  let(:lodging_room_type) { FactoryGirl.create(:lodging_room_type) }
+  let(:lodging_room_option) { FactoryGirl.create(:lodging_room_option, lodging_room_type: lodging_room_type) }
+  let(:form) { described_class.new(params) }
+
+  context "#save" do
+    context "with a lodging type with multiple days" do
+      let!(:lodging_day1) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option) }
+      let!(:lodging_day2) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option) }
+      let!(:lodging_day3) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option) }
+
+      describe "when selecting the whole range" do
+        let(:params) do
+          {
+            registrant_id: competitor.id,
+            lodging_room_option_id: lodging_room_option.id,
+            first_day: lodging_day1.date_offered.strftime("%Y/%m/%d"),
+            last_day: lodging_day3.date_offered.strftime("%Y/%m/%d")
+          }
+        end
+        it "creates registrant_expense_items" do
+          expect do
+            form.save
+          end.to change(RegistrantExpenseItem, :count).by(3)
+        end
+      end
+
+      describe "when selecting a single day" do
+        let(:params) do
+          {
+            registrant_id: competitor.id,
+            lodging_room_option_id: lodging_room_option.id,
+            first_day: lodging_day1.date_offered.strftime("%Y/%m/%d"),
+            last_day: lodging_day1.date_offered.strftime("%Y/%m/%d")
+          }
+        end
+        it "creates only a single registrant_expense_item" do
+          expect do
+            form.save
+          end.to change(RegistrantExpenseItem, :count).by(1)
+        end
+      end
+
+      describe "When selecting outside of the range" do
+        let(:target_date) { (lodging_day1.date_offered - 1.day).strftime("%Y/%m/%d") }
+        let(:params) do
+          {
+            registrant_id: competitor.id,
+            lodging_room_option_id: lodging_room_option.id,
+            first_day: target_date,
+            last_day: lodging_day1.date_offered.strftime("%Y/%m/%d")
+          }
+        end
+
+        it "returns an error that it cannot be fulfilled" do
+          expect(form.save).to be_falsy
+          expect(form.errors.full_messages).to eq(["#{target_date} Unable to be booked. Out of range?"])
+        end
+      end
+
+      describe "When selecting only outside of the range" do
+        let(:target_date) { (lodging_day1.date_offered - 5.days).strftime("%Y/%m/%d") }
+        let(:target_date_end) { (lodging_day1.date_offered - 3.days).strftime("%Y/%m/%d") }
+        let(:params) do
+          {
+            registrant_id: competitor.id,
+            lodging_room_option_id: lodging_room_option.id,
+            first_day: target_date,
+            last_day: target_date_end
+          }
+        end
+
+        it "returns an error that it cannot be fulfilled" do
+          expect(form.save).to be_falsy
+          expect(form.errors.full_messages).to eq(
+            [
+              "#{target_date} Unable to be booked. Out of range?",
+              "#{target_date_end} Unable to be booked. Out of range?"
+            ]
+          )
+        end
+      end
+    end
+
+    context "when the form is not fully filled out" do
+      let!(:lodging_day) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 12, 14)) }
+
+      let(:base_params) do
+        {
+          registrant_id: competitor.id,
+          lodging_room_option_id: lodging_room_option.id,
+          first_day: lodging_day.date_offered.strftime("%Y/%m/%d"),
+          last_day: lodging_day.date_offered.strftime("%Y/%m/%d")
+        }
+      end
+
+      context "without a lodging_room_type" do
+        let(:params) { base_params.merge(lodging_room_option_id: "") }
+
+        it "returns an error message" do
+          expect(form.save).to be_falsy
+          expect(form.errors.full_messages).to eq(
+            [
+              "Lodging room option can't be blank",
+              "2017/12/14 Unable to be booked. Out of range?",
+              "2017/12/14 Unable to be booked. Out of range?"
+            ]
+          )
+        end
+      end
+
+      context "without a start date" do
+        let(:params) { base_params.merge(first_day: "") }
+
+        it "returns an error message" do
+          expect(form.save).to be_falsy
+          expect(form.errors.full_messages).to eq(["First day can't be blank"])
+        end
+      end
+
+      context "without a end date" do
+        let(:params) { base_params.merge(last_day: "") }
+
+        it "returns an error message" do
+          expect(form.save).to be_falsy
+          expect(form.errors.full_messages).to eq(["Last day can't be blank"])
+        end
+      end
+    end
+
+    #   context "with a lodging type with a single day, with a maximum" do
+    #     before do
+    #       lodging_room_type.update!(maximum_available: 1)
+    #     end
+    #     let!(:lodging_day) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 12, 17)) }
+
+    #     let(:params) do
+    #       {
+    #         registrant_id: competitor.id,
+    #         lodging_room_option_id: lodging_room_option.id,
+    #         first_day: lodging_day.date_offered.strftime("%Y/%m/%d"),
+    #         last_day: lodging_day.date_offered.strftime("%Y/%m/%d")
+    #       }
+    #     end
+    #     context "when that day is fully bought" do
+    #       let(:existing_package) { FactoryGirl.create(:lodging_package) }
+    #       let!(:existing_package_day) { FactoryGirl.create(:lodging_package_day, lodging_package: lodging_package, lodging_day: lodging_day)}
+    #       let!(:registrant_expense_item) { FactoryGirl.create(:registrant_expense_item, line_item: lodging_package) }
+
+    #       it "returns falsey" do
+    #         expect(form.save).to be_falsy
+    #       end
+
+    #       it "has an error message" do
+    #         form.save
+    #         expect(form.errors.full_messages).to eq(["2017-12-17 Unable to be booked"])
+    #       end
+
+    #       it "does not allow buying another day" do
+    #         expect do
+    #           form.save
+    #         end.to change(RegistrantExpenseItem, :count).by(0)
+    #       end
+    #     end
+
+    #     context "when the day has remaining space" do
+    #       it "allows adding the new day" do
+    #         expect do
+    #           form.save
+    #         end.to change(RegistrantExpenseItem, :count).by(1)
+    #       end
+    #     end
+    #   end
+    # end
+
+    # describe "#selected_for" do
+    #   context "with no selected elements" do
+    #     it "returns a blank array" do
+    #       expect(described_class.selected_for(competitor)).to eq([])
+    #     end
+    #   end
+
+    #   context "with a single selected element" do
+    #     let!(:lodging_day1) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 12, 28)) }
+    #     let(:expense_item) { lodging_day1.expense_item }
+    #     let!(:registrant_expense_item) { FactoryGirl.create(:registrant_expense_item, registrant: competitor, expense_item: expense_item)}
+
+    #     it "returns a single element array" do
+    #       competitor.reload
+    #       forms = described_class.selected_for(competitor)
+
+    #       expect(forms.count).to eq(1)
+    #       expect(forms.first.lodging_room_type_id).to eq(lodging_room_type.id)
+    #       expect(forms.first.first_day).to eq("2017/12/28")
+    #       expect(forms.first.last_day).to eq("2017/12/28")
+    #     end
+    #   end
+  end
+end

--- a/spec/models/lodging_package_spec.rb
+++ b/spec/models/lodging_package_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe LodgingPackage do
+  let(:date_offered) { Date.new(2018, 1, 5) }
+  let(:lodging_room_type) { FactoryGirl.create(:lodging_room_type, maximum_available: maximum_available) }
+  let(:lodging_room_option) { FactoryGirl.create(:lodging_room_option, lodging_room_type: lodging_room_type) }
+  let(:lodging_day) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: date_offered) }
+  let(:lodging_package) { FactoryGirl.create(:lodging_package, lodging_room_option: lodging_room_option, lodging_room_type: lodging_room_type) }
+  let!(:lodging_package_day) { FactoryGirl.create(:lodging_package_day, lodging_package: lodging_package, lodging_day: lodging_day) }
+
+  context "when limited number days are available" do
+    let(:maximum_available) { 1 }
+    let(:rei) { FactoryGirl.build(:registrant_expense_item, line_item: lodging_package) }
+    context "and none are booked" do
+      it "allows creating the rei" do
+        expect(lodging_package.can_create_registrant_expense_item?(rei)).to eq([])
+      end
+    end
+
+    context "and all are booked" do
+      let(:existing_lodging_package) { FactoryGirl.create(:lodging_package, lodging_room_option: lodging_room_option, lodging_room_type: lodging_room_type) }
+      let!(:existing_lodging_package_day) { FactoryGirl.create(:lodging_package_day, lodging_package: existing_lodging_package, lodging_day: lodging_day) }
+      let!(:registrant_expense_item) { FactoryGirl.create(:registrant_expense_item, line_item: existing_lodging_package) }
+
+      it "does not allow creating the Rei" do
+        expect(lodging_package.can_create_registrant_expense_item?(rei)).to eq(["2018-01-05 Unable to be booked. None Left"])
+      end
+    end
+  end
+end

--- a/spec/models/lodging_room_option_spec.rb
+++ b/spec/models/lodging_room_option_spec.rb
@@ -1,0 +1,108 @@
+# == Schema Information
+#
+# Table name: expense_items
+#
+#  id                     :integer          not null, primary key
+#  position               :integer
+#  created_at             :datetime
+#  updated_at             :datetime
+#  expense_group_id       :integer
+#  has_details            :boolean          default(FALSE), not null
+#  maximum_available      :integer
+#  has_custom_cost        :boolean          default(FALSE), not null
+#  maximum_per_registrant :integer          default(0)
+#  cost_cents             :integer
+#  tax_cents              :integer          default(0), not null
+#  cost_element_id        :integer
+#  cost_element_type      :string
+#
+# Indexes
+#
+#  index_expense_items_expense_group_id                          (expense_group_id)
+#  index_expense_items_on_cost_element_type_and_cost_element_id  (cost_element_type,cost_element_id) UNIQUE
+#
+
+require 'spec_helper'
+
+describe LodgingRoomOption do
+  let(:lodging_room_option) { FactoryGirl.create(:lodging_room_option) }
+  let(:lodging_room_type) { lodging_room_option.lodging_room_type }
+  let(:lodging_package) { FactoryGirl.create(:lodging_package, lodging_room_type: lodging_room_type, lodging_room_option: lodging_room_option) }
+  let!(:lodging_package_day) { FactoryGirl.create(:lodging_package_day, lodging_package: lodging_package, lodging_day: lodging_day) }
+  let(:lodging_day) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option) }
+  let(:rei) { FactoryGirl.build(:registrant_expense_item, line_item: lodging_package) }
+
+  it "can create from factory" do
+    expect(lodging_room_option.valid?).to eq(true)
+  end
+
+  describe "when an associated payment has been created" do
+    before(:each) do
+      @payment = FactoryGirl.create(:payment_detail, line_item: lodging_package)
+      lodging_room_option.reload
+    end
+
+    it "should not be able to destroy this item" do
+      expect(LodgingPackage.all.count).to eq(1)
+      expect(LodgingRoomOption.all.count).to eq(1)
+      expect { lodging_room_option.destroy }.to raise_error(ActiveRecord::DeleteRestrictionError)
+      expect(LodgingPackage.all.count).to eq(1)
+      expect(LodgingRoomOption.all.count).to eq(1)
+    end
+
+    it "does not count this entry as a selected_item when the payment is incomplete" do
+      expect(@payment.payment.completed).to eq(false)
+      expect(lodging_room_option.num_selected_items(lodging_day)).to eq(0)
+      expect(lodging_room_option.num_paid(lodging_day)).to eq(0)
+      expect(lodging_room_option.total_amount_paid(lodging_day)).to eq(0.to_money)
+    end
+
+    it "counts this entry as a selected_item when the payment is complete" do
+      pay = @payment.payment
+      pay.completed = true
+      pay.save!
+      expect(lodging_room_option.num_selected_items(lodging_day)).to eq(1)
+      expect(lodging_room_option.num_paid(lodging_day)).to eq(1)
+      expect(lodging_room_option.total_amount_paid(lodging_day)).to eq(9.99.to_money)
+    end
+  end
+
+  describe "with associated registrant_expense_items" do
+    before(:each) do
+      rei.save! # create the REI
+    end
+
+    it "should count the entry as a selected_item" do
+      expect(lodging_room_option.num_selected_items(lodging_day)).to eq(1)
+      expect(lodging_room_option.num_unpaid(lodging_day)).to eq(1)
+    end
+
+    describe "when the registrant is deleted" do
+      before(:each) do
+        reg = rei.registrant
+        reg.deleted = true
+        reg.save!
+      end
+
+      it "should not count the expense_item as num_unpaid" do
+        expect(lodging_room_option.num_unpaid(lodging_day)).to eq(0)
+      end
+    end
+
+    describe "when the registrant is not completed filling out their registration form" do
+      before(:each) do
+        reg = rei.registrant
+        reg.status = "events"
+        reg.save!
+      end
+
+      it "should not count the expense_item as num_unpaid" do
+        expect(lodging_room_option.num_unpaid(lodging_day)).to eq(0)
+      end
+
+      it "should count the expense_item as num_unpaid when option is selected" do
+        expect(lodging_room_option.num_unpaid(lodging_day, include_incomplete_registrants: true)).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/models/lodging_room_type_spec.rb
+++ b/spec/models/lodging_room_type_spec.rb
@@ -1,7 +1,36 @@
 require 'spec_helper'
 
 describe LodgingRoomType do
-  let(:lodging) { FactoryGirl.create(:lodging) }
+  let(:lodging_room_option) { FactoryGirl.create(:lodging_room_option) }
+  let(:lodging_room_type) { lodging_room_option.lodging_room_type }
+  let(:lodging_package) { FactoryGirl.create(:lodging_package, lodging_room_type: lodging_room_type, lodging_room_option: lodging_room_option) }
+  let!(:lodging_package_day) { FactoryGirl.create(:lodging_package_day, lodging_package: lodging_package, lodging_day: lodging_day) }
+  let(:lodging_day) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option) }
+  let(:rei) { FactoryGirl.build(:registrant_expense_item, line_item: lodging_package) }
+
+  it "lodging_room_type has not reached the maximum" do
+    expect(lodging_room_type.maximum_reached?(lodging_day)).to be_falsey
+  end
+
+  context "When there is a 0-limit set for the maximum available" do
+    before { lodging_room_type.maximum_available = 0 }
+
+    it "has not reached the maximum" do
+      expect(lodging_room_type.maximum_reached?(lodging_day)).to be_falsey
+    end
+  end
+
+  describe "when an associated payment has been created" do
+    before(:each) do
+      @payment = FactoryGirl.create(:payment_detail, line_item: lodging_package)
+      lodging_room_type.reload
+    end
+
+    it "does not count this entry as a selected_item when the payment is incomplete" do
+      expect(@payment.payment.completed).to eq(false)
+      expect(lodging_room_type.num_selected_items(lodging_day)).to eq(0)
+    end
+  end
 end
 
 # == Schema Information

--- a/spec/models/lodging_room_type_spec.rb
+++ b/spec/models/lodging_room_type_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe LodgingRoomType do
+  let(:lodging) { FactoryGirl.create(:lodging) }
+end
+
+# == Schema Information
+#
+# Table name: lodging_room_types
+#
+#  id                :integer          not null, primary key
+#  lodging_id        :integer          not null
+#  position          :integer
+#  name              :string           not null
+#  description       :text
+#  visible           :boolean          default(TRUE), not null
+#  maximum_available :integer
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+# Indexes
+#
+#  index_lodging_room_types_on_lodging_id  (lodging_id)
+#

--- a/spec/models/lodging_spec.rb
+++ b/spec/models/lodging_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Lodging do
+  let(:lodging) { FactoryGirl.create(:lodging) }
+
+  context "destroying" do
+    describe "with an lodging_type" do
+      let!(:lodging_room_type) { FactoryGirl.create(:lodging_room_type, lodging: lodging) }
+      it "does not allow destruction" do
+        expect(lodging.reload.lodging_room_types.length).to eq(1)
+        expect(lodging.destroy).to be_falsey
+      end
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: lodgings
+#
+#  id          :integer          not null, primary key
+#  name        :string           not null
+#  position    :integer
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#

--- a/spec/presenters/lodging_package_presenter_spec.rb
+++ b/spec/presenters/lodging_package_presenter_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe LodgingPackagePresenter do
+  let(:lodging_package) { FactoryGirl.create(:lodging_package) }
+  let(:lodging_room_option) { lodging_package.lodging_room_option }
+  let(:presenter) { described_class.new(lodging_package) }
+
+  describe "#first_day" do
+    context "with no lodging_days" do
+      it "says none" do
+        expect(presenter.first_day).to eq("none")
+      end
+    end
+
+    context "with one lodging day" do
+      let!(:lodging_day) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 1, 1)) }
+      let!(:lodging_package_day) { FactoryGirl.create(:lodging_package_day, lodging_package: lodging_package, lodging_day: lodging_day) }
+
+      it "says that one day" do
+        expect(presenter.first_day).to eq("Jan 01, 2017")
+      end
+    end
+
+    context "with a range of lodging days" do
+      let!(:lodging_day1) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 1, 1)) }
+      let!(:lodging_day2) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 1, 2)) }
+      let!(:lodging_package_day1) { FactoryGirl.create(:lodging_package_day, lodging_package: lodging_package, lodging_day: lodging_day1) }
+      let!(:lodging_package_day2) { FactoryGirl.create(:lodging_package_day, lodging_package: lodging_package, lodging_day: lodging_day2) }
+
+      it "says those days" do
+        expect(presenter.first_day).to eq("Jan 01, 2017")
+        expect(presenter.last_day).to eq("Jan 02, 2017")
+      end
+    end
+  end
+end

--- a/spec/presenters/lodging_package_presenter_spec.rb
+++ b/spec/presenters/lodging_package_presenter_spec.rb
@@ -5,10 +5,10 @@ describe LodgingPackagePresenter do
   let(:lodging_room_option) { lodging_package.lodging_room_option }
   let(:presenter) { described_class.new(lodging_package) }
 
-  describe "#first_day" do
+  describe "#check_in_day" do
     context "with no lodging_days" do
       it "says none" do
-        expect(presenter.first_day).to eq("none")
+        expect(presenter.check_in_day).to eq("none")
       end
     end
 
@@ -17,7 +17,7 @@ describe LodgingPackagePresenter do
       let!(:lodging_package_day) { FactoryGirl.create(:lodging_package_day, lodging_package: lodging_package, lodging_day: lodging_day) }
 
       it "says that one day" do
-        expect(presenter.first_day).to eq("Jan 01, 2017")
+        expect(presenter.check_in_day).to eq("Jan 01, 2017")
       end
     end
 
@@ -28,8 +28,8 @@ describe LodgingPackagePresenter do
       let!(:lodging_package_day2) { FactoryGirl.create(:lodging_package_day, lodging_package: lodging_package, lodging_day: lodging_day2) }
 
       it "says those days" do
-        expect(presenter.first_day).to eq("Jan 01, 2017")
-        expect(presenter.last_day).to eq("Jan 02, 2017")
+        expect(presenter.check_in_day).to eq("Jan 01, 2017")
+        expect(presenter.check_out_day).to eq("Jan 03, 2017")
       end
     end
   end

--- a/spec/presenters/lodging_room_option_presenter_spec.rb
+++ b/spec/presenters/lodging_room_option_presenter_spec.rb
@@ -15,7 +15,7 @@ describe LodgingRoomOptionPresenter do
       let!(:lodging_day) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 1, 1)) }
 
       it "says that one day" do
-        expect(presenter.days_available).to eq("Jan 01, 2017")
+        expect(presenter.days_available).to eq("Jan 01, 2017 - Jan 02, 2017")
       end
     end
 
@@ -24,7 +24,7 @@ describe LodgingRoomOptionPresenter do
       let!(:lodging_day2) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 1, 2)) }
 
       it "says those days" do
-        expect(presenter.days_available).to eq("Jan 01, 2017 - Jan 02, 2017")
+        expect(presenter.days_available).to eq("Jan 01, 2017 - Jan 03, 2017")
       end
     end
 
@@ -35,7 +35,7 @@ describe LodgingRoomOptionPresenter do
       let!(:lodging_day4) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 1, 6)) }
 
       it "says those ranges of days" do
-        expect(presenter.days_available).to eq("Jan 01, 2017 - Jan 02, 2017, Jan 05, 2017 - Jan 06, 2017")
+        expect(presenter.days_available).to eq("Jan 01, 2017 - Jan 03, 2017, Jan 05, 2017 - Jan 07, 2017")
       end
     end
   end

--- a/spec/presenters/lodging_room_option_presenter_spec.rb
+++ b/spec/presenters/lodging_room_option_presenter_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe LodgingRoomOptionPresenter do
+  let(:lodging_room_option) { FactoryGirl.create(:lodging_room_option) }
+  let(:presenter) { described_class.new(lodging_room_option) }
+
+  describe "#days_available" do
+    context "with no lodging_days" do
+      it "says none" do
+        expect(presenter.days_available).to eq("none")
+      end
+    end
+
+    context "with one lodging day" do
+      let!(:lodging_day) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 1, 1)) }
+
+      it "says that one day" do
+        expect(presenter.days_available).to eq("Jan 01, 2017")
+      end
+    end
+
+    context "with a range of lodging days" do
+      let!(:lodging_day1) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 1, 1)) }
+      let!(:lodging_day2) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 1, 2)) }
+
+      it "says those days" do
+        expect(presenter.days_available).to eq("Jan 01, 2017 - Jan 02, 2017")
+      end
+    end
+
+    context "with a broken range of lodging days" do
+      let!(:lodging_day1) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 1, 1)) }
+      let!(:lodging_day2) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 1, 2)) }
+      let!(:lodging_day3) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 1, 5)) }
+      let!(:lodging_day4) { FactoryGirl.create(:lodging_day, lodging_room_option: lodging_room_option, date_offered: Date.new(2017, 1, 6)) }
+
+      it "says those ranges of days" do
+        expect(presenter.days_available).to eq("Jan 01, 2017 - Jan 02, 2017, Jan 05, 2017 - Jan 06, 2017")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow Lodging to be sold by a convention.

Includes the ability to define:
- Lodging
- Lodging Room Types (e.g. 2-bed, 3-bed)
- Lodging Room Options (e.g. With breakfast, without breakfast, etc etc)
- Days offered

Also restricts the number of Lodging Room Type/Day combinations available. E.g. 30 of 2-bed room available each day during the convention.

