### PR TITLE
Fix are-you-sure prompt after modifying form.

### DIFF
--- a/app/assets/javascripts/jquery.are-you-sure.js
+++ b/app/assets/javascripts/jquery.are-you-sure.js
@@ -88,7 +88,7 @@
         return;
       }
 
-      $fields = $form.find(settings.fieldSelector);
+      var $fields = $form.find(settings.fieldSelector);
 
       if (settings.addRemoveFieldsMarksDirty) {              
         // Check if field count has changed
@@ -100,6 +100,7 @@
       }
 
       // Brute force - check each field
+      var $field;
       var isDirty = false;
       $fields.each(function() {
         $field = $(this);
@@ -156,7 +157,7 @@
     if (!settings.silent && !window.aysUnloadSet) {
       window.aysUnloadSet = true;
       $(window).bind('beforeunload', function() {
-        $dirtyForms = $("form").filter('.' + settings.dirtyClass);
+        var $dirtyForms = $("form").filter('.' + settings.dirtyClass);
         if ($dirtyForms.length == 0) {
           return;
         }


### PR DESCRIPTION
If you try to navigate away before saving the form, it will warn you.

This appears to have been broken due
to being included in some form of strict-javascript-related change