### PR TITLE
We don't need to refresh the cert now.

### DIFF
--- a/app/jobs/tenant_creation_job.rb
+++ b/app/jobs/tenant_creation_job.rb
@@ -6,7 +6,6 @@ class TenantCreationJob < ApplicationJob
     Apartment::Tenant.switch(tenant.subdomain) do
       Rails.application.load_seed
       Notifications.new_convention_created(tenant.description, tenant.subdomain).deliver_later
-      ApartmentAcmeClient::RenewalService.run! unless Rails.env.test?
     end
   end
 end


### PR DESCRIPTION
We have a wildcard cert. So we only need a new cert when
a new custom domain is configured