### PR TITLE
More fixing of wysiwyg links

### DIFF
--- a/app/assets/javascripts/wysiwyg.js
+++ b/app/assets/javascripts/wysiwyg.js
@@ -10,7 +10,8 @@ tinymce.init({
   ,
   toolbar: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image | print preview media | forecolor backcolor emoticons",
   image_advtab: true,
-  relative_urls : false,
+  relative_urls: false,
+  convert_urls: false,
   // templates: [
   //   {title: 'Test template 1', content: 'Test 1'},
   //   {title: 'Test template 2', content: 'Test 2'}


### PR DESCRIPTION
specifying only `relative_urls` caused the urls to be `/something/else`, instead of `../else`, but we still want the hostname.