### PR TITLE
Re-introduce monkeypatch, still needed in rails 5.1

### DIFF
--- a/config/initializers/digestor_monkey_patch.rb
+++ b/config/initializers/digestor_monkey_patch.rb
@@ -1,2 +1,38 @@
 # rubocop:disable all
+module ActionView
+  class Digestor
+    class << self
+      def tree(name, finder, partial = false, seen = {})
+        logical_name = name.gsub(%r{/_}, "/")
+
+        options = {}
+        options[:formats] = [finder.rendered_format] if finder.rendered_format
+        options[:formats].push(:html) if finder.rendered_format == :pdf # XXX THIS IS THE PATCH
+        if template = finder.disable_cache { finder.find_all(logical_name, [], partial, [], options).first }
+          finder.rendered_format ||= template.formats.first
+
+          if node = seen[template.identifier] # handle cycles in the tree
+            node
+          else
+            node = seen[template.identifier] = Node.create(name, logical_name, template, partial)
+
+            deps = DependencyTracker.find_dependencies(name, template, finder.view_paths)
+            deps.uniq { |n| n.gsub(%r{/_}, "/") }.each do |dep_file|
+              node.children << tree(dep_file, finder, true, seen)
+            end
+            node
+          end
+        else
+          logger.error "  '#{name}' file doesn't exist, so no dependencies"
+          logger.error "  Couldn't find template for digesting: #{name}"
+          seen[name] ||= Missing.new(name, logical_name, nil)
+        end
+      end
+    end
+  end
+end
+
 # https://github.com/rails/rails/issues/28503
+unless Rails::VERSION::STRING == "5.1.5"
+  raise "Check on Monkeypatch"
+end

--- a/config/initializers/digestor_monkey_patch.rb
+++ b/config/initializers/digestor_monkey_patch.rb
@@ -33,6 +33,6 @@ module ActionView
 end
 
 # https://github.com/rails/rails/issues/28503
-unless Rails::VERSION::STRING == "5.1.5"
+unless Rails::VERSION::STRING == "5.1.6.1"
   raise "Check on Monkeypatch"
 end


### PR DESCRIPTION
If you test the registrant#show.pdf, with caching enabled,
it is clear that this monkeypatch is still needed.

FUTURE NOTE:
Rails 5.2.2 has been tested WITHOUT this patch, and it appears
to work.