### PR TITLE
Update 2019 rules calculation to round scores.

### DIFF
--- a/app/artistic_score_calculators/score_weight_calculator/weighted.rb
+++ b/app/artistic_score_calculators/score_weight_calculator/weighted.rb
@@ -13,6 +13,6 @@ class ScoreWeightCalculator::Weighted
 
       sum += score * score_weights[index]
     end
-    sum / 100.0
+    (sum / 100.0).round(4)
   end
 end

--- a/spec/artistic_score_calculators/score_weight_calculator/weighted_spec.rb
+++ b/spec/artistic_score_calculators/score_weight_calculator/weighted_spec.rb
@@ -10,4 +10,13 @@ RSpec.describe ScoreWeightCalculator::Weighted do
       expect(subject.total(score)).to eq(4.4)
     end
   end
+
+  describe "when the weights are 33 perc. each" do
+    let(:subject) { described_class.new([100.0 / 3, 100.0 / 3, 100.0 / 3]) }
+    let(:score) { [5, 9, 5] }
+
+    it "rounds to the nearest 4 digits" do
+      expect(subject.total(score)).to eq(6.3333)
+    end
+  end
 end


### PR DESCRIPTION
Otherwise, the scores might have many (too many) decimal places