### PR TITLE
The cache counter was being mixed up when copying from existing events.

### DIFF
--- a/app/actions/event_copier.rb
+++ b/app/actions/event_copier.rb
@@ -38,6 +38,8 @@ class EventCopier
     new_event = source_event.dup
     new_event.name = source_event.name
     new_event.category = Category.find_by(name: source_event.category.name)
+    new_event.event_categories_count = 0
+    new_event.event_choices_count = 0
 
     # Set the event_categories before saving the event, to prevent creating the default 'All' EventCategory
     source_event.event_categories.each do |ec|

--- a/spec/actions/event_copier_spec.rb
+++ b/spec/actions/event_copier_spec.rb
@@ -30,6 +30,10 @@ describe EventCopier do
       expect(EventCategory.count).to eq(1)
     end
 
+    it "sets the cached event_categories count properly" do
+      expect(Event.first.event_categories.size).to eq(Event.first.event_categories.count)
+    end
+
     it "copies the event_choice" do
       expect(EventChoice.count).to eq(1)
     end


### PR DESCRIPTION
When copying events from a previous convention, the new event
would have the incorrect number of event_categories.