### PR TITLE
Allow selling noncompetitor registration only

### DIFF
--- a/app/controllers/registrants_controller.rb
+++ b/app/controllers/registrants_controller.rb
@@ -52,7 +52,6 @@ class RegistrantsController < ApplicationController
     @shared_registrants = @user.accessible_registrants - @my_registrants
     @total_owing = @user.total_owing
     @has_print_waiver = @config.print_waiver?
-    @registrant = Registrant.new(user: @user)
 
     respond_to do |format|
       format.html # index.html.erb

--- a/app/models/event_configuration.rb
+++ b/app/models/event_configuration.rb
@@ -280,7 +280,7 @@ class EventConfiguration < ApplicationRecord
   end
 
   def registration_closed_date
-    reg_cost_closed_date = RegistrationCost.for_type("competitor").last_online_period.try(:end_date).try(:+, 1.day)
+    reg_cost_closed_date = RegistrationCost.last_online_period.try(:end_date).try(:+, 1.day)
     reg_cost_closed_date || event_sign_up_closed_date.try(:+, 1.day)
   end
 

--- a/app/policies/registrant_policy.rb
+++ b/app/policies/registrant_policy.rb
@@ -132,6 +132,8 @@ class RegistrantPolicy < ApplicationPolicy
   private
 
   def registration_type_for_sale?(registrant_type)
+    return true if RegistrationCost.for_type(registrant_type).none?
+
     RegistrationCost.for_type(registrant_type).current_period.present?
   end
 

--- a/app/policies/registrant_policy.rb
+++ b/app/policies/registrant_policy.rb
@@ -1,7 +1,9 @@
 class RegistrantPolicy < ApplicationPolicy
   # create a new registrant
   def create?
-    (user_record? && !new_registration_closed?) || super_admin?
+    return true if super_admin?
+
+    user_record? && !new_registration_closed? && registration_type_for_sale?(record.registrant_type)
   end
 
   def create_from_previous?
@@ -128,6 +130,10 @@ class RegistrantPolicy < ApplicationPolicy
   end
 
   private
+
+  def registration_type_for_sale?(registrant_type)
+    RegistrationCost.for_type(registrant_type).current_period.present?
+  end
 
   def user_record?
     record.user == user

--- a/app/views/registrants/_registrant_choices.html.haml
+++ b/app/views/registrants/_registrant_choices.html.haml
@@ -1,23 +1,10 @@
+- # receives competitor_registrant and noncompetitor_registrant objects
 .pricing_options
-  .pricing_option.recommended.competitor_sign_up
-    %h3.recommended_title= t('.recommended')
-    %h3.title= t('competitor')
-    - reg_cost = RegistrationCost.for_type("competitor").current_period
-    - if reg_cost && reg_cost.expense_items.any?
-      .current_price
-        - RegistrationCostPresenter.new(reg_cost).describe_entries do |entry_string|
-          = entry_string
-          %br
-      .price_note= print_time_until_prices_increase(reg_cost)
-    %ul.price_details
-      - EventConfiguration.singleton.competitor_benefits_list.each do |item|
-        %li= item
-    = link_to t(".create_new_competitor"), new_registrant_path(registrant_type: 'competitor'), class: "competitor_button"
-
-  - if @config.noncompetitors?
-    .pricing_option.non-competitor_sign_up
-      %h3.title= t('noncompetitor')
-      - reg_cost = RegistrationCost.for_type("noncompetitor").current_period
+  - if policy(competitor_registrant).create?
+    .pricing_option.recommended.competitor_sign_up
+      %h3.recommended_title= t('.recommended')
+      %h3.title= t('competitor')
+      - reg_cost = RegistrationCost.for_type("competitor").current_period
       - if reg_cost && reg_cost.expense_items.any?
         .current_price
           - RegistrationCostPresenter.new(reg_cost).describe_entries do |entry_string|
@@ -25,9 +12,25 @@
             %br
         .price_note= print_time_until_prices_increase(reg_cost)
       %ul.price_details
-        - EventConfiguration.singleton.noncompetitor_benefits_list.each do |item|
+        - EventConfiguration.singleton.competitor_benefits_list.each do |item|
           %li= item
-      = link_to t(".create_new_noncompetitor"), new_registrant_path(registrant_type: 'noncompetitor'), class: "noncompetitor_button"
+      = link_to t(".create_new_competitor"), new_registrant_path(registrant_type: 'competitor'), class: "competitor_button"
+
+  - if @config.noncompetitors?
+    - if policy(noncompetitor_registrant).create?
+      .pricing_option.non-competitor_sign_up
+        %h3.title= t('noncompetitor')
+        - reg_cost = RegistrationCost.for_type("noncompetitor").current_period
+        - if reg_cost && reg_cost.expense_items.any?
+          .current_price
+            - RegistrationCostPresenter.new(reg_cost).describe_entries do |entry_string|
+              = entry_string
+              %br
+          .price_note= print_time_until_prices_increase(reg_cost)
+        %ul.price_details
+          - EventConfiguration.singleton.noncompetitor_benefits_list.each do |item|
+            %li= item
+        = link_to t(".create_new_noncompetitor"), new_registrant_path(registrant_type: 'noncompetitor'), class: "noncompetitor_button"
 
   - if @config.spectators?
     .pricing_option.spectator_sign_up

--- a/app/views/registrants/index.html.haml
+++ b/app/views/registrants/index.html.haml
@@ -24,11 +24,13 @@
     %br
   %hr
 
-- if policy(@registrant).create? # until registration is closed
+- competitor_registrant = Registrant.new(user: @user, registrant_type: "competitor")
+- noncompetitor_registrant = Registrant.new(user: @user, registrant_type: "noncompetitor")
+- if policy(competitor_registrant).create? || policy(noncompetitor_registrant).create? # until registration is closed
   - if @config.additional_info?
     .sign_up_difference
       = link_to t(".whats_the_difference"), additional_information_url(@config, I18n.locale, "comp_noncomp"), class: "fancybox", title: t(".difference_tooltip")
-  = render "registrant_choices"
+  = render "registrant_choices", competitor_registrant: competitor_registrant, noncompetitor_registrant: noncompetitor_registrant
   = render "registrant_prices"
 - if @shared_registrants.count > 0
   %div


### PR DESCRIPTION
A request from one of the convention directors, they want to still be able to sell noncompetitor registration, without also selling competitor registration