### PR TITLE
Remove print_media_type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ruby:2.7.6
 RUN apt-get update
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash # Installs the node repository
 RUN apt-get install --yes nodejs # Actually install NODEJS
-
+RUN apt-get install fonts-ipafont-gothic
 RUN mkdir /app
 
 WORKDIR /app

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -86,7 +86,6 @@ class ApplicationController < ActionController::Base
 
     render pdf: view_name,
            page_size: "Letter",
-           print_media_type: true,
            margin: { top: 15, bottom: 10, left: 7, right: 7 },
            show_as_html: params[:debug].present?,
            header: { center: header, line: header.present? },


### PR DESCRIPTION
This was preventing loading a bunch of css.
There doesn't seem to be a good reason that we
were using this.

Also add a note about installing japanese font