### PR TITLE
Allow refunds to be specified with up to 5 decimal points.

### DIFF
--- a/app/models/manual_refund.rb
+++ b/app/models/manual_refund.rb
@@ -46,7 +46,7 @@ class ManualRefund
   attribute :note, String
 
   attribute :user, User
-  attribute :percentage, Integer
+  attribute :percentage, Float
   validates :note, :percentage, presence: true
   validate :at_least_one_refunded_element
 

--- a/app/views/admin/manual_payments/_pending_payments.html.haml
+++ b/app/views/admin/manual_payments/_pending_payments.html.haml
@@ -23,5 +23,5 @@
             %br
         %td
           = simple_form_for(pending_payment, url: pay_pending_payment_path(pending_payment), method: :post) do |pf|
-            = pf.input :note
+            = pf.input :note, maxlength: 255
             = pf.submit t(".mark_as_received", payment_number: pending_payment.id), class: "payment_link"

--- a/app/views/admin/manual_refunds/choose.html.haml
+++ b/app/views/admin/manual_refunds/choose.html.haml
@@ -9,18 +9,19 @@
     .small-6.columns.text-right
       = pf.label :note
     .small-6.columns
-      = pf.text_field :note
+      = pf.text_field :note, maxlength: 255
   .row
     .small-6.columns.text-right
       = pf.label :percentage
     .small-6.columns
-      = pf.number_field :percentage
+      = pf.number_field :percentage, step: 0.00001
 
   %h1= t(".paid_items")
   .payment_instructions= t(".choose_items")
   %table.sortable
     %thead
       %tr
+        %th= Registrant.human_attribute_name(:bib_number)
         %th= Registrant.model_name.human
         %th= ExpenseItem.model_name.human
         %th= ExpenseItem.human_attribute_name(:cost)
@@ -31,6 +32,8 @@
     %tbody
       = pf.fields_for :items do |paid_detail|
         %tr
+          %td
+            = paid_detail.object.registrant.bib_number
           %td
             = paid_detail.object.registrant
             = paid_detail.hidden_field :paid_detail_id
@@ -43,6 +46,7 @@
 
     %tfoot
       %tr
+        %th
         %th
         %th= ExpenseItem.human_attribute_name(:total)
         %th.js--total

--- a/app/views/payment_adjustments/exchange_choose.html.haml
+++ b/app/views/payment_adjustments/exchange_choose.html.haml
@@ -22,7 +22,7 @@
 
 = form_tag exchange_create_payment_adjustments_path do
   = label_tag :note
-  = text_field_tag :note
+  = text_field_tag :note, maxlength: 255
   %br
   = label_tag :registrant_id
   = select_tag :registrant_id, options_from_collection_for_select(@registrants, "id", "to_s")

--- a/app/views/payment_adjustments/onsite_pay_confirm.html.haml
+++ b/app/views/payment_adjustments/onsite_pay_confirm.html.haml
@@ -15,7 +15,7 @@
     Cheque
     %br
   = pf.label :note
-  = pf.text_field :note
+  = pf.text_field :note, maxlength: 255
   %h1 Paid Details
   %table.sortable
     %thead

--- a/app/views/payments/_summary.html.haml
+++ b/app/views/payments/_summary.html.haml
@@ -19,6 +19,7 @@
     \:
   %thead
     %tr
+      %th= Registrant.human_attribute_name(:bib_number)
       %th= t(".registrant")
       %th= RegistrantExpenseItem.model_name.human
       %th= t(".cost")
@@ -27,6 +28,7 @@
   %tbody
     - @payment.payment_details.each do |pd|
       %tr
+        %td= pd.registrant.bib_number
         %td
           = link_to pd.registrant, pd.registrant
         %td
@@ -38,6 +40,6 @@
         %td= print_item_cost_currency(pd.cost)
   %tfoot
     %tr
-      %th{:colspan => "3"}
+      %th{:colspan => "4"}
       %th= Payment.human_attribute_name(:total)
       %th= print_formatted_currency(payment.total_amount)

--- a/app/views/payments/show.html.haml
+++ b/app/views/payments/show.html.haml
@@ -31,7 +31,7 @@
       %fieldset.admin_payment.is--hidden
         = simple_form_for @payment, url: admin_complete_payment_path(@payment), method: :post do |f|
           -# Should make this only appear when clicked, and should outline it to make it a group.
-          = f.input :note
+          = f.input :note, maxlength: 255
           = f.submit "Mark as Paid (admin function)", class: "button warning"
       %br
 

--- a/app/views/refunds/show.html.haml
+++ b/app/views/refunds/show.html.haml
@@ -8,11 +8,13 @@
 %table.sortable
   %thead
     %tr
+      %th= Registrant.human_attribute_name(:bib_number)
       %th Registrant
       %th Item
   %tbody
     - @refund.refund_details.each do |detail|
       %tr
+        %td= detail.registrant.bib_number
         %td= detail.registrant
         %td= detail
 = link_to t('back'), user_payments_path(current_user)

--- a/db/migrate/20200403225808_change_refund_percentage_to_float.rb
+++ b/db/migrate/20200403225808_change_refund_percentage_to_float.rb
@@ -1,0 +1,11 @@
+class ChangeRefundPercentageToFloat < ActiveRecord::Migration[5.2]
+  def up
+    # up to 6 digits
+    # up to 5 digits after the decimal point
+    change_column :refunds, :percentage, :decimal, precision: 8, scale: 5
+  end
+
+  def down
+    change_column :refunds, :percentage, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_01_192420) do
+ActiveRecord::Schema.define(version: 2020_04_03_225808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -864,7 +864,7 @@ ActiveRecord::Schema.define(version: 2020_02_01_192420) do
     t.string "note"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer "percentage", default: 100
+    t.decimal "percentage", precision: 8, scale: 5, default: "100.0"
     t.index ["user_id"], name: "index_refunds_on_user_id"
   end
 

--- a/spec/controllers/admin/reg_fees_controller_spec.rb
+++ b/spec/controllers/admin/reg_fees_controller_spec.rb
@@ -16,7 +16,7 @@ describe Admin::RegFeesController do
   describe "POST change the reg fee" do
     before do
       @rp1 = FactoryBot.create(:registration_cost, start_date: Date.new(2010, 1, 1), end_date: Date.new(2012, 1, 1))
-      @rp2 = FactoryBot.create(:registration_cost, start_date: Date.new(2012, 1, 2), end_date: Date.new(2020, 2, 2))
+      @rp2 = FactoryBot.create(:registration_cost, start_date: Date.new(2012, 1, 2), end_date: 2.years.from_now)
       @reg = FactoryBot.create(:competitor)
     end
 

--- a/spec/models/refund_spec.rb
+++ b/spec/models/refund_spec.rb
@@ -41,4 +41,9 @@ describe Refund do
     @refund.note = ""
     expect(@refund.valid?).to eq(false)
   end
+
+  it "allows fractional percentages" do
+    @refund.percentage = 47.393
+    expect(@refund).to be_valid
+  end
 end


### PR DESCRIPTION
This allows us to give a refund of a certain dollar value,
by calculating the percentage refund to sufficient decimal places.

Also restrict the 'notes' field to 255 to prevent db save errors