### PR TITLE
Replace pdf rendering code with rails-supported version.

### DIFF
--- a/app/actions/pdf_renderer.rb
+++ b/app/actions/pdf_renderer.rb
@@ -9,11 +9,11 @@ class PdfRenderer
   end
 
   def raw_pdf
-    lookup_context = ActionView::LookupContext.new(ActionController::Base.view_paths)
-    context = ActionView::Base.with_empty_template_cache.new(lookup_context, instance_variables, nil)
-    renderer = ActionView::Renderer.new(lookup_context)
-
-    html_string = renderer.render context, template: view_target, layout: "layouts/#{layout}"
+    html_string = ApplicationController.render(
+      template: view_target,
+      layout: "layouts/#{layout}",
+      assigns: instance_variables
+    )
 
     WickedPdf.new.pdf_from_string(html_string, pdf_options)
   end


### PR DESCRIPTION
We recently started having frequent persistent issues when trying to render PDFs

The first pdf might work, but subsequent ones would throw 'ActionView::Template::Error: undefined method'