### PR TITLE
More fixing of payment refunds export.

### DIFF
--- a/app/models/refund_detail.rb
+++ b/app/models/refund_detail.rb
@@ -36,6 +36,10 @@ class RefundDetail < ApplicationRecord
     payment_detail.update_attribute(:refunded, true) unless payment_detail.refunded?
   end
 
+  def amount_refunded
+    (percentage.to_f / 100) * payment_detail.amount
+  end
+
   def to_s
     payment_detail
   end

--- a/spec/actions/exporters/payment_refund_exporter_spec.rb
+++ b/spec/actions/exporters/payment_refund_exporter_spec.rb
@@ -10,6 +10,7 @@ describe Exporters::PaymentRefundExporter do
     it "returns some data" do
       data = exporter.rows
       expect(data.count).to eq(1)
+      expect(data[0][3]).not_to be_nil
     end
   end
 
@@ -40,13 +41,15 @@ describe Exporters::PaymentRefundExporter do
     let(:now) { DateTime.current }
     let!(:payment) { FactoryBot.create(:payment, :completed) }
     let(:payment_detail) { FactoryBot.create(:payment_detail, payment: payment) }
-    let!(:refund) { FactoryBot.create(:refund, refund_date: now) }
+    let!(:refund) { FactoryBot.create(:refund, refund_date: now, percentage: 90) }
     let!(:refund_detail) { FactoryBot.create(:refund_detail, payment_detail: payment_detail, refund: refund) }
 
     it "shows the refunded amount" do
       data = exporter.rows
       expect(data.count).to eq(1)
-      expect(data[0][5]).to eq(9.99.to_money)
+      expect(data[0][2]).to eq("9.99")
+      expect(data[0][4]).to eq(90)
+      expect(data[0][5]).to eq("8.99")
       expect(data[0][6]).to eq(now.iso8601)
     end
   end


### PR DESCRIPTION
The Money objects weren't appearing in the excel output. Also, this removes the multiple-refunds-on-a-single-line