### PR TITLE
When a new tenant subdomain has uppercase characters, save with lower…

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -19,6 +19,7 @@ class Tenant < ApplicationRecord
   validates :subdomain, uniqueness: true
   validate :subdomain_has_no_spaces
   before_validation :trim_subdomain
+  before_validation :lowercase_subdomain
 
   has_many :tenant_aliases, dependent: :destroy, inverse_of: :tenant
   has_one :convention_series_member, dependent: :destroy, inverse_of: :tenant
@@ -50,6 +51,10 @@ class Tenant < ApplicationRecord
 
   def trim_subdomain
     self.subdomain = subdomain.strip
+  end
+
+  def lowercase_subdomain
+    self.subdomain = subdomain.downcase
   end
 
   def subdomain_has_no_spaces

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -61,6 +61,12 @@ describe Tenant do
       tenant = FactoryBot.build(:tenant, subdomain: "not allowed")
       expect(tenant).not_to be_valid
     end
+
+    it "lowercases the subdomain if it has uppercase characters" do
+      tenant = FactoryBot.build(:tenant, subdomain: "A-THING")
+      expect(tenant).to be_valid
+      expect(tenant.subdomain).to eq("a-thing")
+    end
   end
 
   context "without tenant aliases" do


### PR DESCRIPTION
…case characters.

Otherwise, searching for tenants with the apartment elevator fails