### PR TITLE
Improve usa registration flow

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -41,6 +41,8 @@ Metrics/BlockNesting:
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
   Max: 403
+  Exclude:
+    - 'app/models/registrant.rb'
 
 # Offense count: 29
 Metrics/CyclomaticComplexity:

--- a/app/actions/exporters/organization_memberships_exporter.rb
+++ b/app/actions/exporters/organization_memberships_exporter.rb
@@ -6,7 +6,8 @@ class Exporters::OrganizationMembershipsExporter
   def headers
     [
       "Id",
-      "Organization Membership#",
+      "Manual Organization Membership#",
+      "System Organization Membership#",
       "First Name",
       "Last Name",
       "Birthday",
@@ -24,10 +25,11 @@ class Exporters::OrganizationMembershipsExporter
 
   def rows
     data = []
-    @registrants.includes(payment_details: [:payment]).each do |reg|
+    @registrants.includes(:organization_membership, payment_details: [:payment]).each do |reg|
       row = [
         reg.bib_number,
-        reg.contact_detail.organization_member_number,
+        reg.organization_membership_manual_member_number,
+        reg.organization_membership_system_member_number,
         reg.first_name,
         reg.last_name,
         reg.birthday,
@@ -39,7 +41,7 @@ class Exporters::OrganizationMembershipsExporter
         reg.contact_detail.phone,
         reg.contact_detail.email,
         reg.club,
-        reg.contact_detail.organization_membership_confirmed?
+        reg.organization_membership_confirmed?
       ]
       data << row
     end

--- a/app/actions/registrant_copier.rb
+++ b/app/actions/registrant_copier.rb
@@ -22,6 +22,10 @@ class RegistrantCopier
     ContactDetail.new(previous_contact_detail_attributes) if previous_contact_detail_attributes.any?
   end
 
+  def organization_membership
+    OrganizationMembership.new(previous_organization_membership_attributes) if previous_organization_membership_attributes.any?
+  end
+
   private
 
   def previous_registrant_attributes
@@ -54,12 +58,25 @@ class RegistrantCopier
            mobile
            email
            club
-           club_contact
-           organization_member_number].each do |attribute|
+           club_contact].each do |attribute|
           contact_attributes[attribute] = contact_detail.send(attribute)
         end
       end
     end
     contact_attributes
+  end
+
+  def previous_organization_membership_attributes
+    organization_membership_attributes = {}
+    Apartment::Tenant.switch(subdomain) do
+      previous_reg = Registrant.find(previous_id)
+      if previous_reg.organization_membership.present?
+        organization_membership = previous_reg.organization_membership
+        %i[system_member_number manual_member_number].each do |attribute|
+          organization_membership_attributes[attribute] = organization_membership.send(attribute)
+        end
+      end
+    end
+    organization_membership_attributes
   end
 end

--- a/app/actions/usa_membership_checker.rb
+++ b/app/actions/usa_membership_checker.rb
@@ -2,13 +2,13 @@
 # WildApricot membership database
 class UsaMembershipChecker
   attr_reader :first_name, :last_name, :birthdate
-  attr_reader :legacy_usa_member_number, :wildapricot_member_number
+  attr_reader :manual_member_number, :wildapricot_member_number
 
-  def initialize(first_name:, last_name:, birthdate:, usa_member_number:, wildapricot_member_number:)
+  def initialize(first_name:, last_name:, birthdate:, manual_member_number:, wildapricot_member_number:)
     @first_name = first_name
     @last_name = last_name
     @birthdate = birthdate
-    @legacy_usa_member_number = usa_member_number
+    @manual_member_number = manual_member_number
     @wildapricot_member_number = wildapricot_member_number
   end
 
@@ -41,6 +41,10 @@ class UsaMembershipChecker
       if result.none?
         # Then search for usa via manual_member_number (if specified)
         result = search_contacts(filter_by_old_usa_membership_id)
+      end
+      if result.none?
+        # Search as if the manual_member_number is a wildapricot ID
+        result = search_contacts(filter_by_manual_id_as_wildapricot_id)
       end
 
       result
@@ -85,7 +89,13 @@ class UsaMembershipChecker
   end
 
   def filter_by_old_usa_membership_id
-    "'Old Member ID' eq '#{legacy_usa_member_number}'"
+    "'Old Member ID' eq '#{manual_member_number}'" \
+    " and 'LastName' eq '#{last_name}'"
+  end
+
+  def filter_by_manual_id_as_wildapricot_id
+    "'ID' eq '#{manual_member_number}' " \
+    " and 'LastName' eq '#{last_name}'"
   end
 
   def filter_by_wildapricot_id

--- a/app/controllers/export_registrants_controller.rb
+++ b/app/controllers/export_registrants_controller.rb
@@ -102,10 +102,10 @@ class ExportRegistrantsController < ApplicationController
     ]
 
     data = []
-    Registrant.active.includes(:user, :contact_detail).each do |reg|
+    Registrant.active.includes(:user, :organization_membership, :contact_detail).each do |reg|
       row = [
         reg.bib_number,
-        reg.contact_detail.organization_member_number,
+        reg.organization_membership_member_number,
         reg.first_name,
         reg.last_name,
         reg.birthday,

--- a/app/controllers/organization_memberships_controller.rb
+++ b/app/controllers/organization_memberships_controller.rb
@@ -8,13 +8,13 @@ class OrganizationMembershipsController < ApplicationController
 
   def toggle_confirm
     @registrant = Registrant.find(params[:id])
-    cd = @registrant.contact_detail
+    om = @registrant.create_organization_membership_record
 
-    if cd.organization_membership_manually_confirmed?
-      cd.update_attribute(:organization_membership_manually_confirmed, false)
+    if om.manually_confirmed?
+      om.update_attribute(:manually_confirmed, false)
       flash[:notice] = "Marked #{@registrant} as unconfirmed"
     else
-      cd.update_attribute(:organization_membership_manually_confirmed, true)
+      om.update_attribute(:manually_confirmed, true)
       flash[:notice] = "Marked #{@registrant} as confirmed"
     end
 
@@ -28,10 +28,10 @@ class OrganizationMembershipsController < ApplicationController
 
   def update_number
     @registrant = Registrant.find(params[:id])
-    cd = @registrant.contact_detail
+    om = @registrant.create_organization_membership_record
 
     if params[:membership_number]
-      cd.update_attribute(:organization_member_number, params[:membership_number])
+      om.update_attribute(:system_member_number, params[:membership_number])
       flash[:notice] = "Updated Member Number"
     else
       flash[:alert] = "Unable to update member number"
@@ -68,6 +68,6 @@ class OrganizationMembershipsController < ApplicationController
   end
 
   def load_registrants
-    @registrants = Registrant.where(registrant_type: ["competitor", "noncompetitor"]).includes(:contact_detail).active
+    @registrants = Registrant.where(registrant_type: ["competitor", "noncompetitor"]).includes(:organization_membership).active
   end
 end

--- a/app/controllers/organization_memberships_controller.rb
+++ b/app/controllers/organization_memberships_controller.rb
@@ -31,7 +31,7 @@ class OrganizationMembershipsController < ApplicationController
     om = @registrant.create_organization_membership_record
 
     if params[:membership_number]
-      om.update_attribute(:system_member_number, params[:membership_number])
+      om.update_attribute(:manual_member_number, params[:membership_number])
       flash[:notice] = "Updated Member Number"
     else
       flash[:alert] = "Unable to update member number"

--- a/app/controllers/registrants/build_controller.rb
+++ b/app/controllers/registrants/build_controller.rb
@@ -173,7 +173,7 @@ class Registrants::BuildController < ApplicationController
      registrant_choices_attributes: %i[event_choice_id value id],
      registrant_event_sign_ups_attributes: %i[event_category_id signed_up event_id id],
      registrant_best_times_attributes: %i[source_location formatted_value event_id id],
-     organization_membership_attributes: %i[manual_member_number],
+     organization_membership_attributes: %i[id manual_member_number],
      contact_detail_attributes: %i[id email
                                    birthplace italian_fiscal_code
                                    address city country_residence country_representing

--- a/app/controllers/registrants/build_controller.rb
+++ b/app/controllers/registrants/build_controller.rb
@@ -69,6 +69,7 @@ class Registrants::BuildController < ApplicationController
     copier = RegistrantCopier.new(params[:previous_registrant], params[:registrant][:registrant_type])
     @registrant = copier.registrant
     @contact_detail = copier.contact_detail
+    @organization_membership = copier.organization_membership
 
     @registrant.user = current_user
     authorize @registrant
@@ -78,6 +79,10 @@ class Registrants::BuildController < ApplicationController
       if @contact_detail
         @contact_detail.registrant = @registrant
         @contact_detail.save(validate: false) # the contact_detail may not be valid yet.
+      end
+      if @organization_membership
+        @organization_membership.registrant = @registrant
+        @organization_membership.save
       end
       session[:copy_from_previous_warnings] ||= []
       session[:copy_from_previous_warnings] << @registrant.id
@@ -168,10 +173,11 @@ class Registrants::BuildController < ApplicationController
      registrant_choices_attributes: %i[event_choice_id value id],
      registrant_event_sign_ups_attributes: %i[event_category_id signed_up event_id id],
      registrant_best_times_attributes: %i[source_location formatted_value event_id id],
+     organization_membership_attributes: %i[manual_member_number],
      contact_detail_attributes: %i[id email
                                    birthplace italian_fiscal_code
                                    address city country_residence country_representing
-                                   mobile phone state_code zip club club_contact organization_member_number
+                                   mobile phone state_code zip club club_contact
                                    emergency_name emergency_relationship emergency_attending emergency_primary_phone emergency_other_phone
                                    responsible_adult_name responsible_adult_phone]]
   end

--- a/app/models/contact_detail.rb
+++ b/app/models/contact_detail.rb
@@ -59,8 +59,6 @@ class ContactDetail < ApplicationRecord
 
   validates :email, presence: true
 
-  after_commit :update_usa_membership_status, on: [:create], if: proc { EventConfiguration.singleton.organization_membership_usa? }
-
   delegate :minor?, to: :registrant, allow_nil: true
 
   # Italians are required to enter VAT_Number and Birthplace
@@ -87,18 +85,5 @@ class ContactDetail < ApplicationRecord
     else
       state_code
     end
-  end
-
-  # is this registrant a member of the relevant unicycling federation?
-  def organization_membership_confirmed?
-    organization_membership_system_confirmed? || organization_membership_manually_confirmed?
-  end
-
-  private
-
-  def update_usa_membership_status
-    return if registrant_id.blank?
-
-    UpdateUsaMembershipStatusWorker.perform_async(registrant_id)
   end
 end

--- a/app/models/email_filters/non_confirmed_organization_members.rb
+++ b/app/models/email_filters/non_confirmed_organization_members.rb
@@ -26,7 +26,7 @@ class EmailFilters::NonConfirmedOrganizationMembers
   end
 
   def registrants
-    Registrant.where(registrant_type: ["competitor", "noncompetitor"]).active_or_incomplete.includes(:contact_detail, :user).reject(&:organization_membership_confirmed?)
+    Registrant.where(registrant_type: ["competitor", "noncompetitor"]).active_or_incomplete.includes(:contact_detail, :organization_membership, :user).reject(&:organization_membership_confirmed?)
   end
 
   # object whose policy must respond to `:contact_registrants?`

--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -1,0 +1,35 @@
+# == Schema Information
+#
+# Table name: organization_memberships
+#
+#  id                   :bigint(8)        not null, primary key
+#  registrant_id        :bigint(8)
+#  manual_member_number :string
+#  system_member_number :string
+#  manually_confirmed   :boolean          default(FALSE), not null
+#  system_confirmed     :boolean          default(FALSE), not null
+#  system_status        :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
+# Indexes
+#
+#  index_organization_memberships_on_registrant_id  (registrant_id)
+#
+
+class OrganizationMembership < ApplicationRecord
+  belongs_to :registrant, inverse_of: :organization_membership, touch: true
+
+  # is this registrant a member of the relevant unicycling federation?
+  def organization_membership_confirmed?
+    system_confirmed? || manually_confirmed?
+  end
+
+  def member_number
+    description = []
+    description << "Membership ID ##{system_member_number}" if system_member_number.present?
+    description << "Legacy ID ##{manual_member_number}" if manual_member_number.present? && system_member_number != manual_member_number
+
+    description.join(", ")
+  end
+end

--- a/app/views/organization_memberships/_member_row.html.haml
+++ b/app/views/organization_memberships/_member_row.html.haml
@@ -5,10 +5,10 @@
     -# this shouldn't happen, as all "active" should include a contact_detail
     - next if reg.contact_detail.nil?
     %td
-      %span.member_number.js--toggle{ id: "membership_number_#{reg.bib_number}", data: { toggle_target: "#member_number_form_#{reg.bib_number}" } }= reg.contact_detail.organization_member_number.presence || "set number"
+      %span.member_number.js--toggle{ id: "membership_number_#{reg.bib_number}", data: { toggle_target: "#member_number_form_#{reg.bib_number}" } }= reg.organization_membership_member_number.presence || "set number"
       %span.is--hidden{ id: "member_number_form_#{reg.bib_number}" }
         = form_tag update_number_organization_membership_path(id: reg.id), method: :put, remote: true do
-          = text_field_tag :membership_number, reg.contact_detail.organization_member_number
+          = text_field_tag :membership_number, reg.organization_membership_system_member_number
           = submit_tag "Update Membership #", class: "button tiny"
     %td= reg.first_name
     %td= reg.last_name
@@ -22,13 +22,13 @@
       = reg.organization_membership_confirmed?
       - unless reg.organization_membership_confirmed?
         %br
-        = reg.contact_detail.try!(:organization_membership_system_status)
+        = reg.organization_membership_system_status
         - if @config.organization_membership_usa?
           = link_to "Refresh USA status", refresh_usa_status_organization_membership_path(id: reg.id), remote: true, method: :post
     %td
-      - if reg.contact_detail.organization_membership_system_confirmed?
+      - if reg.organization_membership_system_confirmed?
         = "Confirmed by System"
-      - elsif reg.contact_detail.organization_membership_manually_confirmed?
+      - elsif reg.organization_membership_manually_confirmed?
         = "Manually Confirmed"
         %br
         = link_to "Mark as unconfirmed", toggle_confirm_organization_membership_path(id: reg.id), method: :put, remote: true

--- a/app/views/registrants/_contact_summary.html.haml
+++ b/app/views/registrants/_contact_summary.html.haml
@@ -27,17 +27,6 @@
     %p
       %b= ContactDetail.human_attribute_name(:club_contact)
       = contact_detail.club_contact
-    - if @config.organization_membership_config?
-      %p
-        %b= organization_membership_label(@config)
-        = contact_detail.organization_member_number
-      - if @config.organization_membership_usa?
-        %p
-          %b= ContactDetail.human_attribute_name(:organization_membership_system_status)
-          = render "/registrants/usa_membership_badge", contact_detail: contact_detail
-          %span.non_printable
-            = link_to usa_membership_welcome_path, target: "_blank" do
-              %span.help_bubble{ title: "More details" }
     - if EventConfiguration.singleton.request_emergency_contact?
       %p
         %b= t(".emergency_contact_name")

--- a/app/views/registrants/_organization_membership.html.haml
+++ b/app/views/registrants/_organization_membership.html.haml
@@ -1,0 +1,13 @@
+- cache_i18n [@config, organization_membership] do
+  - if @config.organization_membership_config?
+    %div.organization_membership
+      %p
+        %b= organization_membership_label(@config)
+        = organization_membership.member_number
+      - if @config.organization_membership_usa?
+        %p
+          %b= OrganizationMembership.human_attribute_name(:system_status)
+          = render "/registrants/usa_membership_badge", organization_membership: organization_membership
+          %span.non_printable
+            = link_to usa_membership_welcome_path, target: "_blank" do
+              %span.help_bubble{ title: "More details" }

--- a/app/views/registrants/_summary.html.haml
+++ b/app/views/registrants/_summary.html.haml
@@ -26,5 +26,8 @@
         %b= t(".default_wheel_size")
         = @registrant.default_wheel_size
 
-  - if policy(@registrant).show_contact_details? && @registrant.contact_detail
-    = render :partial => "/registrants/contact_summary", locals: { :contact_detail => @registrant.contact_detail }
+  - if policy(@registrant).show_contact_details?
+    - if @registrant.contact_detail
+      = render :partial => "/registrants/contact_summary", locals: { :contact_detail => @registrant.contact_detail }
+    - if @registrant.organization_membership
+      = render partial: "/registrants/organization_membership", locals: { organization_membership: @registrant.organization_membership }

--- a/app/views/registrants/_usa_membership_badge.html.haml
+++ b/app/views/registrants/_usa_membership_badge.html.haml
@@ -1,4 +1,4 @@
-- if contact_detail.organization_membership_confirmed?
+- if organization_membership.organization_membership_confirmed?
   %span.label.callout.success Verified
 - else
   %span.label.callout.alert Not Verified

--- a/app/views/registrants/_usa_membership_status.html.haml
+++ b/app/views/registrants/_usa_membership_status.html.haml
@@ -10,6 +10,8 @@
   .small-6.columns
     USA Details
   .small-6.columns
+    = organization_membership.member_number
+    %br
     = organization_membership.system_status
 .row
   .small-12.columns

--- a/app/views/registrants/_usa_membership_status.html.haml
+++ b/app/views/registrants/_usa_membership_status.html.haml
@@ -7,9 +7,9 @@
       %span.help_bubble{ title: "More details" }
 
 .row.js--usa_member_status
-  .small-4.columns
+  .small-6.columns
     USA Details
-  .small-8.columns
+  .small-6.columns
     = organization_membership.system_status
 .row
   .small-12.columns

--- a/app/views/registrants/_usa_membership_status.html.haml
+++ b/app/views/registrants/_usa_membership_status.html.haml
@@ -2,7 +2,7 @@
   .small-6.columns
     USA membership status
   .small-6.column.js--usa_member_status
-    = render "/registrants/usa_membership_badge", contact_detail: contact_detail
+    = render "/registrants/usa_membership_badge", organization_membership: organization_membership
     = link_to usa_membership_welcome_path, target: "_blank" do
       %span.help_bubble{ title: "More details" }
 
@@ -10,10 +10,10 @@
   .small-4.columns
     USA Details
   .small-8.columns
-    = contact_detail.organization_membership_system_status
+    = organization_membership.system_status
 .row
   .small-12.columns
-    = link_to "Recheck USA Status", refresh_usa_status_registrant_path(contact_detail.registrant.bib_number), remote: true, method: :put, class: "js--usa_member_status_refresh"
+    = link_to "Recheck USA Status", refresh_usa_status_registrant_path(organization_membership.registrant.bib_number), remote: true, method: :put, class: "js--usa_member_status_refresh"
     .js--usa_member_refresh_notice.is--hidden
       Checking....
       %br

--- a/app/views/registrants/build/_contact_detail.html.haml
+++ b/app/views/registrants/build/_contact_detail.html.haml
@@ -6,6 +6,7 @@
     .row
       .small-12.large-6.columns
         = render "/registrants/build/contact_detail/team_affiliation", f: f
+        = render "/registrants/build/organization_membership/form", reg_f: reg_f
       .small-12.large-6.columns
         = render "/registrants/build/contact_detail/address", f: f, other_registrant: other_registrant
       .small-12.large-6.columns

--- a/app/views/registrants/build/add_contact_details.html.haml
+++ b/app/views/registrants/build/add_contact_details.html.haml
@@ -1,4 +1,5 @@
 - @registrant.build_contact_detail if @registrant.contact_detail.nil?
+- @registrant.create_organization_membership_record if @config.organization_membership_config?
 - @has_online_waiver = @config.online_waiver?
 - @has_rules = @config.accept_rules?
 - @other_registrant = (current_user.registrants.active - [@registrant]).last

--- a/app/views/registrants/build/contact_detail/_team_affiliation.html.haml
+++ b/app/views/registrants/build/contact_detail/_team_affiliation.html.haml
@@ -7,16 +7,3 @@
   .row
     .small-6.columns= f.label :club_contact
     .small-6.columns= f.text_field :club_contact, :size => 25
-  - if @config.organization_membership_config?
-    // USA does not have a "membership number"
-    - if @config.organization_membership_usa?
-      = render "/registrants/usa_membership_status", contact_detail: f.object
-    - else
-      .row
-        .small-6.columns
-          = f.label :organization_member_number, organization_membership_label(@config)
-        .small-6.columns
-          = f.text_field :organization_member_number, :size => 5, :class => "ui-tooltip",
-            title: t(".organization_membership_number_tooltip",
-            organization_type: t("organization_membership_types.#{@config.organization_membership_type}"),
-            convention_name: @config.short_name)

--- a/app/views/registrants/build/organization_membership/_form.html.haml
+++ b/app/views/registrants/build/organization_membership/_form.html.haml
@@ -1,17 +1,15 @@
 -# locals: reg_f
 - if @config.organization_membership_config?
-  // USA does not have a "membership number"
   %fieldset
+    = reg_f.simple_fields_for :organization_membership do |f|
+      %fieldset
+        .row
+          .small-6.columns
+            = f.label :manual_member_number, organization_membership_label(@config)
+          .small-6.columns
+            = f.text_field :manual_member_number, :size => 5, :class => "ui-tooltip",
+              title: t(".organization_membership_number_tooltip",
+              organization_type: t("organization_membership_types.#{@config.organization_membership_type}"),
+              convention_name: @config.short_name)
     - if @config.organization_membership_usa?
       = render "/registrants/usa_membership_status", organization_membership: reg_f.object.organization_membership
-    - else
-      = reg_f.simple_fields_for :organization_membership do |f|
-        %fieldset
-          .row
-            .small-6.columns
-              = f.label :manual_member_number, organization_membership_label(@config)
-            .small-6.columns
-              = f.text_field :manual_member_number, :size => 5, :class => "ui-tooltip",
-                title: t(".organization_membership_number_tooltip",
-                organization_type: t("organization_membership_types.#{@config.organization_membership_type}"),
-                convention_name: @config.short_name)

--- a/app/views/registrants/build/organization_membership/_form.html.haml
+++ b/app/views/registrants/build/organization_membership/_form.html.haml
@@ -1,0 +1,16 @@
+-# locals: reg_f
+- if @config.organization_membership_config?
+  // USA does not have a "membership number"
+  - if @config.organization_membership_usa?
+    = render "/registrants/usa_membership_status", organization_membership: reg_f.object.organization_membership
+  - else
+    = reg_f.simple_fields_for :organization_membership do |f|
+      %fieldset
+        .row
+          .small-6.columns
+            = f.label :manual_member_number, organization_membership_label(@config)
+          .small-6.columns
+            = f.text_field :manual_member_number, :size => 5, :class => "ui-tooltip",
+              title: t(".organization_membership_number_tooltip",
+              organization_type: t("organization_membership_types.#{@config.organization_membership_type}"),
+              convention_name: @config.short_name)

--- a/app/views/registrants/build/organization_membership/_form.html.haml
+++ b/app/views/registrants/build/organization_membership/_form.html.haml
@@ -1,16 +1,17 @@
 -# locals: reg_f
 - if @config.organization_membership_config?
   // USA does not have a "membership number"
-  - if @config.organization_membership_usa?
-    = render "/registrants/usa_membership_status", organization_membership: reg_f.object.organization_membership
-  - else
-    = reg_f.simple_fields_for :organization_membership do |f|
-      %fieldset
-        .row
-          .small-6.columns
-            = f.label :manual_member_number, organization_membership_label(@config)
-          .small-6.columns
-            = f.text_field :manual_member_number, :size => 5, :class => "ui-tooltip",
-              title: t(".organization_membership_number_tooltip",
-              organization_type: t("organization_membership_types.#{@config.organization_membership_type}"),
-              convention_name: @config.short_name)
+  %fieldset
+    - if @config.organization_membership_usa?
+      = render "/registrants/usa_membership_status", organization_membership: reg_f.object.organization_membership
+    - else
+      = reg_f.simple_fields_for :organization_membership do |f|
+        %fieldset
+          .row
+            .small-6.columns
+              = f.label :manual_member_number, organization_membership_label(@config)
+            .small-6.columns
+              = f.text_field :manual_member_number, :size => 5, :class => "ui-tooltip",
+                title: t(".organization_membership_number_tooltip",
+                organization_type: t("organization_membership_types.#{@config.organization_membership_type}"),
+                convention_name: @config.short_name)

--- a/app/views/welcome/usa_membership.html.haml
+++ b/app/views/welcome/usa_membership.html.haml
@@ -15,7 +15,7 @@
       %p
         During Registration, your membership will be checked against the
         = link_to "USA Membership Database", "https://unicyclingsocietyofamerica.wildapricot.org/join-us"
-        to confirm that your membership is currently valid. We will check it again before the first day of competition, to ensure that your membership has not lapsed.
+        to confirm that your membership is currently valid. We will check it again before the first day of competition, to ensure that your membership has not lapsed. The displayed User ID is the "User ID" of the membership database.
 
       %p
         All Competitors and Non-Competitors must be current USA Members.

--- a/app/workers/update_usa_membership_status_worker.rb
+++ b/app/workers/update_usa_membership_status_worker.rb
@@ -8,22 +8,30 @@ class UpdateUsaMembershipStatusWorker
     Rails.logger.debug "USA membership check for #{registrant_id}"
     registrant = Registrant.find(registrant_id)
 
-    contact_detail = registrant.contact_detail
-    return if contact_detail.blank? # Can't proceed without a place to store the result
+    organization_membership = registrant.create_organization_membership_record
 
-    checker = UsaMembershipChecker.new(registrant.first_name, registrant.last_name, registrant.birthday)
+    checker = UsaMembershipChecker.new(
+      first_name: registrant.first_name,
+      last_name: registrant.last_name,
+      birthdate: registrant.birthday,
+      usa_member_number: organization_membership.manual_member_number,
+      wildapricot_member_number: organization_membership.system_member_number
+    )
 
-    process_response(contact_detail, checker.current_member?)
+    if checker.current_member?
+      organization_membership.update(
+        system_confirmed: true,
+        system_member_number: checker.current_wildapricot_id,
+        system_status: "confirmed"
+      )
+    else
+      organization_membership.update(
+        system_confirmed: true,
+        system_status: "Not Confirmed"
+      )
+    end
   rescue JSON::ParserError => ex
     raise "Error (#{ex}) parsing response from USA database for #{request}"
-  end
-
-  # Take the response hash, and update the registrant record
-  def process_response(contact_detail, member)
-    contact_detail.update(
-      organization_membership_system_confirmed: member,
-      organization_membership_system_status: member ? "confirmed" : "Not Confirmed"
-    )
   end
 
   def event_is_usa?

--- a/app/workers/update_usa_membership_status_worker.rb
+++ b/app/workers/update_usa_membership_status_worker.rb
@@ -14,7 +14,7 @@ class UpdateUsaMembershipStatusWorker
       first_name: registrant.first_name,
       last_name: registrant.last_name,
       birthdate: registrant.birthday,
-      usa_member_number: organization_membership.manual_member_number,
+      manual_member_number: organization_membership.manual_member_number,
       wildapricot_member_number: organization_membership.system_member_number
     )
 
@@ -26,7 +26,7 @@ class UpdateUsaMembershipStatusWorker
       )
     else
       organization_membership.update(
-        system_confirmed: true,
+        system_confirmed: false,
         system_status: "Not Confirmed"
       )
     end

--- a/config/locales/models/contact_detail.da.yml
+++ b/config/locales/models/contact_detail.da.yml
@@ -18,8 +18,6 @@ da:
         emergency_relationship: Relation
         italian_fiscal_code: Skattekodeks påkrævet for italienske deltagere
         mobile: Mobiltelefon
-        organization_member_number: Unicykel organsition medlems nummer
-        organization_membership_system_status: Medlems status
         phone: Telefon
         responsible_adult_name: Navn
         responsible_adult_phone: Primære telfon

--- a/config/locales/models/contact_detail.de.yml
+++ b/config/locales/models/contact_detail.de.yml
@@ -19,8 +19,6 @@ de:
         italian_fiscal_code: Umsatzsteuer Ident Nummer (erforderlich für Italienische
           Teilnehmer)
         mobile: Mobiltelefonnummer
-        organization_member_number: Mitgliedsnummer des Einrad Verbandes
-        organization_membership_system_status: Mitglieds Status
         phone: Telefonnummer
         responsible_adult_name: Name
         responsible_adult_phone: Haupt Rufnummer

--- a/config/locales/models/contact_detail.en.yml
+++ b/config/locales/models/contact_detail.en.yml
@@ -22,8 +22,6 @@ en:
         phone: Phone
         responsible_adult_phone: Primary Phone
         responsible_adult_name: Name
-        organization_member_number: Unicycling Organization Membership Number
-        organization_membership_system_status: Membership Status
         zip: Zip
     models:
       contact_detail:

--- a/config/locales/models/contact_detail.es.yml
+++ b/config/locales/models/contact_detail.es.yml
@@ -18,8 +18,6 @@ es:
         emergency_relationship: Relación
         italian_fiscal_code: Código Fiscal (Requerido para participantes italianos)
         mobile: Móvil
-        organization_member_number: Número de membresía de Organización de Monociclismo
-        organization_membership_system_status: Estado de la membresía
         phone: Teléfono
         responsible_adult_name: Nombre
         responsible_adult_phone: Teléfono principal

--- a/config/locales/models/contact_detail.fr.yml
+++ b/config/locales/models/contact_detail.fr.yml
@@ -18,8 +18,6 @@ fr:
         emergency_relationship: Lien
         italian_fiscal_code: Code fiscal (Requis pour les participants Italiens)
         mobile: Numéro de portable
-        organization_member_number: Numéro d'adhérent fédéral
-        organization_membership_system_status: Statut de votre adhésion
         phone: Numéro de téléphone
         responsible_adult_name: Nom
         responsible_adult_phone: Numéro de téléphone principal

--- a/config/locales/models/contact_detail.it.yml
+++ b/config/locales/models/contact_detail.it.yml
@@ -18,8 +18,6 @@ it:
         emergency_relationship: Relazione
         italian_fiscal_code: Numero fiscale (Obbligatorio per i partecipanti italiani)
         mobile: Cellulare
-        organization_member_number: Numero di membro dell'organizzazione monociclistica
-        organization_membership_system_status: Stato dell'associato
         phone: Telefono
         responsible_adult_name: Nome
         responsible_adult_phone: Numero di telefono principale

--- a/config/locales/models/contact_detail.nl.yml
+++ b/config/locales/models/contact_detail.nl.yml
@@ -18,8 +18,6 @@ nl:
         emergency_relationship: Verwantschap
         italian_fiscal_code: Fiscale code (nodig voor Italiaanse deelnemers)
         mobile: Mobiel telefoonummer
-        organization_member_number: IUF lidnummer
-        organization_membership_system_status: Status van je lidmaatschap
         phone: Telefoon
         responsible_adult_name: Naam
         responsible_adult_phone: Telefoon

--- a/config/locales/models/organization_membership.da.yml
+++ b/config/locales/models/organization_membership.da.yml
@@ -1,0 +1,7 @@
+---
+da:
+  activerecord:
+    attributes:
+      organization_membership:
+        member_number: Unicykel organsition medlems nummer
+        system_status: Medlems status

--- a/config/locales/models/organization_membership.de.yml
+++ b/config/locales/models/organization_membership.de.yml
@@ -1,0 +1,7 @@
+---
+de:
+  activerecord:
+    attributes:
+      organization_membership:
+        member_number: Mitgliedsnummer des Einrad Verbandes
+        system_status: Mitglieds Status

--- a/config/locales/models/organization_membership.en.yml
+++ b/config/locales/models/organization_membership.en.yml
@@ -1,0 +1,11 @@
+---
+en:
+  activerecord:
+    attributes:
+      organization_membership:
+        member_number: Unicycling Organization Membership Number
+        system_status: Membership Status
+    models:
+      organization_membership:
+        one: Organization Membership
+        other: Organization Memberships

--- a/config/locales/models/organization_membership.es.yml
+++ b/config/locales/models/organization_membership.es.yml
@@ -1,0 +1,7 @@
+---
+es:
+  activerecord:
+    attributes:
+      organization_membership:
+        member_number: Número de membresía de Organización de Monociclismo
+        system_status: Estado de la membresía

--- a/config/locales/models/organization_membership.fr.yml
+++ b/config/locales/models/organization_membership.fr.yml
@@ -1,0 +1,7 @@
+---
+fr:
+  activerecord:
+    attributes:
+      organization_membership:
+        member_number: Numéro d'adhérent fédéral
+        system_status: Statut de votre adhésion

--- a/config/locales/models/organization_membership.it.yml
+++ b/config/locales/models/organization_membership.it.yml
@@ -1,0 +1,7 @@
+---
+it:
+  activerecord:
+    attributes:
+      organization_membership:
+        member_number: Numero di membro dell'organizzazione monociclistica
+        system_status: Stato dell'associato

--- a/config/locales/models/organization_membership.nl.yml
+++ b/config/locales/models/organization_membership.nl.yml
@@ -1,0 +1,7 @@
+---
+nl:
+  activerecord:
+    attributes:
+      organization_membership:
+        member_number: IUF lidnummer
+        system_status: Status van je lidmaatschap

--- a/config/locales/views/registrants/build/contact_detail/team_affiliation.da.yml
+++ b/config/locales/views/registrants/build/contact_detail/team_affiliation.da.yml
@@ -4,6 +4,4 @@ da:
     build:
       contact_detail:
         team_affiliation:
-          organization_membership_number_tooltip: Et %{organization_type} Medlemsskab
-            er påkrævet for at deltage i %{convention_name}
           team_affiliation: Hold tilknytning

--- a/config/locales/views/registrants/build/contact_detail/team_affiliation.de.yml
+++ b/config/locales/views/registrants/build/contact_detail/team_affiliation.de.yml
@@ -4,6 +4,4 @@ de:
     build:
       contact_detail:
         team_affiliation:
-          organization_membership_number_tooltip: Eine %{organization_type} Mitgliedschaft
-            ist erforderlich um an der %{convention_name} teilnehmen zu können
           team_affiliation: Team Zugehörigkeit

--- a/config/locales/views/registrants/build/contact_detail/team_affiliation.en.yml
+++ b/config/locales/views/registrants/build/contact_detail/team_affiliation.en.yml
@@ -5,5 +5,3 @@ en:
       contact_detail:
         team_affiliation:
           team_affiliation: Team Affiliation
-          organization_membership_number_tooltip: A %{organization_type} membership is required to participate at
-            %{convention_name}

--- a/config/locales/views/registrants/build/contact_detail/team_affiliation.es.yml
+++ b/config/locales/views/registrants/build/contact_detail/team_affiliation.es.yml
@@ -4,6 +4,4 @@ es:
     build:
       contact_detail:
         team_affiliation:
-          organization_membership_number_tooltip: Se requiere una membresía a la %{organization_type}
-            para participar en %{convention_name}
           team_affiliation: Afiliación al Equipo

--- a/config/locales/views/registrants/build/contact_detail/team_affiliation.fr.yml
+++ b/config/locales/views/registrants/build/contact_detail/team_affiliation.fr.yml
@@ -4,6 +4,4 @@ fr:
     build:
       contact_detail:
         team_affiliation:
-          organization_membership_number_tooltip: Une adhésion à la %{organization_type}
-            est requise pour participer à %{convention_name}
           team_affiliation: Appartenance à une équipe

--- a/config/locales/views/registrants/build/organization_membership/form.da.yml
+++ b/config/locales/views/registrants/build/organization_membership/form.da.yml
@@ -1,0 +1,8 @@
+---
+da:
+  registrants:
+    build:
+      organization_membership:
+        form:
+          organization_membership_number_tooltip: Et %{organization_type} Medlemsskab
+            er påkrævet for at deltage i %{convention_name}

--- a/config/locales/views/registrants/build/organization_membership/form.de.yml
+++ b/config/locales/views/registrants/build/organization_membership/form.de.yml
@@ -1,0 +1,8 @@
+---
+de:
+  registrants:
+    build:
+      organization_membership:
+        form:
+          organization_membership_number_tooltip: Eine %{organization_type} Mitgliedschaft
+            ist erforderlich um an der %{convention_name} teilnehmen zu können

--- a/config/locales/views/registrants/build/organization_membership/form.en.yml
+++ b/config/locales/views/registrants/build/organization_membership/form.en.yml
@@ -1,0 +1,8 @@
+---
+en:
+  registrants:
+    build:
+      organization_membership:
+        form:
+          organization_membership_number_tooltip: A %{organization_type} membership is required to participate at
+            %{convention_name}

--- a/config/locales/views/registrants/build/organization_membership/form.es.yml
+++ b/config/locales/views/registrants/build/organization_membership/form.es.yml
@@ -1,0 +1,8 @@
+---
+es:
+  registrants:
+    build:
+      organization_membership:
+        form:
+          organization_membership_number_tooltip: Se requiere una membresía a la %{organization_type}
+            para participar en %{convention_name}

--- a/config/locales/views/registrants/build/organization_membership/form.fr.yml
+++ b/config/locales/views/registrants/build/organization_membership/form.fr.yml
@@ -1,0 +1,8 @@
+---
+fr:
+  registrants:
+    build:
+      organization_membership:
+        form:
+          organization_membership_number_tooltip: Une adhésion à la %{organization_type}
+            est requise pour participer à %{convention_name}

--- a/db/migrate/20190121220246_create_membership_table.rb
+++ b/db/migrate/20190121220246_create_membership_table.rb
@@ -1,0 +1,13 @@
+class CreateMembershipTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :organization_memberships do |t|
+      t.references :registrant
+      t.string :manual_member_number
+      t.string :system_member_number
+      t.boolean :manually_confirmed, default: false, null: false
+      t.boolean :system_confirmed, default: false, null: false
+      t.string :system_status
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181126020943) do
+ActiveRecord::Schema.define(version: 20190121220246) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -727,6 +727,18 @@ ActiveRecord::Schema.define(version: 20181126020943) do
     t.boolean "alternate", default: false, null: false
     t.index ["competitor_id"], name: "index_members_competitor_id"
     t.index ["registrant_id"], name: "index_members_registrant_id"
+  end
+
+  create_table "organization_memberships", force: :cascade do |t|
+    t.bigint "registrant_id"
+    t.string "manual_member_number"
+    t.string "system_member_number"
+    t.boolean "manually_confirmed", default: false, null: false
+    t.boolean "system_confirmed", default: false, null: false
+    t.string "system_status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["registrant_id"], name: "index_organization_memberships_on_registrant_id"
   end
 
   create_table "page_images", id: :serial, force: :cascade do |t|

--- a/lib/tasks/one_time.rake
+++ b/lib/tasks/one_time.rake
@@ -8,6 +8,7 @@ namespace :one_time do
          contact_detail.organization_membership_manually_confirmed? ||
          contact_detail.organization_membership_system_confirmed?
         organization_membership = registrant.create_organization_membership_record
+        organization_membership.legacy_member_number = contact_detail.organization_member_number
         organization_membership.manual_member_number = contact_detail.organization_member_number
         organization_membership.manually_confirmed = contact_detail.manually_confirmed
 

--- a/lib/tasks/one_time.rake
+++ b/lib/tasks/one_time.rake
@@ -8,7 +8,6 @@ namespace :one_time do
          contact_detail.organization_membership_manually_confirmed? ||
          contact_detail.organization_membership_system_confirmed?
         organization_membership = registrant.create_organization_membership_record
-        organization_membership.legacy_member_number = contact_detail.organization_member_number
         organization_membership.manual_member_number = contact_detail.organization_member_number
         organization_membership.manually_confirmed = contact_detail.manually_confirmed
 

--- a/lib/tasks/one_time.rake
+++ b/lib/tasks/one_time.rake
@@ -1,0 +1,22 @@
+namespace :one_time do
+  desc "Migrate from ContactDetail to OrganizationMembership"
+  task migrate_memberships: :environment do
+    puts "Migrating Organization Memberships from ContactDetail..."
+    ContactDetail.includes(:registrant).all.find_each do |contact_detail|
+      registrant = contact_detail.registrant
+      if contact_detail.organization_member_number.present? ||
+         contact_detail.organization_membership_manually_confirmed? ||
+         contact_detail.organization_membership_system_confirmed?
+        organization_membership = registrant.create_organization_membership_record
+        organization_membership.manual_member_number = contact_detail.organization_member_number
+        organization_membership.manually_confirmed = contact_detail.manually_confirmed
+
+        organization_membership.system_confirmed = contact_detail.system_confirmed
+        organization_membership.system_status = contact_detail.system_status
+        organization_membership.updated_at = contact_detail.updated_at
+        organization_membership.save
+      end
+    end
+    puts "Done"
+  end
+end

--- a/spec/actions/exporters/organization_memberships_exporter_spec.rb
+++ b/spec/actions/exporters/organization_memberships_exporter_spec.rb
@@ -8,7 +8,7 @@ describe Exporters::OrganizationMembershipsExporter do
   it "outputs some rows" do
     exporter = described_class.new(Registrant.all)
     expect(exporter.headers).to include("Id")
-    expect(exporter.headers).to include("Organization Membership#")
+    expect(exporter.headers).to include("Manual Organization Membership#")
     expect(exporter.rows.count).to eq(5)
   end
 end

--- a/spec/actions/usa_membership_checker_spec.rb
+++ b/spec/actions/usa_membership_checker_spec.rb
@@ -6,7 +6,7 @@ describe UsaMembershipChecker do
       first_name: first_name,
       last_name: last_name,
       birthdate: birthday,
-      usa_member_number: usa_member_number,
+      manual_member_number: usa_member_number,
       wildapricot_member_number: wildapricot_member_number
     )
   end

--- a/spec/actions/usa_membership_checker_spec.rb
+++ b/spec/actions/usa_membership_checker_spec.rb
@@ -1,14 +1,25 @@
 require 'spec_helper'
 
 describe UsaMembershipChecker do
-  subject(:subject) { described_class.new(first_name, last_name, birthday) }
+  subject(:subject) do
+    described_class.new(
+      first_name: first_name,
+      last_name: last_name,
+      birthdate: birthday,
+      usa_member_number: usa_member_number,
+      wildapricot_member_number: wildapricot_member_number
+    )
+  end
 
   let(:first_name) { "John" }
   let(:last_name) { "Smith" }
   let(:birthday) { Date.new(2000, 1, 1) }
+  let(:usa_member_number) { nil }
+  let(:wildapricot_member_number) { nil }
   let(:good_response) do
     [
       {
+        "Id" => "12345",
         "FirstName" => "John",
         "LastName" => "Smith",
         "MembershipEnabled" => true,
@@ -48,6 +59,7 @@ describe UsaMembershipChecker do
 
     it "is a current member" do
       expect(subject).to be_current_member
+      expect(subject.current_wildapricot_id).to eq("12345")
     end
   end
 
@@ -58,6 +70,7 @@ describe UsaMembershipChecker do
 
     it "is not a current member" do
       expect(subject).not_to be_current_member
+      expect(subject.current_wildapricot_id).to be_nil
     end
   end
 end

--- a/spec/controllers/organization_memberships_controller_spec.rb
+++ b/spec/controllers/organization_memberships_controller_spec.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: organization_memberships
+#
+#  id                   :bigint(8)        not null, primary key
+#  registrant_id        :bigint(8)
+#  manual_member_number :string
+#  system_member_number :string
+#  manually_confirmed   :boolean          default(FALSE), not null
+#  system_confirmed     :boolean          default(FALSE), not null
+#  system_status        :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
+# Indexes
+#
+#  index_organization_memberships_on_registrant_id  (registrant_id)
+#
+
 require 'spec_helper'
 
 describe OrganizationMembershipsController do
@@ -10,7 +29,7 @@ describe OrganizationMembershipsController do
   end
 
   let(:registrant) { FactoryBot.create(:registrant) }
-  let(:contact_detail) { registrant.contact_detail }
+  let(:organization_membership) { registrant.organization_membership }
 
   describe "#index" do
     it "can list all members" do
@@ -23,20 +42,20 @@ describe OrganizationMembershipsController do
     context "when the user is not yet confirmed" do
       it "can confirm" do
         put :toggle_confirm, params: { id: registrant.id }
-        expect(registrant.reload.contact_detail).to be_organization_membership_manually_confirmed
+        expect(registrant.reload.organization_membership).to be_manually_confirmed
       end
       it "can confirm with JS" do
         put :toggle_confirm, params: { id: registrant.id, format: :js }
-        expect(registrant.reload.contact_detail).to be_organization_membership_manually_confirmed
+        expect(registrant.reload.organization_membership).to be_manually_confirmed
       end
     end
 
     context "when the user is a confirmed member" do
-      before { contact_detail.update_attribute(:organization_membership_manually_confirmed, true) }
+      before { organization_membership.update_attribute(:manually_confirmed, true) }
 
       it "can unconfirm" do
         put :toggle_confirm, params: { id: registrant.id }
-        expect(registrant.reload.contact_detail).not_to be_organization_membership_manually_confirmed
+        expect(registrant.reload.organization_membership).not_to be_manually_confirmed
       end
     end
   end
@@ -46,7 +65,7 @@ describe OrganizationMembershipsController do
 
     it "saves the membership number" do
       put :update_number, params: { id: registrant.id, membership_number: new_member_number }, format: :js
-      expect(registrant.reload.contact_detail.organization_member_number).to eq new_member_number
+      expect(registrant.reload.organization_membership.system_member_number).to eq new_member_number
     end
   end
 

--- a/spec/controllers/organization_memberships_controller_spec.rb
+++ b/spec/controllers/organization_memberships_controller_spec.rb
@@ -65,7 +65,7 @@ describe OrganizationMembershipsController do
 
     it "saves the membership number" do
       put :update_number, params: { id: registrant.id, membership_number: new_member_number }, format: :js
-      expect(registrant.reload.organization_membership.system_member_number).to eq new_member_number
+      expect(registrant.reload.organization_membership.manual_member_number).to eq new_member_number
     end
   end
 

--- a/spec/controllers/registrants/build_controller_spec.rb
+++ b/spec/controllers/registrants/build_controller_spec.rb
@@ -29,7 +29,6 @@ describe Registrants::BuildController do
         zip: "12345",
         club: "TCUC",
         club_contact: "Connie",
-        organization_member_number: "12345",
         email: "fake@example.com",
         volunteer: false,
         emergency_name: "Jane",
@@ -39,6 +38,9 @@ describe Registrants::BuildController do
         emergency_other_phone: "911",
         responsible_adult_name: "Andy",
         responsible_adult_phone: "312-555-5555"
+      },
+      organization_membership_attributes: {
+        manual_member_number: "12345"
       }
     }
   end

--- a/spec/controllers/registrants_controller_spec.rb
+++ b/spec/controllers/registrants_controller_spec.rb
@@ -61,7 +61,6 @@ describe RegistrantsController do
         zip: "12345",
         club: "TCUC",
         club_contact: "Connie",
-        organization_member_number: "12345",
         volunteer: false,
         emergency_name: "Jane",
         emergency_relationship: "Sig. Oth.",
@@ -70,6 +69,9 @@ describe RegistrantsController do
         emergency_other_phone: "911",
         responsible_adult_name: "Andy",
         responsible_adult_phone: "312-555-5555"
+      },
+      organization_membership_attributes: {
+        member_number: "12345"
       }
     }
   end

--- a/spec/factories/contact_details.rb
+++ b/spec/factories/contact_details.rb
@@ -52,7 +52,6 @@ FactoryBot.define do
     sequence(:email) { |n| "EmailMyString+#{n}@example.com" }
     club { "TCUC" }
     club_contact { "Connie Cotter" }
-    organization_member_number { "00001" }
     emergency_name { "Jane Doe" }
     emergency_relationship { "SO" }
     emergency_attending { false }

--- a/spec/factories/organization_memberships.rb
+++ b/spec/factories/organization_memberships.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: organization_memberships
+#
+#  id                   :bigint(8)        not null, primary key
+#  registrant_id        :bigint(8)
+#  manual_member_number :string
+#  system_member_number :string
+#  manually_confirmed   :boolean          default(FALSE), not null
+#  system_confirmed     :boolean          default(FALSE), not null
+#  system_status        :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
+# Indexes
+#
+#  index_organization_memberships_on_registrant_id  (registrant_id)
+#
+
+# Read about factories at https://github.com/thoughtbot/factory_bot
+
+FactoryBot.define do
+  factory :organization_membership do
+    manual_member_number { "00001" }
+    system_member_number { "00001" }
+  end
+end


### PR DESCRIPTION
- Separates the manual-id-number from the system-gathered id value.
- Searches the wildapricot DB in multiple ways, to try to find a match
- stores the wildapricot ID in the db.
