### PR TITLE
Add event category grouping feature

### DIFF
--- a/.dockerenv/services
+++ b/.dockerenv/services
@@ -1,4 +1,4 @@
-DOMAIN=local.com:3000
+DOMAIN=lvh.me:3000
 SSL_ENABLED=false
 SECRET_KEY_BASE=XXXX
 

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'country_select'
 gem 'fancybox2-rails', github: 'sureswiftcapital/fancybox2-rails', branch: "rails6" # for rails 6 support
 gem 'foundation-rails'
 gem "haml-rails"
+gem 'importmap-rails'
 gem "jc-validates_timeliness"
 gem 'jquery-datatables-rails'
 gem 'jquery-datetimepicker-rails'
@@ -38,7 +39,6 @@ gem 'money-rails'
 gem 'recaptcha', require: 'recaptcha/rails'
 gem 'select2-rails'
 gem 'simple_form'
-gem 'importmap-rails'
 gem 'stimulus-rails'
 gem 'tinymce-rails'
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ gem 'money-rails'
 gem 'recaptcha', require: 'recaptcha/rails'
 gem 'select2-rails'
 gem 'simple_form'
+gem 'importmap-rails'
+gem 'stimulus-rails'
 gem 'tinymce-rails'
 
 # system utils

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,6 +344,9 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    importmap-rails (1.1.6)
+      actionpack (>= 6.0.0)
+      railties (>= 6.0.0)
     jc-validates_timeliness (3.1.1)
       timeliness (~> 0.3.7)
     jmespath (1.6.2)
@@ -631,6 +634,8 @@ GEM
       net-ssh (>= 2.8.0)
     ssrf_filter (1.1.1)
     state_machines (0.5.0)
+    stimulus-rails (1.2.1)
+      railties (>= 6.0.0)
     stripe (8.5.0)
     teaspoon (1.2.2)
       railties (>= 3.2.5)
@@ -726,6 +731,7 @@ DEPENDENCIES
   haml-rails
   hcaptcha
   http_accept_language
+  importmap-rails
   jc-validates_timeliness
   jquery-datatables-rails
   jquery-datetimepicker-rails
@@ -770,6 +776,7 @@ DEPENDENCIES
   simple_form
   spreadsheet
   sprockets (< 4)
+  stimulus-rails
   stripe
   teaspoon-jasmine
   tinymce-rails

--- a/README.md
+++ b/README.md
@@ -379,11 +379,9 @@ To do this:
 1. install `docker `and `docker-compose`.
 1. run `docker-compose up`
 1. Create the database schema with `docker-compose exec app bundle exec rake db:create db:schema:load`
-1. Add an entry to your /etc/hosts file `sudo vi /etc/hosts`: `127.0.0.1 www.local.com`
-1. open http://www.local.com:3000/new
+1. open http://test.lvh.me:3000/new
 1. Create a new database by using the "creation access code" of "Unplanned Dismount". Specify the subdomain as "test"
-1. Add an entry to your /etc/hosts file `sudo vi /etc/hosts`: `127.0.0.1 test.local.com`
-1. open http://test.local.com:3000, and then you can "Sign Up" in order to create a new user account.
+1. open http://test.lvh.me:3000, and then you can "Sign Up" in order to create a new user account.
 1. From the "My Account" page, you can use the "admin upgrade code" to make yourself into an admin.
 1. From the "User Management" page, you can grant yourself many more roles, allowing access to most of the remaining administrative tools. (Only Super-Admin users have access to more power)
 

--- a/app/controllers/convention_setup/event_category_grouping_entries_controller.rb
+++ b/app/controllers/convention_setup/event_category_grouping_entries_controller.rb
@@ -1,0 +1,48 @@
+class ConventionSetup::EventCategoryGroupingEntriesController < ConventionSetup::BaseConventionSetupController
+  include SortableObject
+
+  before_action :authorize_setup
+  before_action :set_ecge_breadcrumb
+
+  # GET /event_category_grouping_entries
+  def index
+    @event_category_grouping_entry = EventCategoryGroupingEntry.new
+    @event_category_groupings = EventCategoryGrouping.all
+    @event_categories = EventCategory.all
+  end
+
+  # POST /event_category_grouping_entries
+  def create
+    @event_category_grouping_entry = EventCategoryGroupingEntry.new(event_category_grouping_entry_params)
+    if @event_category_grouping_entry.save
+      redirect_to convention_setup_event_category_grouping_entries_path, notice: 'Category Grouping Entry was successfully created.'
+    else
+      @event_category_groupings = EventCategoryGrouping.all
+      @event_categories = EventCategory.all
+      render action: "index"
+    end
+  end
+
+  # DELETE /event_category_grouping_entries/1
+  def destroy
+    @event_category_grouping_entry = EventCategoryGroupingEntry.find(params[:id])
+    @event_category_grouping_entry.destroy
+    flash[:notice] = "Category Grouping Entry deleted"
+
+    redirect_to convention_setup_event_category_grouping_entries_path
+  end
+
+  private
+
+  def set_ecge_breadcrumb
+    add_breadcrumb "Event Category Groupings", convention_setup_event_category_grouping_entries_path
+  end
+
+  def authorize_setup
+    authorize @config, :setup_convention?
+  end
+
+  def event_category_grouping_entry_params
+    params.require(:event_category_grouping_entry).permit(:event_category_grouping_id, :event_category_id)
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,0 +1,2 @@
+// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import "controllers"

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,0 +1,9 @@
+import { Application } from "@hotwired/stimulus"
+
+const application = Application.start()
+
+// Configure Stimulus development experience
+application.debug = false
+window.Stimulus   = application
+
+export { application }

--- a/app/javascript/controllers/entries_matching_controller.js
+++ b/app/javascript/controllers/entries_matching_controller.js
@@ -55,29 +55,31 @@ export default class extends Controller {
     console.log("changeD")
     var target = event.target
 
-    // check each group to see if the currently selected value is in a group
-    this.groupsValue.forEach((group) => {
-      if (group.includes(parseInt(target.value))) {
-        // the currently selected value is in this group
-        console.log("GROUP CONTAINS VALUE")
+    // check all elements to see if they need to change
+    this.eventCategoryElementTargets.forEach((entry) => {
+      if (entry.value === '') return // isn't selected
+      if (entry == target) return // is self
 
-        // check all elements
-        // And find any which COULD select a value in this set
-        // But do not
-        this.eventCategoryElementTargets.forEach((entry) => {
-          if (entry.value === '') return // isn't selected
-          if (entry == target) return // is self
-          if (group.includes(parseInt(entry.value))) return // already in the same 'group'
+      // check each group to see if the currently selected value is in a group
+      var acceptableElementValues = this.groupsValue.filter( (group) => group.includes(parseInt(target.value))).flat()
 
-          var entryOptionValues = Array.from(entry.options).map(e => e.value);
+      if (acceptableElementValues.length == 0) return // current selected value isn't in a grouping
+      if (acceptableElementValues.includes(parseInt(entry.value))) return
+      // the currently selected value is in this group
+      console.log("GROUP CONTAINS VALUE")
 
-          // Does this element have a value which is in the target group?
-          var shouldSelect = entryOptionValues.filter( (optionValue) => group.includes(parseInt(optionValue)))
-          if (shouldSelect.length != 0) {
-            entry.value = shouldSelect[0]
-            alert("Changing value")
-          }
-        })
+      var entryOptionValues = Array.from(entry.options).map(e => e.value);
+
+      // Does this element have a value which is in the target group?
+      var shouldSelect = entryOptionValues.filter( (optionValue) => acceptableElementValues.includes(parseInt(optionValue)))
+      if (shouldSelect.length == 0) return
+      if (shouldSelect.length == 1) {
+        entry.value = shouldSelect[0]
+        alert("Changing value")
+      }
+      if (shouldSelect.length > 1) {
+        entry.value = ''
+        alert("Clearing value")
       }
     })
   }

--- a/app/javascript/controllers/entries_matching_controller.js
+++ b/app/javascript/controllers/entries_matching_controller.js
@@ -1,0 +1,91 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Entries Matching Controller
+//
+// On the Event Choices page, this enforces a requirement
+// that users choose "matching" event_categories
+//
+// Inputs:
+// groups:
+//   - This indicates the event_category_id which must all be set together
+//   - e.g. [[1, 2, 3], [4, 5]] indicates ids 1,2,3 are a group, and 4,5 are a group
+// event_category_element:
+//   - This is a select element which must be monitored
+//   - If this element value changes, we check ALL other select elements, and if any of them have
+//     not-in-this-set values, we display an alert message, AND change the OTHER value
+//
+// Example usage:
+// <div data-controller="entries-matching" data-entries-matching-groups-value="[[1,2,3],[4,5]]">
+//   <select data-entries-matching-target="eventCategoryElement">
+//     <option>
+//     <option value="1">
+//     <option value="4">
+//   </select>
+//
+//   <select data-entries-matching-target="eventCategoryElement">
+//     <option>
+//     <option value="2">
+//     <option value="5">
+//   </select>
+//
+//   <select data-entries-matching-target="eventCategoryElement">
+//     <option>
+//     <option value="3">
+//   </select>
+// </div>
+export default class extends Controller {
+
+  static targets = ["eventCategoryElement"]
+  static values = {
+    groups: Array
+  }
+
+  connect() {
+    console.log("Connected EntriesMatchingController")
+    console.log(this.groupsValue)
+  }
+
+  // Does the current element belong to a group?
+  // If so, check to see if any eventCategoryElement
+  // is selected to the OTHER values in that group
+  // IF they are, change their selection to the correct group value
+  // OR to blank
+  // AND show an alert
+  change(event) {
+    console.log("changeD")
+    var target = event.target
+
+    // check each group to see if the currently selected value is in a group
+    this.groupsValue.forEach((group) => {
+      if (group.includes(parseInt(target.value))) {
+        // the currently selected value is in this group
+        console.log("GROUP CONTAINS VALUE")
+
+        // check all elements
+        // And find any which COULD select a value in this set
+        // But do not
+        this.eventCategoryElementTargets.forEach((entry) => {
+          if (entry.value === '') return // isn't selected
+          if (entry == target) return // is self
+          if (group.includes(parseInt(entry.value))) return // already in the same 'group'
+
+          var entryOptionValues = Array.from(entry.options).map(e => e.value);
+
+          // Does this element have a value which is in the target group?
+          var shouldSelect = entryOptionValues.filter( (optionValue) => group.includes(parseInt(optionValue)))
+          if (shouldSelect.length != 0) {
+            entry.value = shouldSelect[0]
+            alert("Changing value")
+          }
+        })
+      }
+    })
+  }
+
+  // Each select element is automatically configured to trigger
+  // the 'change' action if the value is changed
+  eventCategoryElementTargetConnected(element) {
+    console.log("connecting target")
+    element.dataset.action = "entries-matching#change"
+  }
+}

--- a/app/javascript/controllers/entries_matching_controller.js
+++ b/app/javascript/controllers/entries_matching_controller.js
@@ -6,13 +6,17 @@ import { Controller } from "@hotwired/stimulus"
 // that users choose "matching" event_categories
 //
 // Inputs:
-// groups:
+// groups-value:
 //   - This indicates the event_category_id which must all be set together
 //   - e.g. [[1, 2, 3], [4, 5]] indicates ids 1,2,3 are a group, and 4,5 are a group
 // event_category_element:
 //   - This is a select element which must be monitored
 //   - If this element value changes, we check ALL other select elements, and if any of them have
 //     not-in-this-set values, we display an alert message, AND change the OTHER value
+// change-message-value:
+//   - This is a text message which will be presented when the javascript chooses to change a user's selection
+// clear-message-value:
+//   - This is a text message which will be presented when the javascript chooses to clear a user's selection
 //
 // Example usage:
 // <div data-controller="entries-matching" data-entries-matching-groups-value="[[1,2,3],[4,5]]">
@@ -37,12 +41,18 @@ export default class extends Controller {
 
   static targets = ["eventCategoryElement"]
   static values = {
-    groups: Array
+    groups: Array,
+    clearMessage: String,
+    changeMessage: String
   }
 
   connect() {
-    console.log("Connected EntriesMatchingController")
-    console.log(this.groupsValue)
+    if (this.clearMessageValue == '') {
+      this.clearMessageValue = "You must choose similar categories for your events. We have cleared one of your choices...please re-choose the appropriate category"
+    }
+    if (this.changeMessageValue == '') {
+      this.changeMessageValue = "You must compete in the same category in these events. We have updated your other event category to match"
+    }
   }
 
   // Does the current element belong to a group?
@@ -52,7 +62,6 @@ export default class extends Controller {
   // OR to blank
   // AND show an alert
   change(event) {
-    console.log("changeD")
     var target = event.target
 
     // check all elements to see if they need to change
@@ -66,7 +75,6 @@ export default class extends Controller {
       if (acceptableElementValues.length == 0) return // current selected value isn't in a grouping
       if (acceptableElementValues.includes(parseInt(entry.value))) return
       // the currently selected value is in this group
-      console.log("GROUP CONTAINS VALUE")
 
       var entryOptionValues = Array.from(entry.options).map(e => e.value);
 
@@ -75,11 +83,11 @@ export default class extends Controller {
       if (shouldSelect.length == 0) return
       if (shouldSelect.length == 1) {
         entry.value = shouldSelect[0]
-        alert("Changing value")
+        alert(this.changeMessageValue)
       }
       if (shouldSelect.length > 1) {
         entry.value = ''
-        alert("Clearing value")
+        alert(this.clearMessageValue)
       }
     })
   }
@@ -87,7 +95,6 @@ export default class extends Controller {
   // Each select element is automatically configured to trigger
   // the 'change' action if the value is changed
   eventCategoryElementTargetConnected(element) {
-    console.log("connecting target")
     element.dataset.action = "entries-matching#change"
   }
 }

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.element.textContent = "Hello World!"
+  }
+}

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,11 @@
+// Import and register all your controllers from the importmap under controllers/*
+
+import { application } from "controllers/application"
+
+// Eager load all controllers defined in the import map under controllers/**/*_controller
+import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
+eagerLoadControllersFrom("controllers", application)
+
+// Lazy load controllers as they appear in the DOM (remember not to preload controllers in import map!)
+// import { lazyLoadControllersFrom } from "@hotwired/stimulus-loading"
+// lazyLoadControllersFrom("controllers", application)

--- a/app/models/event_category_grouping.rb
+++ b/app/models/event_category_grouping.rb
@@ -1,0 +1,7 @@
+class EventCategoryGrouping < ApplicationRecord
+  has_many :event_category_grouping_entries, dependent: :restrict_with_error
+
+  def to_s
+    event_category_grouping_entries.map(&:event_category).map(&:to_s).join(", ")
+  end
+end

--- a/app/models/event_category_grouping_entry.rb
+++ b/app/models/event_category_grouping_entry.rb
@@ -1,0 +1,28 @@
+class EventCategoryGroupingEntry < ApplicationRecord
+  belongs_to :event_category_grouping
+  belongs_to :event_category
+
+  validates :event_category_id, uniqueness: { scope: [ :event_category_grouping_id] }
+
+  # If being created with a 'nil' event_category_grouping, automatically creates one
+  before_validation :create_event_category_grouping
+  around_destroy :delete_associated_event_category_grouping
+
+  # If being deleted, and is the last one in an event_category_grouping, automatically deletes one
+
+  private
+
+  def create_event_category_grouping
+    if event_category_grouping_id.blank?
+      self.event_category_grouping = EventCategoryGrouping.create
+    end
+  end
+
+  def delete_associated_event_category_grouping
+    ecg = event_category_grouping
+    yield
+    if ecg.reload.event_category_grouping_entries.count.zero?
+      ecg.destroy
+    end
+  end
+end

--- a/app/models/event_category_grouping_entry.rb
+++ b/app/models/event_category_grouping_entry.rb
@@ -2,7 +2,7 @@ class EventCategoryGroupingEntry < ApplicationRecord
   belongs_to :event_category_grouping
   belongs_to :event_category
 
-  validates :event_category_id, uniqueness: { scope: [ :event_category_grouping_id] }
+  validates :event_category_id, uniqueness: { scope: [:event_category_grouping_id] }
 
   # If being created with a 'nil' event_category_grouping, automatically creates one
   before_validation :create_event_category_grouping

--- a/app/views/attending/_event.html.haml
+++ b/app/views/attending/_event.html.haml
@@ -14,7 +14,7 @@
 
     - if !(event.event_categories.size == 1)
       %td.event_choice
-        = resu.input :event_category_id, collection: form.event_categories, as: :select , disabled: form.inaccessible_event_categories, include_blank: true, label: t('.category')
+        = resu.input :event_category_id, collection: form.event_categories, as: :select , disabled: form.inaccessible_event_categories, include_blank: true, label: t('.category'), input_html: { data: { entries_matching_target: "eventCategoryElement" }}
 
   - # Padding before EventChoices
   - if category.max_number_of_event_choices != event.num_choices

--- a/app/views/attending/_events.html.haml
+++ b/app/views/attending/_events.html.haml
@@ -1,6 +1,8 @@
 - @categories = categories
 - @registrant = registrant
-#tabs{ data: { controller: "entries-matching", entries_matching_groups_value: EventCategoryGrouping.all.map {|g| g.event_category_grouping_entries.map(&:event_category_id) } } }
+- content_for :importmap_modules do
+  = javascript_import_module_tag "controllers"
+#tabs{ data: { controller: "entries-matching", entries_matching_groups_value: EventCategoryGrouping.all.map {|g| g.event_category_grouping_entries.map(&:event_category_id) }, entries_matching_clear_message_value: t('.clear_selection_message'), entries_matching_change_message_value: t('.change_selection_message') } }
   %ul
     - @categories.each do |category|
       %li

--- a/app/views/attending/_events.html.haml
+++ b/app/views/attending/_events.html.haml
@@ -1,6 +1,6 @@
 - @categories = categories
 - @registrant = registrant
-#tabs
+#tabs{ data: { controller: "entries-matching", entries_matching_groups_value: "[[2,5,8]]" } }
   %ul
     - @categories.each do |category|
       %li

--- a/app/views/attending/_events.html.haml
+++ b/app/views/attending/_events.html.haml
@@ -1,6 +1,6 @@
 - @categories = categories
 - @registrant = registrant
-#tabs{ data: { controller: "entries-matching", entries_matching_groups_value: "[[2,5,8]]" } }
+#tabs{ data: { controller: "entries-matching", entries_matching_groups_value: EventCategoryGrouping.all.map {|g| g.event_category_grouping_entries.map(&:event_category_id) } } }
   %ul
     - @categories.each do |category|
       %li

--- a/app/views/convention_setup/categories/index.html.haml
+++ b/app/views/convention_setup/categories/index.html.haml
@@ -7,6 +7,8 @@
   %b= t("note")
   = t(".manage_events_note")
 
+%p
+  = link_to "Event Category Groupings", convention_setup_event_category_grouping_entries_path
 - if @categories.any?
   %h2= t(".existing_categories")
 

--- a/app/views/convention_setup/event_category_grouping_entries/_form.html.haml
+++ b/app/views/convention_setup/event_category_grouping_entries/_form.html.haml
@@ -1,0 +1,9 @@
+= simple_form_for([:convention_setup, @event_category_grouping_entry]) do |f|
+  = render partial: "shared/error_messages", object: @event_category_grouping_entry
+
+  - # If a BLANK is selected, we will create a new event_category_grouping
+  = f.input :event_category_grouping_id, collection: @event_category_groupings, include_blank: true, hint: "If you don't select one, a new group will be created"
+
+  = f.input :event_category_id, collection: @event_categories, label_method: :to_s, include_blank: true
+
+  = f.button :submit

--- a/app/views/convention_setup/event_category_grouping_entries/index.html.haml
+++ b/app/views/convention_setup/event_category_grouping_entries/index.html.haml
@@ -1,0 +1,26 @@
+%h1 Event Category Grouping Entries
+
+%p
+  By creating a group of Event Categories, the system will ensure that registrants choose all of the same group of event_categories.
+  %br
+  %b Example:
+  All "Beginner" or All "Advanced".
+
+%div
+%table
+  %thead
+    %tr
+      %th Group #
+      %th Entry
+      %th
+  %tbody
+    - @event_category_groupings.each do |event_category_grouping|
+      - event_category_grouping.event_category_grouping_entries.each do |ecge|
+        %tr
+          %td= event_category_grouping.id
+          %td= ecge.event_category
+          %td= link_to t("delete"), [:convention_setup, ecge], method: :delete, data: { confirm: t("are_you_sure") }
+
+%fieldset.form__fieldset
+  %h3= t(".new_event_category")
+  = render 'form'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,6 +1,8 @@
 !!! 5
 %html{ lang: I18n.locale }
   %head
+    = javascript_importmap_tags
+    = javascript_import_module_tag "controllers"
     = render partial: "layouts/metatags"
     %title
       = @config.short_name

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,7 +2,7 @@
 %html{ lang: I18n.locale }
   %head
     = javascript_importmap_tags
-    = javascript_import_module_tag "controllers"
+    = yield(:importmap_modules)
     = render partial: "layouts/metatags"
     %title
       = @config.short_name

--- a/bin/importmap
+++ b/bin/importmap
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/application"
+require "importmap/commands"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -86,4 +86,6 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  config.hosts << "test.lvh.me"
 end

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,6 @@
+# Pin npm packages by running ./bin/importmap
+
+pin "application", preload: true
+pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
+pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
+pin_all_from "app/javascript/controllers", under: "controllers"

--- a/config/locales/views/attending/events.en.yml
+++ b/config/locales/views/attending/events.en.yml
@@ -3,3 +3,5 @@ en:
   attending:
     events:
       more_info: Competition Details
+      clear_selection_message: You must choose similar categories for your events. We have cleared one of your choices...please re-choose the appropriate category.
+      change_selection_message: You must compete in the same category in these events. We have updated your other event category to match.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -340,6 +340,8 @@ Rails.application.routes.draw do
       resources :pages do
         resources :images, only: %i[index create destroy]
       end
+
+      resources :event_category_grouping_entries, except: %i[new edit update]
     end
     scope "convention_setup", module: "convention_setup" do
       resources :coupon_codes, except: [:show]

--- a/db/migrate/20230612175854_add_event_category_grouping_tables.rb
+++ b/db/migrate/20230612175854_add_event_category_grouping_tables.rb
@@ -1,0 +1,13 @@
+class AddEventCategoryGroupingTables < ActiveRecord::Migration[7.0]
+  def up
+    create_table :event_category_groupings do |t|
+      t.timestamps
+    end
+
+    create_table :event_category_grouping_entries do |t|
+      t.references :event_category_grouping, index: { name: "ecge_grouping" }
+      t.references :event_category, index: { name: "ecge_event_category" }
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_09_012335) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_12_175854) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -325,6 +325,20 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_09_012335) do
     t.boolean "warning_on_registration_summary", default: false, null: false
     t.index ["event_id", "name"], name: "index_event_categories_on_event_id_and_name", unique: true
     t.index ["event_id", "position"], name: "index_event_categories_event_id"
+  end
+
+  create_table "event_category_grouping_entries", force: :cascade do |t|
+    t.bigint "event_category_grouping_id"
+    t.bigint "event_category_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_category_grouping_id"], name: "ecge_grouping"
+    t.index ["event_category_id"], name: "ecge_event_category"
+  end
+
+  create_table "event_category_groupings", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "event_category_translations", force: :cascade do |t|

--- a/spec/factories/event_category_grouping_entries.rb
+++ b/spec/factories/event_category_grouping_entries.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :event_category_grouping_entry do
+    event_category_grouping
+    event_category
+  end
+end

--- a/spec/factories/event_category_groupings.rb
+++ b/spec/factories/event_category_groupings.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :event_category_grouping do
+  end
+end

--- a/spec/models/event_category_grouping_entry_spec.rb
+++ b/spec/models/event_category_grouping_entry_spec.rb
@@ -22,6 +22,7 @@ describe EventCategoryGroupingEntry do
 
     context "when there are multiple entries for the same grouping" do
       let!(:entry2) { FactoryBot.create(:event_category_grouping_entry, event_category_grouping: entry.event_category_grouping) }
+
       it "does not destroy the grouping" do
         expect do
           entry.destroy

--- a/spec/models/event_category_grouping_entry_spec.rb
+++ b/spec/models/event_category_grouping_entry_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe EventCategoryGroupingEntry do
+  context "when created with a event category and no group" do
+    let(:event_category) { FactoryBot.create(:event_category) }
+
+    it "creates a group" do
+      entry = described_class.new(event_category_id: event_category.id)
+      expect(entry.save).to be_truthy
+      expect(EventCategoryGrouping.count).to eq(1)
+    end
+  end
+
+  context "when deleting an entry" do
+    let!(:entry) { FactoryBot.create(:event_category_grouping_entry) }
+
+    it "destroys the grouping" do
+      expect do
+        entry.destroy
+      end.to change(EventCategoryGrouping, :count).by(-1)
+    end
+
+    context "when there are multiple entries for the same grouping" do
+      let!(:entry2) { FactoryBot.create(:event_category_grouping_entry, event_category_grouping: entry.event_category_grouping) }
+      it "does not destroy the grouping" do
+        expect do
+          entry.destroy
+        end.not_to change(EventCategoryGrouping, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows admin to set a "Event Category Group" which enforces the choice of multiple events with the same event category.

For example: Muni Uphill and Muni Downhill both offer "Beginner" and "Advanced" categories. With this feature, the registrant can be prevented from choosing "Beginner" uphill and "Advanced" downhill.