### PR TITLE
Only show competitors on medical certificate review page

### DIFF
--- a/app/controllers/admin/medical_certificates_controller.rb
+++ b/app/controllers/admin/medical_certificates_controller.rb
@@ -4,7 +4,7 @@ class Admin::MedicalCertificatesController < ApplicationController
 
   # GET /admin/medical_certificates
   def index
-    @registrants = Registrant.active.includes(:contact_detail, :user)
+    @registrants = Registrant.competitor.active.includes(:contact_detail, :user)
   end
 
   private


### PR DESCRIPTION
We only ask competitors for medical certificate, so we should only review competitors for the same