### PR TITLE
Add dutch

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -32,6 +32,7 @@
 //= require select2_locale_ja
 //= require select2_locale_it
 //= require select2_locale_da
+//= require select2_locale_nl
 // NOTE: not available select2_locale_ja
 //= require fancybox
 //= require cocoon

--- a/app/controllers/convention_setup/event_configurations_controller.rb
+++ b/app/controllers/convention_setup/event_configurations_controller.rb
@@ -178,7 +178,7 @@ class ConventionSetup::EventConfigurationsController < ConventionSetup::BaseConv
   def payment_settings_params
     params.require(:event_configuration).permit(
       :paypal_account,
-      :paypal_mode,
+      :payment_mode,
       :stripe_public_key,
       :stripe_secret_key,
       :offline_payment,

--- a/app/models/event_configuration.rb
+++ b/app/models/event_configuration.rb
@@ -32,7 +32,7 @@
 #  italian_requirements                          :boolean          default(FALSE), not null
 #  rules_file_name                               :string
 #  accept_rules                                  :boolean          default(FALSE), not null
-#  paypal_mode                                   :string           default("disabled")
+#  payment_mode                                  :string           default("disabled")
 #  offline_payment                               :boolean          default(FALSE), not null
 #  enabled_locales                               :string           not null
 #  comp_noncomp_page_id                          :integer
@@ -121,11 +121,11 @@ class EventConfiguration < ApplicationRecord
     organization_membership_type.present?
   end
 
-  def self.paypal_modes
+  def self.payment_modes
     ["disabled", "test", "enabled"]
   end
 
-  validates :paypal_mode, inclusion: { in: paypal_modes }
+  validates :payment_mode, inclusion: { in: payment_modes }
 
   nilify_blanks only: %i[rulebook_url event_url], before: :validation
 
@@ -174,7 +174,7 @@ class EventConfiguration < ApplicationRecord
   end
 
   def online_payment?
-    paypal_mode == "test" || paypal_mode == "enabled"
+    payment_mode == "test" || payment_mode == "enabled"
   end
 
   def can_only_drop_or_modify_events?
@@ -184,7 +184,7 @@ class EventConfiguration < ApplicationRecord
   end
 
   def paypal_test?
-    paypal_mode == "test"
+    payment_mode == "test"
   end
 
   def print_waiver?

--- a/app/views/convention_setup/event_configurations/payment_settings.html.haml
+++ b/app/views/convention_setup/event_configurations/payment_settings.html.haml
@@ -46,7 +46,7 @@
     = f.input :stripe_secret_key
     %hr
     = f.input :currency_code, collection: EventConfiguration.currency_codes
-    = f.input :paypal_mode, collection: EventConfiguration.paypal_modes, include_blank: false
+    = f.input :payment_mode, collection: EventConfiguration.payment_modes, include_blank: false
     = f.input :offline_payment
     = render "shared/wysiwyg"
     = f.input :offline_payment_description, as: :text, input_html: { class: "tinymce" }

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module Workspace
 
     # These are the default list of available languages.
     # Note: this is overwritten in application_controller.rb once an EventConfiguration is loaded.
-    config.i18n.available_locales = %i[en fr de hu es ja ko it da]
+    config.i18n.available_locales = %i[en fr de hu es ja ko it da nl]
 
     config.encoding = "utf-8"
 

--- a/config/locales/base.nl.yml
+++ b/config/locales/base.nl.yml
@@ -1,0 +1,3 @@
+---
+nl:
+  language_name: Dutch

--- a/config/locales/models/event_configuration.da.yml
+++ b/config/locales/models/event_configuration.da.yml
@@ -25,4 +25,3 @@ da:
         offline_payment: Tillad offline betaling
         offline_payment_description: Detaljer for offline betaling
         paypal_account: Paypal Merchant Account Email
-        paypal_mode: Paypal Mode

--- a/config/locales/models/event_configuration.de.yml
+++ b/config/locales/models/event_configuration.de.yml
@@ -28,7 +28,7 @@ de:
         offline_payment: Gib Details zur offline Zahlmethode an
         offline_payment_description: Details der offline Zahlmethode
         paypal_account: Paypal Händler Account E-Mail
-        paypal_mode: Paypal Modus
+        payment_mode: Angemeldeter Modus
         registrants_should_specify_default_wheel_size: Teilnehmer sollen ihre Standard
           Radgröße spezifizieren
         request_address: Adresse erfragen
@@ -45,7 +45,7 @@ de:
         start_date: Erster Tag der Veranstaltung
         style_name: Webseiten Stil
         under_construction: wird gerade überarbeitet
-    models: 
+    models:
   helpers:
     submit:
       event_configuration:

--- a/config/locales/models/event_configuration.en.yml
+++ b/config/locales/models/event_configuration.en.yml
@@ -22,7 +22,7 @@ en:
         under_construction: Under Construction
         artistic_closed_date: Last day to accept new Artistic Registration
         currency_code: Currency Code
-        paypal_mode: Paypal Mode
+        payment_mode: Payment Mode
         competitor: Competitor
         noncompetitor: Non-Competitor
         spectator: Spectator

--- a/config/locales/models/event_configuration.fr.yml
+++ b/config/locales/models/event_configuration.fr.yml
@@ -29,7 +29,7 @@ fr:
         offline_payment: Configuration des détails sur le paiement hors ligne
         offline_payment_description: Détails pour le paiement hors ligne
         paypal_account: Email du compte marchand PayPal
-        paypal_mode: Mode Paypal
+        payment_mode: Mode Payment
         registrants_should_specify_default_wheel_size: Le compétiteur doit spécifier
           sa taille de roue par défaut
         request_address: Demander l'addresse

--- a/config/locales/models/event_configuration.it.yml
+++ b/config/locales/models/event_configuration.it.yml
@@ -28,7 +28,7 @@ it:
         offline_payment: Fornire dettagli per il pagamento offline
         offline_payment_description: Dettagli per il pagamento offline
         paypal_account: Account email PayPal
-        paypal_mode: Modalità PayPal
+        payment_mode: Modalità Iscritto
         registrants_should_specify_default_wheel_size: Gli iscritti devono specificare
           la dimensione della ruota per difetto
         request_address: Indirizzo richiesto

--- a/db/migrate/20181126020943_rename_paypal_mode.rb
+++ b/db/migrate/20181126020943_rename_paypal_mode.rb
@@ -1,0 +1,5 @@
+class RenamePaypalMode < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :event_configurations, :paypal_mode, :payment_mode
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181119041437) do
+ActiveRecord::Schema.define(version: 20181126020943) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -401,7 +401,7 @@ ActiveRecord::Schema.define(version: 20181119041437) do
     t.boolean "italian_requirements", default: false, null: false
     t.string "rules_file_name"
     t.boolean "accept_rules", default: false, null: false
-    t.string "paypal_mode", default: "disabled"
+    t.string "payment_mode", default: "disabled"
     t.boolean "offline_payment", default: false, null: false
     t.string "enabled_locales", null: false
     t.integer "comp_noncomp_page_id"

--- a/spec/factories/event_configurations.rb
+++ b/spec/factories/event_configurations.rb
@@ -32,7 +32,7 @@
 #  italian_requirements                          :boolean          default(FALSE), not null
 #  rules_file_name                               :string
 #  accept_rules                                  :boolean          default(FALSE), not null
-#  paypal_mode                                   :string           default("disabled")
+#  payment_mode                                  :string           default("disabled")
 #  offline_payment                               :boolean          default(FALSE), not null
 #  enabled_locales                               :string           not null
 #  comp_noncomp_page_id                          :integer
@@ -80,7 +80,7 @@ FactoryBot.define do
     max_award_place { 5 }
     spectators { false }
     paypal_account { "ROBIN+merchant@dunlopweb.com" }
-    paypal_mode { "enabled" }
+    payment_mode { "enabled" }
     offline_payment { false }
     under_construction { false }
 

--- a/spec/models/event_configuration_spec.rb
+++ b/spec/models/event_configuration_spec.rb
@@ -32,7 +32,7 @@
 #  italian_requirements                          :boolean          default(FALSE), not null
 #  rules_file_name                               :string
 #  accept_rules                                  :boolean          default(FALSE), not null
-#  paypal_mode                                   :string           default("disabled")
+#  payment_mode                                  :string           default("disabled")
 #  offline_payment                               :boolean          default(FALSE), not null
 #  enabled_locales                               :string           not null
 #  comp_noncomp_page_id                          :integer
@@ -310,11 +310,11 @@ describe EventConfiguration do
   end
 
   it "returns the live paypal url when paypal mode is enabled" do
-    @ev.update_attribute(:paypal_mode, "enabled")
+    @ev.update_attribute(:payment_mode, "enabled")
     expect(described_class.paypal_base_url).to eq("https://www.paypal.com")
   end
   it "returns the test paypal url when paypal mode is TEST" do
-    @ev.update_attribute(:paypal_mode, "test")
+    @ev.update_attribute(:payment_mode, "test")
     expect(described_class.paypal_base_url).to eq("https://www.sandbox.paypal.com")
   end
 

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -102,7 +102,7 @@ describe Payment do
   end
 
   describe "With an environment config with test mode disabled" do
-    let!(:event_configuration) { FactoryBot.create :event_configuration, paypal_mode: "enabled" }
+    let!(:event_configuration) { FactoryBot.create :event_configuration, payment_mode: "enabled" }
 
     it "has a REAL paypal_post_url" do
       expect(@pay.paypal_post_url).to eq("https://www.paypal.com/cgi-bin/webscr")


### PR DESCRIPTION
This will not show up in the footer of the site until more changes are done, but I want there to be a non-trivial amount of text translated into dutch before I make those last changes.

So, a "translator" needs to go and perform the translations first.