### PR TITLE
Revert "Update jquery-ui-rails for security warning"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'importmap-rails'
 gem "jc-validates_timeliness"
 gem 'jquery-datatables-rails'
 gem 'jquery-rails'
-gem 'jquery-ui-rails'
+gem 'jquery-ui-rails', '6.0.1'
 gem 'money-rails'
 gem 'rails-assets-datetimepicker', source: 'https://rails-assets.org'
 gem 'recaptcha', require: 'recaptcha/rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,7 +353,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails (7.0.0)
+    jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     json (2.6.2)
     kaminari (1.2.2)
@@ -723,7 +723,7 @@ DEPENDENCIES
   jc-validates_timeliness
   jquery-datatables-rails
   jquery-rails
-  jquery-ui-rails
+  jquery-ui-rails (= 6.0.1)
   kaminari
   money-rails
   nilify_blanks


### PR DESCRIPTION
Reverts rdunlop/unicycling-registration#2514

Reverting because it appears that the inclusion of jquery-color 2.2.0 causes some problems with the way that we are loading jQuery.