### PR TITLE
PaymentDetail expects amount to have period as separator.

### DIFF
--- a/app/views/payments/_form_contents.html.haml
+++ b/app/views/payments/_form_contents.html.haml
@@ -32,7 +32,8 @@
           = pf.hidden_field :free
         %td= print_item_cost_currency(pf.object.tax)
         %td
-          = pf.hidden_field :amount, value: number_to_currency(pf.object.amount, format: "%n")
+          -# This must be in the format of "12.34" (no commas)
+          = pf.hidden_field :amount, value: pf.object.amount.format(separator: ".", symbol: nil, thousands_separator: nil)
           = print_item_cost_currency(pf.object.amount)
         %td.choose_payments
           = pf.check_box :_destroy, {checked: true, :class => "delete_payment_item js--costItem", data: { cents: pf.object.amount.to_f * 100 } }, '0', '1'


### PR DESCRIPTION
In german (and others) the separator is comma, so we have
to specify it explicitly