### PR TITLE
Allow Track E-Timer to give us hundreds-only data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -520,8 +520,8 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     rolify (5.3.0)
     rollbar (3.4.2)
     ros-apartment-sidekiq (1.2.0)

--- a/app/actions/importers/parsers/chip.rb
+++ b/app/actions/importers/parsers/chip.rb
@@ -79,7 +79,9 @@ class Importers::Parsers::Chip < Importers::Parsers::Base
       # TimeParser will do this when it finds only a single "thousands" point.
       imported_time
     when 2
-      imported_time * 10
+      # We should multiply "* 10", but we don't, because
+      # TimeParser will do this when it finds only two "thousands" point.
+      imported_time
     when 3
       imported_time * 1
     when 4

--- a/app/lib/time_parser.rb
+++ b/app/lib/time_parser.rb
@@ -30,6 +30,8 @@ class TimeParser
     thous = seconds_and_hundreds[(index + 1)..]
     if thous.length == 1
       results[:thousands] = thous.to_i * 100
+    elsif thous.length == 2 # allows input from timer as hundreds
+      results[:thousands] = thous.to_i * 10
     else
       results[:thousands] = thous.to_i
     end

--- a/app/lib/time_parser.rb
+++ b/app/lib/time_parser.rb
@@ -28,9 +28,11 @@ class TimeParser
     results[:seconds] = seconds_and_hundreds[0..(index - 1)].to_i
 
     thous = seconds_and_hundreds[(index + 1)..]
-    if thous.length == 1
+    case thous.length
+    when 1
       results[:thousands] = thous.to_i * 100
-    elsif thous.length == 2 # allows input from timer as hundreds
+    when 2
+      # allows input from timer as hundreds
       results[:thousands] = thous.to_i * 10
     else
       results[:thousands] = thous.to_i

--- a/spec/lib/time_parser_spec.rb
+++ b/spec/lib/time_parser_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe TimeParser do
+  let(:parser) { described_class.new(time) }
+
+  describe "with a time with thousands" do
+    let(:time) { "23.123" }
+
+    it "returns the correct thousands" do
+      expect(parser.result[:thousands]).to eq(123)
+    end
+  end
+
+  describe "with only hundreds" do
+    let(:time) { "23.12" }
+
+    it "returns the correct thousands" do
+      expect(parser.result[:thousands]).to eq(120)
+    end
+  end
+
+  describe "with only tens" do
+    let(:time) { "23.1" }
+
+    it "returns the correct thousands" do
+      expect(parser.result[:thousands]).to eq(100)
+    end
+  end
+end


### PR DESCRIPTION
When the e-timer is configured to provide only 2 decimal places, the system was incorrectly assuming it was 3 decimal places.