### PR TITLE
Replace therubyracer with nodejs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -140,10 +140,6 @@ end
 gem 'coffee-rails'
 gem 'sass-rails'
 
-# See https://github.com/sstephenson/execjs#readme for more supported runtimes
-# Necessary so that the uglifier can process/compress the assets
-gem 'therubyracer'
-
 gem 'uglifier', '>= 1.0.3'
 
 # To use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,6 @@ GEM
     kaminari-core (1.1.1)
     kgio (2.11.2)
     kostya-sigar (2.0.2)
-    libv8 (3.16.14.19)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -469,7 +468,6 @@ GEM
       redis-store (>= 1.2, < 2)
     redis-store (1.6.0)
       redis (>= 2.2, < 5)
-    ref (2.0.0)
     regexp_parser (1.3.0)
     remotipart (1.4.2)
     request_store (1.4.1)
@@ -572,9 +570,6 @@ GEM
     teaspoon-jasmine (2.3.4)
       teaspoon (>= 1.0.0)
     temple (0.8.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -700,7 +695,6 @@ DEPENDENCIES
   spreadsheet
   stripe
   teaspoon-jasmine
-  therubyracer
   tinymce-rails
   tolk!
   uglifier (>= 1.0.3)


### PR DESCRIPTION
theRubyracer is not compatible with modern autoprefixer-rails versions