### PR TITLE
Add registered gender options

### DIFF
--- a/app/actions/importers/registrant_data_importer.rb
+++ b/app/actions/importers/registrant_data_importer.rb
@@ -63,10 +63,10 @@ class Importers::RegistrantDataImporter < Importers::BaseImporter
   def build_and_save_imported_result(registrant_hash, user)
     registrant = find_existing_registrant(registrant_hash)
     registrant.registered_gender = if registrant_hash[:gender] == "m"
-                          "Male"
-                        else
-                          "Female"
-                        end
+                                     "Male"
+                                   else
+                                     "Female"
+                                   end
     registrant.user = user
     registrant.status = "base_details"
     registrant.save!

--- a/app/actions/importers/registrant_data_importer.rb
+++ b/app/actions/importers/registrant_data_importer.rb
@@ -62,7 +62,7 @@ class Importers::RegistrantDataImporter < Importers::BaseImporter
   # Throws an exception if not valid
   def build_and_save_imported_result(registrant_hash, user)
     registrant = find_existing_registrant(registrant_hash)
-    registrant.gender = if registrant_hash[:gender] == "m"
+    registrant.registered_gender = if registrant_hash[:gender] == "m"
                           "Male"
                         else
                           "Female"

--- a/app/actions/registrant_copier.rb
+++ b/app/actions/registrant_copier.rb
@@ -37,7 +37,8 @@ class RegistrantCopier
         middle_initial: previous_reg.middle_initial,
         last_name: previous_reg.last_name,
         birthday: previous_reg.birthday,
-        gender: previous_reg.gender
+        registered_gender: previous_reg.registered_gender,
+        competitive_gender: previous_reg.competitive_gender
       }
     end
   end

--- a/app/controllers/registrants/build_controller.rb
+++ b/app/controllers/registrants/build_controller.rb
@@ -171,7 +171,7 @@ class Registrants::BuildController < ApplicationController
   end
 
   def attributes
-    [:first_name, :gender, :last_name, :middle_initial, :birthday, :registrant_type, :volunteer,
+    [:first_name, :registered_gender, :gender, :last_name, :middle_initial, :birthday, :registrant_type, :volunteer,
      :online_waiver_signature, :online_waiver_acceptance, :wheel_size_id, :rules_accepted,
      :medical_certificate, :medical_questionnaire_filled_out, :medical_questionnaire_attest_all_no,
      volunteer_opportunity_ids: [],

--- a/app/controllers/sample_data/registrants_controller.rb
+++ b/app/controllers/sample_data/registrants_controller.rb
@@ -12,11 +12,19 @@ class SampleData::RegistrantsController < SampleData::BaseController
     num_registrants = params[:number].to_i
     resu_errors = 0
     num_registrants.times do
+      registered_gender = ["Male", "Female", "Other"].sample
+      gender = if registered_gender == "Other"
+                 ["Male", "Female"].sample
+               else
+                 registered_gender
+               end
+
       registrant = Registrant.create!(
         first_name: Faker::Name.first_name,
         last_name: Faker::Name.last_name,
         birthday: Faker::Date.between(from: 5.years.ago, to: 55.years.ago),
-        gender: ["Male", "Female"].sample,
+        gender: gender,
+        registered_gender: registered_gender,
         registrant_type: "competitor",
         ineligible: false,
         rules_accepted: true,

--- a/app/views/registrants/_base_details.html.haml
+++ b/app/views/registrants/_base_details.html.haml
@@ -10,7 +10,28 @@
       .row
         = f.date_select :birthday, {:start_year => 1920, :end_year => Time.now.year, :include_blank => true}, class: "small-4 columns"
   .competitor_show.noncompetitor_show.row
+    .small-2.columns
+      = t('.gender')
+    .small-10.columns
+      = f.radio_button :registered_gender, 'Male'
+      = f.label :gender_male, t('.male'), :class => "required"
+      = f.radio_button :registered_gender, 'Female'
+      = f.label :gender_female, t('.female'), :class => "required"
+      = f.radio_button :registered_gender, 'Other'
+      = f.label :gender_other, t('.other'), :class => "required"
+
+    -# If registered_gender is "Other", present a sub-selection
+    -# which allows selection of the competitive_gender
+    -#
+    -# If the registered_gender is Male or Female, the competitive_gender
+    -# Is always set to Male or Female respectively
+  .competitor_show.noncompetitor_show.row
     .small-12.columns
+      = t('.registered_gender_description')
+  .competitor_show.noncompetitor_show.row
+    .small-2.columns
+      = t('.competitive_gender')
+    .small-10.columns
       = f.radio_button :gender, 'Male'
       = f.label :gender_male, t('.male'), :class => "required"
       = f.radio_button :gender, 'Female'

--- a/app/views/registrants/_base_details.html.haml
+++ b/app/views/registrants/_base_details.html.haml
@@ -13,26 +13,32 @@
     .small-2.columns
       = t('.gender')
     .small-10.columns
-      = f.radio_button :registered_gender, 'Male'
-      = f.label :gender_male, t('.male'), :class => "required"
-      = f.radio_button :registered_gender, 'Female'
-      = f.label :gender_female, t('.female'), :class => "required"
-      = f.radio_button :registered_gender, 'Other'
-      = f.label :gender_other, t('.other'), :class => "required"
+      = f.radio_button :registered_gender, 'Male', class: "js--displayIfChecked"
+      = f.label :registered_gender_male, t('.male'), :class => "required"
+      = f.radio_button :registered_gender, 'Female', class: "js--displayIfChecked"
+      = f.label :registered_gender_female, t('.female'), :class => "required"
+      = f.radio_button :registered_gender, 'Other', class: "js--displayIfChecked", data: { displayblock: "competitive_gender" }
+      = f.label :registered_gender_other, t('.other'), :class => "required"
 
     -# If registered_gender is "Other", present a sub-selection
     -# which allows selection of the competitive_gender
     -#
     -# If the registered_gender is Male or Female, the competitive_gender
     -# Is always set to Male or Female respectively
-  .competitor_show.noncompetitor_show.row
-    .small-12.columns
-      = t('.registered_gender_description')
-  .competitor_show.noncompetitor_show.row
-    .small-2.columns
-      = t('.competitive_gender')
-    .small-10.columns
-      = f.radio_button :gender, 'Male'
-      = f.label :gender_male, t('.male'), :class => "required"
-      = f.radio_button :gender, 'Female'
-      = f.label :gender_female, t('.female'), :class => "required"
+  .competitive_gender
+    .competitor_show.noncompetitor_show.row
+      .small-12.columns
+        = t('.registered_gender_description_1')
+        %br
+        = t('.registered_gender_description_2')
+        %br
+        = t('.registered_gender_description_3')
+
+    .competitor_show.noncompetitor_show.row
+      .small-2.columns
+        = t('.competitive_gender')
+      .small-10.columns
+        = f.radio_button :gender, 'Male'
+        = f.label :gender_male, t('.male'), :class => "required"
+        = f.radio_button :gender, 'Female'
+        = f.label :gender_female, t('.female'), :class => "required"

--- a/app/views/registrants/_summary.html.haml
+++ b/app/views/registrants/_summary.html.haml
@@ -10,8 +10,11 @@
       = @registrant.middle_initial
       = @registrant.last_name
     %p.competitor_show.noncompetitor_show
-      %b= t(".gender")
-      = @registrant.gender
+      %b= t(".registered_gender")
+      = @registrant.registered_gender
+      - if @registrant.registered_gender != @registrant.competitive_gender
+        %b= t(".competitive_gender")
+        = @registrant.competitive_gender
 
       %b= t(".birthday")
       = @registrant.birthday.try(:strftime, "%d-%b-%Y")

--- a/config/locales/views/registrants/base_details.en.yml
+++ b/config/locales/views/registrants/base_details.en.yml
@@ -10,11 +10,11 @@ en:
       required_fields: Required fields
       gender: Gender
       competitive_gender: Competitive Gender
-      registered_gender_description: We are committed to making our unicycling events inclusive events for all unicyclists.
+      registered_gender_description_1: We are committed to making our unicycling events inclusive events for all unicyclists.
         We seek to provide events free from discrimination of any type. We recognize that meeting this goal may take some changes.
 
-        As a first step, we have added a third gender category to registration ("Other"). You can now select Male, Female, or Other.
+      registered_gender_description_2: As a first step, we have added a third gender category to registration ("Other"). You can now select Male, Female, or Other.
 
-        However, we are constrained by the current IUF Rulebook regarding competition gender divisions.
+      registered_gender_description_3: However, we are constrained by the current IUF Rulebook regarding competition gender divisions.
         So when choosing "Other", participants need to select a gender to compete with.
         You may select whichever gender you want to compete as.

--- a/config/locales/views/registrants/base_details.en.yml
+++ b/config/locales/views/registrants/base_details.en.yml
@@ -6,4 +6,15 @@ en:
       birthday: Birthday
       female: Female
       male: Male
+      other: Other
       required_fields: Required fields
+      gender: Gender
+      competitive_gender: Competitive Gender
+      registered_gender_description: We are committed to making our unicycling events inclusive events for all unicyclists.
+        We seek to provide events free from discrimination of any type. We recognize that meeting this goal may take some changes.
+
+        As a first step, we have added a third gender category to registration ("Other"). You can now select Male, Female, or Other.
+
+        However, we are constrained by the current IUF Rulebook regarding competition gender divisions.
+        So when choosing "Other", participants need to select a gender to compete with.
+        You may select whichever gender you want to compete as.

--- a/config/locales/views/registrants/summary.da.yml
+++ b/config/locales/views/registrants/summary.da.yml
@@ -5,7 +5,7 @@ da:
       age: Alder
       birthday: Fødselsdag
       default_wheel_size: Standard Track Racing hjul størelse
-      gender: Køn
+      registered_gender: Køn
       name: Navn
       registration_summary: Tilmeldings oversigt
       volunteer: Frivilig

--- a/config/locales/views/registrants/summary.de.yml
+++ b/config/locales/views/registrants/summary.de.yml
@@ -5,7 +5,7 @@ de:
       age: Alter
       birthday: Geburtstag
       default_wheel_size: Standard Radgröße für Bahnrennen
-      gender: Geschlecht
+      registered_gender: Geschlecht
       name: Name
       registration_summary: Anmelde Zusammenfassung
       user_account_email: Benutzer Email

--- a/config/locales/views/registrants/summary.en.yml
+++ b/config/locales/views/registrants/summary.en.yml
@@ -5,7 +5,8 @@ en:
       age: Age
       birthday: Birthday
       default_wheel_size: Default Track Racing Wheel Size
-      gender: Gender
+      competitive_gender: Competitive Gender
+      registered_gender: Gender
       name: Name
       registration_summary: Registration Summary
       user_account_email: User Account Email

--- a/config/locales/views/registrants/summary.es.yml
+++ b/config/locales/views/registrants/summary.es.yml
@@ -5,7 +5,7 @@ es:
       age: Edad
       birthday: Fecha de nacimiento
       default_wheel_size: Tamaño Predeterminado de la rueda de Pista
-      gender: Sexo
+      registered_gender: Sexo
       name: Nombre
       registration_summary: Resumen de la inscripción
       user_account_email: Correo Electrónico de la Cuenta del Usuario

--- a/config/locales/views/registrants/summary.fr.yml
+++ b/config/locales/views/registrants/summary.fr.yml
@@ -5,7 +5,7 @@ fr:
       age: Âge
       birthday: Date de naissance
       default_wheel_size: Default Wheel Size
-      gender: Sexe
+      registered_gender: Sexe
       name: Nom
       registration_summary: Résumé de l’inscription
       user_account_email: E-mail d'utilisateur

--- a/config/locales/views/registrants/summary.it.yml
+++ b/config/locales/views/registrants/summary.it.yml
@@ -5,7 +5,7 @@ it:
       age: Età
       birthday: Data di compleanno
       default_wheel_size: Dimensione ruota per difetto per le gare in pista
-      gender: Genere
+      registered_gender: Genere
       name: Nome
       registration_summary: Riassunto della registrazione
       user_account_email: Account utente Email

--- a/db/migrate/20231218025355_add_registered_gender_to_registrant.rb
+++ b/db/migrate/20231218025355_add_registered_gender_to_registrant.rb
@@ -6,6 +6,5 @@ class AddRegisteredGenderToRegistrant < ActiveRecord::Migration[7.0]
         execute "UPDATE registrants SET registered_gender = gender"
       end
     end
-
   end
 end

--- a/db/migrate/20231218025355_add_registered_gender_to_registrant.rb
+++ b/db/migrate/20231218025355_add_registered_gender_to_registrant.rb
@@ -1,0 +1,11 @@
+class AddRegisteredGenderToRegistrant < ActiveRecord::Migration[7.0]
+  def change
+    add_column :registrants, :registered_gender, :string
+    reversible do |direction|
+      direction.up do
+        execute "UPDATE registrants SET registered_gender = gender"
+      end
+    end
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_12_175854) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_18_025355) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1004,6 +1004,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_12_175854) do
     t.datetime "medical_questionnaire_filled_out_at", precision: nil
     t.datetime "medical_questionnaire_attest_all_no_at", precision: nil
     t.boolean "medical_certificate_manually_confirmed", default: false, null: false
+    t.string "registered_gender"
     t.index ["bib_number"], name: "index_registrants_on_bib_number", unique: true
     t.index ["deleted"], name: "index_registrants_deleted"
     t.index ["registrant_type"], name: "index_registrants_on_registrant_type"

--- a/spec/controllers/registrants/build_controller_spec.rb
+++ b/spec/controllers/registrants/build_controller_spec.rb
@@ -18,7 +18,7 @@ describe Registrants::BuildController do
     {
       first_name: "Robin",
       last_name: "Dunlop",
-      gender: "Male",
+      registered_gender: "Male",
       user_id: user.id,
       birthday: Date.new(1982, 1, 19),
       contact_detail_attributes: {
@@ -186,7 +186,7 @@ describe Registrants::BuildController do
           "birthday(2i)" => "1",
           "birthday(3i)" => "13",
           "birthday(1i)" => "1995",
-          gender: "Male"
+          registered_gender: "Male"
         }
       end
 
@@ -310,7 +310,7 @@ describe Registrants::BuildController do
       {
         first_name: "Robin",
         last_name: "Dunlop",
-        gender: "Male",
+        registered_gender: "Male",
         birthday: Date.new(1982, 1, 19)
       }
     end

--- a/spec/controllers/registrants_controller_spec.rb
+++ b/spec/controllers/registrants_controller_spec.rb
@@ -51,7 +51,7 @@ describe RegistrantsController do
     {
       first_name: "Robin",
       last_name: "Dunlop",
-      gender: "Male",
+      registered_gender: "Male",
       user_id: @user.id,
       birthday: Date.new(1982, 1, 19),
       contact_detail_attributes: {

--- a/spec/factories/registrants.rb
+++ b/spec/factories/registrants.rb
@@ -43,6 +43,7 @@ FactoryBot.define do
     last_name { "LastMyString" }
     birthday { 18.years.ago }
     gender { "Male" }
+    registered_gender { "Male" }
     user # FactoryBot
     registrant_type { 'competitor' }
     ineligible { false }

--- a/spec/models/registrant_spec.rb
+++ b/spec/models/registrant_spec.rb
@@ -176,8 +176,8 @@ describe Registrant do
       expect(@reg.valid?).to eq(false)
     end
 
-    it "requires gender" do
-      @reg.gender = nil
+    it "requires registered_gender" do
+      @reg.registered_gender = nil
       expect(@reg.valid?).to eq(false)
     end
 
@@ -186,13 +186,13 @@ describe Registrant do
     end
 
     it "has either Male or Female gender" do
-      @reg.gender = "Male"
+      @reg.registered_gender = "Male"
       expect(@reg.valid?).to eq(true)
 
-      @reg.gender = "Female"
+      @reg.registered_gender = "Female"
       expect(@reg.valid?).to eq(true)
 
-      @reg.gender = "Other"
+      @reg.registered_gender = "None"
       expect(@reg.valid?).to eq(false)
     end
 

--- a/spec/support/feature_shared_contexts.rb
+++ b/spec/support/feature_shared_contexts.rb
@@ -120,10 +120,10 @@ shared_context 'basic registrant data' do
     select '20',    from: 'registrant_birthday_3i'
     select '1982',  from: 'registrant_birthday_1i'
 
-    # Temporary, until we add JS to hide the 2nd 'Male' option.
-    # since there are 2 'Male' options initially
-    # choose 'registrant_registered_gender_male'
-    choose 'Male'
+    # Temporary, until we figured out why the JS to hide the 2nd 'Male' option.
+    # isn't being picked up by the specs
+    # since there are 2 'Male' options (2nd one hidden)
+    choose 'registrant_registered_gender_male'
 
     sleep 1 # needed or else the feature spec fails to register that the "Male" has been selected.
   end

--- a/spec/support/feature_shared_contexts.rb
+++ b/spec/support/feature_shared_contexts.rb
@@ -119,7 +119,11 @@ shared_context 'basic registrant data' do
     select 'May',   from: 'registrant_birthday_2i'
     select '20',    from: 'registrant_birthday_3i'
     select '1982',  from: 'registrant_birthday_1i'
-    choose 'Male'
+
+    # Temporary, until we add JS to hide the 2nd 'Male' option.
+    # since there are 2 'Male' options initially
+    choose 'registrant_registered_gender_male'
+
     sleep 1 # needed or else the feature spec fails to register that the "Male" has been selected.
   end
 end

--- a/spec/support/feature_shared_contexts.rb
+++ b/spec/support/feature_shared_contexts.rb
@@ -122,7 +122,8 @@ shared_context 'basic registrant data' do
 
     # Temporary, until we add JS to hide the 2nd 'Male' option.
     # since there are 2 'Male' options initially
-    choose 'registrant_registered_gender_male'
+    # choose 'registrant_registered_gender_male'
+    choose 'Male'
 
     sleep 1 # needed or else the feature spec fails to register that the "Male" has been selected.
   end


### PR DESCRIPTION
This adds the "Other" gender to the Registrant Base Details page.
If they choose "Other", it asks for their "Competitive Gender".

For now, we only then use the "Other" for display on their Summary page. Everything else uses the "competitive_gender" (aka: "gender").