### PR TITLE
move registration summary PDF expenses to after events.

### DIFF
--- a/app/views/registrants/_show_single_registrant.pdf.haml
+++ b/app/views/registrants/_show_single_registrant.pdf.haml
@@ -16,8 +16,6 @@
   .l--column{ class: "show_#{@registrant.registrant_type}_elements" }
     // this partial includes conditional-display logic..do not cache it
     = render :partial => "/registrants/summary", formats: :html
-    - cache_i18n ['pdf_expenses', @registrant, @registrant.members_cache_key, @config] do
-      = render :partial => "/registrants/registrant_expenses", formats: :html
     // contains caching
     = render partial: "/registrants/registrant_songs", formats: :html
   .l--column
@@ -26,4 +24,5 @@
         = render "/registrants/registrant_events_or_competition_assignments"
       - else
         = render :partial => "/registrants/registrant_events", formats: :html
-
+    - cache_i18n ['pdf_expenses', @registrant, @registrant.members_cache_key, @config] do
+      = render :partial => "/registrants/registrant_expenses", formats: :html


### PR DESCRIPTION
This should help page layout (was flowing onto 2 pages frequently)