### PR TITLE
Update the API response for Competitions to include an 'id' field and…

### DIFF
--- a/app/controllers/api/competitions_controller.rb
+++ b/app/controllers/api/competitions_controller.rb
@@ -23,15 +23,18 @@ class Api::CompetitionsController < ApplicationController
       results_pdfs = if competition.published?
                        competition.competition_results.active.map do |result|
                          {
+                           id: result.id,
                            name: result.to_s,
                            pdf: public_result_url(result),
-                           published_at: competition.published_at.iso8601
+                           published_at: result.published_date.iso8601
                          }
                        end
                      end
 
       {
-        name: [competition.award_title_name, competition.award_subtitle_name].compact.join(" - "),
+        id: competition.id,
+        name: competition.award_title_name,
+        subtitle: competition.award_subtitle_name,
         competitor_list_pdf: competitor_list_pdf,
         start_list_pdf: start_list_pdf,
         results: results_pdfs,

--- a/spec/factories/competition_results.rb
+++ b/spec/factories/competition_results.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     results_file { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', "sample.pdf"), "application/pdf") }
     system_managed { false }
     published { true }
-    published_date { Date.current }
+    published_date { DateTime.current }
     sequence(:name) { |n| "My new result#{n}" }
   end
 end


### PR DESCRIPTION
… other minor improvements

This accomplishes what https://github.com/rdunlop/unicycling-registration/pull/2114 intended, though with some minor adjustments.