### PR TITLE
Add eventdate to the iuf membership checking api call.

### DIFF
--- a/app/actions/membership_checker/iuf.rb
+++ b/app/actions/membership_checker/iuf.rb
@@ -46,7 +46,8 @@ module MembershipChecker
       [
         "first_name=#{first_name}",
         "last_name=#{last_name}",
-        "birthdate=#{birthdate.iso8601}"
+        "birthdate=#{birthdate.iso8601}",
+        "eventdate=#{EventConfiguration.singleton.estimated_end_date.iso8601}"
       ].join("&")
     end
 

--- a/app/models/event_configuration.rb
+++ b/app/models/event_configuration.rb
@@ -316,6 +316,11 @@ class EventConfiguration < ApplicationRecord
     age_calculation_base_date || start_date
   end
 
+  # Most unicons are 11-12 days long
+  def estimated_end_date
+    start_date + 12.days
+  end
+
   def registration_closed?
     return true if under_construction?
 

--- a/spec/actions/membership_checker/iuf_spec.rb
+++ b/spec/actions/membership_checker/iuf_spec.rb
@@ -49,4 +49,14 @@ describe MembershipChecker::Iuf do
       expect(subject.current_system_id).to be_nil
     end
   end
+
+  context "with an event configuration start date" do
+    before do
+      EventConfiguration.singleton.update(start_date: Date.new(2024, 7, 12))
+    end
+
+    it "has the correct request string" do
+      expect(subject.request_string).to eq("first_name=John&last_name=Smith&birthdate=2000-01-01&eventdate=2024-07-24")
+    end
+  end
 end


### PR DESCRIPTION
This passes the end-of-convention date to the IUF membership system, to ensure that registrants are valid members during the whole duration of the convention