### PR TITLE
remove develop branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,13 +126,18 @@ workflows:
           filters:
             branches:
               only:
-                - develop
+                - master
+      - approve-prod-push:
+          type: approval
+          requires:
+            - release_stage
+          filters:
+            branches:
+              only:
+                - master
       - release_prod:
           requires:
-            - rspec
-            - tablexi/rubocop
-            - tablexi/bundle_audit
-            - tablexi/check_db_schema
+            - approve-prod-push
           filters:
             branches:
               only:

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,5 +1,5 @@
 set :deploy_to, '/home/ec2-user/unicycling-registration'
 set :rails_env, 'stage'
-set :branch, ENV["CIRCLE_SHA1"] || ENV["REVISION"] || ENV["BRANCH_NAME"] || "develop"
+set :branch, ENV["CIRCLE_SHA1"] || ENV["REVISION"] || ENV["BRANCH_NAME"] || "master"
 
 server 'regtest.unicycling-software.com', user: 'ec2-user', roles: %w[web app db]


### PR DESCRIPTION
We are eliminating the 'develop' branch and using 'master' for both
staging and production deployments. This allows the same SHA to be
deployed both places, making it easier to track