### PR TITLE
Improve datetimepicker by setting default/min/max

### DIFF
--- a/app/assets/javascripts/date_picker.js
+++ b/app/assets/javascripts/date_picker.js
@@ -1,12 +1,24 @@
 $(function() {
-  const create_date_picker = el => $(el).datetimepicker({
-    timepicker: false,
-    format: "Y/m/d",
-    scrollMonth: false,
-    scrollTime: false,
-    scrollInput: false,
-    defaultDate: ''
-  });
+  var create_date_picker = function(el) {
+    var options = {
+      timepicker: false,
+      format: "Y/m/d",
+      scrollMonth: false,
+      scrollTime: false,
+      scrollInput: false,
+      defaultDate: ''
+    };
+    if ($(el).data("min-date").length > 0) {
+      options["minDate"] = $(el).data("min-date")
+      options["startDate"] = options["minDate"]
+    }
+
+    if ($(el).data("max-date").length > 0) {
+      options["maxDate"] = $(el).data("max-date")
+    }
+
+    $(el).datetimepicker(options);
+  };
 
   // this needs to be in a loop or else the pickers don't work well on the Important Dates page
   $(".datepicker").each((_, el) => {

--- a/app/views/registrants/build/_new_lodging.html.haml
+++ b/app/views/registrants/build/_new_lodging.html.haml
@@ -42,12 +42,16 @@
   %fieldset.small-12.large-6.columns
     %legend Add Lodging
     = simple_form_for(LodgingForm.new, url: registrant_lodgings_path(@registrant)) do |f|
+      - min_max_dates = {}
+      - if LodgingDay.any?
+        - min_max_dates[:min_date] = LodgingDay.ordered.first.date_offered.strftime("%Y/%m/%d")
+        - min_max_dates[:max_date] = (LodgingDay.ordered.last.date_offered + 1.day).strftime("%Y/%m/%d")
       .row
         .small-12.medium-4.columns
           = f.input :lodging_room_option_id, collection: Lodging.active.ordered.all, as: :grouped_select, group_method: :ordered_lodging_room_options
         .small-12.medium-4.columns
-          = f.input :check_in_day, input_html: { class: "datepicker" }
+          = f.input :check_in_day, input_html: { class: "datepicker", data: min_max_dates }
         .small-12.medium-4.columns
-          = f.input :check_out_day, input_html: { class: "datepicker" }
+          = f.input :check_out_day, input_html: { class: "datepicker", data: min_max_dates }
       .row
         = f.submit "Add Lodging", class: "button"


### PR DESCRIPTION
Modify the datetime picker to be smarter so that it uses the Lodging start/end dates in order to improve the picker display/options.