### PR TITLE
Use preload because the member->registrant is polymorphic.

### DIFF
--- a/app/views/printing/competitions/announcer.html.haml
+++ b/app/views/printing/competitions/announcer.html.haml
@@ -14,7 +14,7 @@
         %th= RepresentationType.description
 
     %tbody
-      - competitors = @competition.competitors.includes(:members => [:registrant => [:contact_detail]]).active
+      - competitors = @competition.competitors.preload(:members => [:registrant => [:contact_detail]]).active
       - competitors = competitors.reorder("competitors.lowest_member_bib_number")
       - competitors.each do |comp|
         -# Why is this cached with i18n?

--- a/app/views/printing/competitions/start_list.html.haml
+++ b/app/views/printing/competitions/start_list.html.haml
@@ -3,7 +3,7 @@
 
   - wave_times = @competition.wave_times
 
-  - competitors = @competition.competitors.includes(:members => [:registrant => [:contact_detail]]).active
+  - competitors = @competition.competitors.preload(:members => [:registrant => [:contact_detail]]).active
 
   // Artistic
   - if @competition.compete_in_order?


### PR DESCRIPTION
Sometimes rails chooses to attempt to eager load this, and it failed because this relationship is (newly) polymorphic