### PR TITLE
Revert Wkhtmltopdf update.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,8 @@ gem 'rolify'
 gem 'prawn-labels'
 gem 'spreadsheet'
 gem 'wicked_pdf'
-gem 'wkhtmltopdf-binary'
+gem 'wkhtmltopdf-binary', '0.12.3.1'
+# newer versions of wkhtmltopdf seem to have shrunken fonts on Mac OS X
 
 # Front-end
 gem "autoprefixer-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -601,7 +601,7 @@ GEM
     wicked (1.3.3)
       railties (>= 3.0.7)
     wicked_pdf (1.1.0)
-    wkhtmltopdf-binary (0.12.4)
+    wkhtmltopdf-binary (0.12.3.1)
     xpath (3.1.0)
       nokogiri (~> 1.8)
 
@@ -697,7 +697,7 @@ DEPENDENCIES
   whenever
   wicked
   wicked_pdf
-  wkhtmltopdf-binary
+  wkhtmltopdf-binary (= 0.12.3.1)
 
 RUBY VERSION
    ruby 2.4.3p205


### PR DESCRIPTION
The newer version was causing issues with mac os x development.
Fonts were too small to read