### PR TITLE
Remove use of placeholders for clarity.

### DIFF
--- a/app/views/attending/_event.html.haml
+++ b/app/views/attending/_event.html.haml
@@ -31,9 +31,11 @@
         - when "text"
           = ec.input :value, as: :string, label: ec.object.event_choice.label, wrapper_html: {title: choice.tooltip }
         - when "multiple"
+          - # NOTE: "multiple" and "best_time" are deprecated types. No longer available in the admin UI.
           = ec.label :value, choice.label, :title => choice.tooltip
           = ec.select :value, ec.object.event_choice.values, {:include_blank => true}, :title => choice.tooltip
         - when "best_time"
+          - # NOTE: "multiple" and "best_time" are deprecated types. No longer available in the admin UI.
           = ec.text_field :value, :placeholder => ec.object.event_choice.label, :title => choice.tooltip.blank? ? choice.tooltip : "hh:mm:ss or mm:ss"
   - if event.best_time?
     %td

--- a/app/views/best_times/_registrant_form.html.haml
+++ b/app/views/best_times/_registrant_form.html.haml
@@ -2,7 +2,7 @@
 = simple_form_for(registrant_best_time, url: event_category_best_time_path(event_category, registrant.id), method: :put, remote: true) do |f|
   = f.hidden_field :id
   = f.input :source_location
-  = f.input :formatted_value, placeholder: registrant_best_time.hint
+  = f.input :formatted_value, hint: "Format: #{registrant_best_time.hint}"
   = f.submit "Update", class: "button", data: { disable_with: false }
 
 - if registrant_best_time.persisted?

--- a/app/views/registrants/_name.en.html.haml
+++ b/app/views/registrants/_name.en.html.haml
@@ -1,8 +1,8 @@
 .small-2.columns.inline
-  = f.label :first_name, t('.name'), :class => "required"
+  = t('.name')
 .small-4.columns
-  = f.text_field :first_name, :placeholder => t(".first_name"), :size => 12, :autofocus => "true"
+  = f.input :first_name, size: 12, autofocus: true
 .small-2.column
-  = f.text_field :middle_initial, :size => 1
+  = f.input :middle_initial
 .small-4.columns
-  = f.text_field :last_name, :placeholder => t(".last_name"), :size => 15
+  = f.input :last_name

--- a/app/views/registrants/_name.fr.html.haml
+++ b/app/views/registrants/_name.fr.html.haml
@@ -1,6 +1,6 @@
-.small-4.columns
-  = f.label :last_name, t(".name"), :class => "required"
-.small-4.columns
-  = f.text_field :last_name, :placeholder => t(".last_name"), :size => 15, :autofocus => "true"
-.small-4.columns
-  = f.text_field :first_name, :placeholder => t(".first_name"), :size => 12
+.small-2.columns
+  %b= t(".name")
+.small-5.columns
+  = f.input :last_name, autofocus: true
+.small-5.columns
+  = f.input :first_name

--- a/app/views/registrants/_new_name.html.haml
+++ b/app/views/registrants/_new_name.html.haml
@@ -22,7 +22,7 @@
       = link_to t("cancel"), user_registrants_path(@user)
 
   %div{ id: "tabs-new-registrant"}
-    = form_for(@registrant, url: registrant_build_index_path(user_id: @user.id, registrant_id: "building")) do |f|
+    = simple_form_for(@registrant, url: registrant_build_index_path(user_id: @user.id, registrant_id: "building")) do |f|
       = f.hidden_field :registrant_type
       = render partial: "shared/error_messages", object: @registrant
       = render "registrants/build/errors", registrant: @registrant

--- a/app/views/registrants/build/add_name.html.haml
+++ b/app/views/registrants/build/add_name.html.haml
@@ -1,4 +1,4 @@
-= form_for(@registrant, url: wizard_path, method: :put) do |f|
+= simple_form_for(@registrant, url: wizard_path, method: :put) do |f|
   = render "registrants/build/errors", registrant: @registrant
 
   .data_block


### PR DESCRIPTION
the problem with using placeholders is that as soon as you fill in the fields, it's not possible to refer back to the placeholder to ensure that you did it correctly.

As a result, the information provided in the placeholder is nearly useless as soon as the user starts typing.

As an alternative, we use 'hints' which appear beneath the input box, and don't disappear