### PR TITLE
Add a new stripe mode, for advanced stripe payment

### DIFF
--- a/app/actions/stripe_webhook/manager.rb
+++ b/app/actions/stripe_webhook/manager.rb
@@ -1,0 +1,60 @@
+# Manage the stripe webhook callbacks
+
+module StripeWebhook
+  class Manager
+    WEBHOOK_NAME = "checkout.session.completed".freeze
+    attr_reader :stripe_secret_key, :domain
+
+    def initialize(stripe_secret_key, domain)
+      @stripe_secret_key = stripe_secret_key
+      @domain = domain
+    end
+
+    def register_callback
+      set_api_key
+
+      Stripe::WebhookEndpoint.create(
+        url: url,
+        enabled_events: enabled_events,
+        api_version: "2019-12-03"
+      )
+    end
+
+    def unregister_callback
+      set_api_key
+      existing_webhook = webhook?
+      return unless existing_webhook
+
+      Stripe::WebhookEndpoint.delete(existing_webhook)
+    end
+
+    # determine whether the necessary webhook exists
+    # return the ID of the webhook, if present
+    # return nil otherwise
+    def webhook?
+      set_api_key
+      hooks = Stripe::WebhookEndpoint.list
+      matching_hook = hooks.detect do |hook|
+        hook.url == url
+      end
+
+      matching_hook&.id
+    end
+
+    private
+
+    def set_api_key
+      Stripe.api_key = @stripe_secret_key
+    end
+
+    def url
+      "#{domain}/webhook/endpoint"
+    end
+
+    def enabled_events
+      [
+        WEBHOOK_NAME
+      ]
+    end
+  end
+end

--- a/app/actions/stripe_webhook/verifier.rb
+++ b/app/actions/stripe_webhook/verifier.rb
@@ -1,0 +1,33 @@
+# Manage the stripe webhook callbacks
+
+module StripeWebhook
+  # verify that a received webhook is authentic
+  class Verifier
+    attr_reader :webhook_secret
+    def initialize(webhook_secret:)
+      @webhook_secret = webhook_secret
+    end
+
+    # check that the event is authentic
+    # and return av event object
+    # return false if invalid
+    def verify_and_decode(body:, headers:)
+      header = headers["Stripe-Signature"]
+      begin
+        event = Stripe::Webhook.construct_event(
+          body, header, webhook_secret
+        )
+      rescue JSON::ParserError => e
+        Rollbar.error(e)
+        # Invalid payload
+        return false
+      rescue Stripe::SignatureVerificationError => e
+        Rollbar.error(e)
+        # Invalid signature
+        return false
+      end
+
+      event
+    end
+  end
+end

--- a/app/controllers/stripe_payments_controller.rb
+++ b/app/controllers/stripe_payments_controller.rb
@@ -1,3 +1,4 @@
+# Handles the "old" stripe way, without webhooks
 class StripePaymentsController < ApplicationController
   before_action :skip_authorization
   skip_before_action :verify_authenticity_token
@@ -21,7 +22,7 @@ class StripePaymentsController < ApplicationController
     token = params[:stripeToken]
 
     if payment.completed
-      PaymentMailer.ipn_received("Stripe Payment already completed. Invoice ID: " + paypal.order_number).deliver_later
+      PaymentMailer.ipn_received("Stripe Payment already completed. Invoice ID: " + payment.invoice_id).deliver_later
     else
       charge = create_charge(token)
       if charge.captured

--- a/app/controllers/stripe_webhooks_controller.rb
+++ b/app/controllers/stripe_webhooks_controller.rb
@@ -1,0 +1,52 @@
+# Handles receipt of a completed stripe checkout session
+# marks the related payment completed
+class StripeWebhooksController < ApplicationController
+  before_action :skip_authorization
+  skip_before_action :verify_authenticity_token
+
+  # Stripe webhook endpoint on receipt of a webhook
+  def create
+    unless @config.payment_type == "advanced_stripe"
+      Rollbar.error("Received stripe webhook without a configured secret", tenant: Apartment::Tenant.current)
+      return head :not_found
+    end
+
+    verifier = StripeWebhook::Verifier.new(webhook_secret: @config.stripe_webhook_secret)
+    event = verifier.verify_and_decode(body: request.body.read, headers: request.headers)
+
+    unless event
+      Rollbar.error("Received invalid stripe event", tenant: Apartment::Tenant.current)
+      return head :not_found
+    end
+
+    case event.type
+    when StripeWebhook::Manager::WEBHOOK_NAME
+      process_checkout_session(event.data.object)
+    end
+
+    head :ok
+  end
+
+  private
+
+  # find the associated payment, and mark it as complete
+  def process_checkout_session(checkout_session)
+    invoice_id = checkout_session.client_reference_id
+
+    payment = Payment.find_by(invoice_id: invoice_id)
+
+    if payment.nil?
+      PaymentMailer.ipn_received("Stripe Payment not found for invoice_id #{invoice_id}").deliver_later
+      return
+    end
+
+    if payment.completed
+      PaymentMailer.ipn_received("Stripe Payment already completed. Invoice ID: " + payment.invoice_id).deliver_later
+      return
+    end
+    payment_intent_id = checkout_session.payment_intent
+
+    payment.complete(transaction_id: payment_intent_id, payment_date: Time.current)
+    PaymentMailer.payment_completed(payment).deliver_later
+  end
+end

--- a/app/models/payment_detail_summary.rb
+++ b/app/models/payment_detail_summary.rb
@@ -37,6 +37,10 @@ class PaymentDetailSummary
     false
   end
 
+  def amount_cents
+    (amount.to_i * 100).round
+  end
+
   def ==(other)
     other.count == count &&
       other.payment_id == payment_id &&

--- a/app/policies/payment_policy.rb
+++ b/app/policies/payment_policy.rb
@@ -15,7 +15,7 @@ class PaymentPolicy < ApplicationPolicy
     !registration_closed? || super_admin?
   end
 
-  %i[create complete pay_offline apply_coupon].each do |meth|
+  %i[create advanced_stripe complete pay_offline apply_coupon].each do |meth|
     define_method("#{meth}?") do
       manage?
     end

--- a/app/views/payments/_stripe_advanced_payment_form.html.haml
+++ b/app/views/payments/_stripe_advanced_payment_form.html.haml
@@ -1,0 +1,2 @@
+= form_tag advanced_stripe_payment_path(payment) do
+  = submit_tag t("payments.stripe_payment_form.pay_with_stripe"), :class => "payment_link"

--- a/app/views/payments/advanced_stripe.html.erb
+++ b/app/views/payments/advanced_stripe.html.erb
@@ -1,0 +1,10 @@
+<script src="https://js.stripe.com/v3/"></script>
+<script>
+  var stripe = Stripe("<%= @config.stripe_public_key %>");
+  stripe.redirectToCheckout({
+    sessionId: "<%= @session_id %>"
+  }).then(function (result) {
+    alert("Error with stripe checkout");
+    alert(result.error.message);
+  });
+</script>

--- a/app/views/payments/show.html.haml
+++ b/app/views/payments/show.html.haml
@@ -15,11 +15,13 @@
   .row
     = t(".please_proceed_with_payment")
     - if @payment.total_amount > 0.to_money
-      - if @config.online_payment?
-        - if @config.paypal_account?
-          = render "paypal_payment_form", payment: @payment, config: @config
-        - elsif @config.stripe_secret_key?
-          = render "stripe_payment_form", payment: @payment, config: @config
+      - case @config.payment_type
+      - when "paypal"
+        = render "paypal_payment_form", payment: @payment, config: @config
+      - when "stripe"
+        = render "stripe_payment_form", payment: @payment, config: @config
+      - when "advanced_stripe"
+        = render "stripe_advanced_payment_form", payment: @payment, config: @config, payment_intent: @payment_intent
     - else
       = form_tag complete_payment_path(@payment) do
         = submit_tag t(".complete_payment"), class: "payment_link"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   get '422', to: 'errors#not_permitted'
   get '500', to: 'errors#internal_server_error'
 
+  post "/webhook/endpoint", to: "stripe_webhooks#create"
+
   scope "(:locale)", locale: /en|fr|de|hu|es|ja|ko|it|da|nl/ do
     resources :registrant_group_types, only: [:index] do
       shallow do
@@ -171,6 +173,7 @@ Rails.application.routes.draw do
         post :pay_offline
         post :apply_coupon
         post :stripe, controller: "stripe_payments"
+        post :advanced_stripe
       end
     end
     resources :pending_payments, only: [], controller: "admin/pending_payments" do

--- a/db/migrate/20200201192420_add_stripe_webhook_secret.rb
+++ b/db/migrate/20200201192420_add_stripe_webhook_secret.rb
@@ -1,0 +1,5 @@
+class AddStripeWebhookSecret < ActiveRecord::Migration[5.2]
+  def change
+    add_column :event_configurations, :stripe_webhook_secret, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_10_133523) do
+ActiveRecord::Schema.define(version: 2020_02_01_192420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -427,6 +427,7 @@ ActiveRecord::Schema.define(version: 2019_09_10_133523) do
     t.integer "medical_certificate_info_page_id"
     t.integer "volunteer_option_page_id"
     t.datetime "add_expenses_end_date"
+    t.string "stripe_webhook_secret"
   end
 
   create_table "event_confirmation_emails", force: :cascade do |t|


### PR DESCRIPTION
This enhances the pay-with-stripe functionality to provide for SCA (https://support.stripe.com/topics/strong-customer-authentication) support.

This will help prevent declining a creditcard in certain european counttries/banks.