### PR TITLE
Add ability for payment_admin to send a Manual-Payment.

### DIFF
--- a/app/controllers/admin/manual_payments_controller.rb
+++ b/app/controllers/admin/manual_payments_controller.rb
@@ -26,7 +26,11 @@ class Admin::ManualPaymentsController < ApplicationController
 
   def create
     @manual_payment = ManualPayment.new(params[:manual_payment])
-    @manual_payment.user = current_user
+    if params[:assign_to_registrant_user]
+      @manual_payment.assign_registrants_user = true
+    else
+      @manual_payment.user = current_user
+    end
 
     if @manual_payment.save
       payment = @manual_payment.created_payment

--- a/app/views/admin/manual_payments/choose.html.haml
+++ b/app/views/admin/manual_payments/choose.html.haml
@@ -48,6 +48,11 @@
           %th{ colspan: 2 }
           %th
 
+    %br
+    = check_box_tag(:assign_to_registrant_user, false)
+    = label_tag(:assign_to_registrant_user, "Assign this payment to the associated user (not to you)")
+    %br
+
     = submit_tag t(".submit"), :class => "payment_link"
 
 %div

--- a/app/views/payments/_summary.html.haml
+++ b/app/views/payments/_summary.html.haml
@@ -3,6 +3,10 @@
   %b= Payment.human_attribute_name(:payment_id)
   #{payment.id} - #{payment.invoice_id}
 
+%p
+  %b= User.model_name.human
+  = payment.user
+
 - if payment.completed
   %p
     %b= Payment.human_attribute_name(:transaction_id)

--- a/app/views/payments/show.html.haml
+++ b/app/views/payments/show.html.haml
@@ -9,6 +9,9 @@
     %p= t(".offline_payment_instructions_description")
     = @config.offline_payment_description.try(:html_safe)
 
+- if current_user != @payment.user
+  .alert-box.callout.secondary.top_banner Send this URL to the user (#{@payment.user}) in order to ask them to pay for these items
+
 - unless @payment.completed_or_offline?
   .row
     = render partial: 'add_coupon'

--- a/spec/controllers/admin/manual_payments_controller_spec.rb
+++ b/spec/controllers/admin/manual_payments_controller_spec.rb
@@ -59,5 +59,27 @@ describe Admin::ManualPaymentsController do
         expect(response).to redirect_to(new_manual_payment_path)
       end
     end
+
+    context "when choosing to choose the user automatically" do
+      let(:registrant) { rei.registrant }
+
+      it "assigns the user to the related registrant's user" do
+        expect do
+          post :create, params: {
+            manual_payment: {
+              unpaid_details_attributes: {
+                "0" => {
+                  registrant_expense_item_id: rei.id,
+                  pay_for: "1"
+                }
+              }
+            },
+            assign_to_registrant_user: "1"
+          }
+        end.to change(Payment, :count).by(1)
+        p = Payment.last
+        expect(p.user).to eq(registrant.user)
+      end
+    end
   end
 end


### PR DESCRIPTION
This allows creating/sending incomplete payments to
users for them to complete, without allowing them to
create payment records directly