### PR TITLE
Catch stripe exceptions, and display the error message to the user.

### DIFF
--- a/app/controllers/stripe_payments_controller.rb
+++ b/app/controllers/stripe_payments_controller.rb
@@ -34,6 +34,9 @@ class StripePaymentsController < ApplicationController
       end
     end
     redirect_to payment_path(payment), alert: "Error processing payment"
+  rescue Stripe::CardError => e
+    Rollbar.error(e)
+    redirect_to Payment_path(payment), alert: "Error processing payment #{e.error.message}"
   end
 
   def create_charge(token)


### PR DESCRIPTION
Hopefully this will make it clearer to the user that the problem
is with their card/processor