### PR TITLE
When all events options are not-allowed (aka: on-site with locked reg…

### DIFF
--- a/app/controllers/registrants/build_controller.rb
+++ b/app/controllers/registrants/build_controller.rb
@@ -187,6 +187,6 @@ class Registrants::BuildController < ApplicationController
   end
 
   def registrant_params
-    params.require(:registrant).permit(attributes)
+    params.fetch(:registrant, {}).permit(attributes)
   end
 end


### PR DESCRIPTION
… options),

still want to allow the controller action to succeed