### PR TITLE
Display the row even if the bib number is not found.

### DIFF
--- a/app/views/import_results/_matching_registrant_cell.html.haml
+++ b/app/views/import_results/_matching_registrant_cell.html.haml
@@ -1,15 +1,19 @@
 - reg = import_result.matching_registrant
-%td= reg
-- matching_competitor = import_result.matching_competitor
-- if matching_competitor.try(:competition) == import_result.competition
-  %td.competitor_exists Yes
+- if reg.nil?
+  %td
+  %td.competitor_not_exists Invalid Bib Number
 - else
-  - import_into_matching_competitions = import_result.competition.import_results_into_other_competition?
-  - if import_into_matching_competitions
-    - other_competition = reg.matching_competition_in_event(import_result.competition.event)
-    - if other_competition
-      %td.competitor_other_comp_exists No (but #{other_competition} does, so I'll import it there)
+  %td= reg
+  - matching_competitor = import_result.matching_competitor
+  - if matching_competitor.try(:competition) == import_result.competition
+    %td.competitor_exists Yes
+  - else
+    - import_into_matching_competitions = import_result.competition.import_results_into_other_competition?
+    - if import_into_matching_competitions
+      - other_competition = reg.matching_competition_in_event(import_result.competition.event)
+      - if other_competition
+        %td.competitor_other_comp_exists No (but #{other_competition} does, so I'll import it there)
+      - else
+        %td.competitor_not_exists No
     - else
       %td.competitor_not_exists No
-  - else
-    %td.competitor_not_exists No

--- a/spec/controllers/import_results_controller_spec.rb
+++ b/spec/controllers/import_results_controller_spec.rb
@@ -174,4 +174,19 @@ describe ImportResultsController do
       expect(response).to redirect_to(data_entry_user_competition_import_results_path(import.user, competition))
     end
   end
+
+  describe "GET display_chip" do
+    context "when the data includes registrants which exist" do
+    end
+
+    context "when the data includes a registrant ID which we don't have" do
+      let(:competition) { FactoryBot.create(:timed_competition, import_results_into_other_competition: true) }
+      let!(:import_result) { FactoryBot.create(:import_result, bib_number: "123", competition: competition) }
+
+      it "displays the page" do
+        get :display_chip, params: { competition_id: competition.id, user_id: import_result.user }
+        expect(response).to be_successful
+      end
+    end
+  end
 end


### PR DESCRIPTION
Was only broken when using 'import_into_other_competitions' feature