### PR TITLE
limit stripe description to 499 characters.

### DIFF
--- a/app/controllers/stripe_payments_controller.rb
+++ b/app/controllers/stripe_payments_controller.rb
@@ -43,7 +43,7 @@ class StripePaymentsController < ApplicationController
     Stripe::Charge.create(
       amount: payment.total_amount.cents,
       currency: @config.currency_code,
-      description: @payment.long_description,
+      description: @payment.long_description.truncate(499),
       source: token,
       metadata: metadata
     )

--- a/app/controllers/stripe_payments_controller.rb
+++ b/app/controllers/stripe_payments_controller.rb
@@ -52,7 +52,7 @@ class StripePaymentsController < ApplicationController
   def metadata
     {
       payment_id: payment.id,
-      details: payment.long_description
+      details: payment.long_description.truncate(499)
     }
   end
 end


### PR DESCRIPTION
We received errors which say that the description must be less than 500 characters