### PR TITLE
add ability to enable automatic-competitor-creation

### DIFF
--- a/app/controllers/competition_setup/competitions_controller.rb
+++ b/app/controllers/competition_setup/competitions_controller.rb
@@ -71,7 +71,7 @@ class CompetitionSetup::CompetitionsController < ApplicationController
                                         :penalty_seconds, :automatic_competitor_creation, :combined_competition_id,
                                         :sign_in_list_enabled, :time_entry_columns,
                                         :import_results_into_other_competition,
-                                        :hide_max_laps_count,
+                                        :hide_max_laps_count, :allow_competitor_creation_during_import_approval,
                                         :score_ineligible_competitors, :results_header,
                                         competition_sources_attributes: %i[id event_category_id gender_filter min_age max_age competition_id max_place _destroy])
   end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -15,7 +15,7 @@ module FormHelper
   end
 
   def eligible_registrants(competition)
-    if @config.can_create_competitors_at_lane_assignment? # rubocop:disable Rails/HelperInstanceVariable
+    if competition.allow_competitor_creation_during_import_approval?
       AvailableRegistrants.all
     else
       competition.registrants.sort_by(&:bib_number)

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -369,6 +369,12 @@ class Competition < ApplicationRecord
     end
   end
 
+  def allow_competitor_creation_during_import_approval?
+    return true if EventConfiguration.singleton.can_create_competitors_at_lane_assignment?
+
+    allow_competitor_creation_during_import_approval
+  end
+
   # returns all of the results together, ignoring age-group data
   def results_list
     res = competitors.active.to_a

--- a/app/models/import_result.rb
+++ b/app/models/import_result.rb
@@ -76,7 +76,7 @@ class ImportResult < ApplicationRecord
         end
       end
     end
-    if competitor.nil? && EventConfiguration.singleton.can_create_competitors_at_lane_assignment?
+    if competitor.nil? && competition.allow_competitor_creation_during_import_approval?
       # still no competitor, create one in the current event
       registrant = matching_registrant
       target_competition.create_competitor_from_registrants([registrant], nil)

--- a/app/models/two_attempt_entry.rb
+++ b/app/models/two_attempt_entry.rb
@@ -93,7 +93,7 @@ class TwoAttemptEntry < ApplicationRecord
   def import!
     # TODO: this should only create a competitor if in the correct "mode"
     competitor = matching_competitor
-    if competitor.nil? && EventConfiguration.singleton.can_create_competitors_at_lane_assignment?
+    if competitor.nil? && competition.allow_competitor_creation_during_import_approval
       registrant = matching_registrant
       competition.create_competitor_from_registrants([registrant], nil)
       competitor = competition.find_competitor_with_bib_number(bib_number)

--- a/app/policies/competitor_policy.rb
+++ b/app/policies/competitor_policy.rb
@@ -30,7 +30,7 @@ class CompetitorPolicy < ApplicationPolicy
   def create?
     return false unless record.competition.unlocked?
 
-    director_or_competition_admin?(user, record.competition) || config.can_create_competitors_at_lane_assignment?
+    director_or_competition_admin?(user, record.competition) || record.competition.allow_competitor_creation_during_import_approval?
   end
 
   def update?

--- a/app/views/competition_setup/competitions/_form.html.haml
+++ b/app/views/competition_setup/competitions/_form.html.haml
@@ -93,6 +93,10 @@
   = f.check_box :automatic_competitor_creation, disabled: "disabled"
   %p DISABLED automatic creation because I think that it's more trouble than it's worth
 
+  %br
+  = f.label :allow_competitor_creation_during_import_approval
+  = f.check_box :allow_competitor_creation_during_import_approval
+
   %p Selecting this option will automatically create a competitor whenever a registrant signs up for any source-event.
 
   .js--blockVisibleTarget{ data: { show: ["Overall Champion"] } }

--- a/db/migrate/20240717225306_competitor_creation_during_import.rb
+++ b/db/migrate/20240717225306_competitor_creation_during_import.rb
@@ -1,0 +1,5 @@
+class CompetitorCreationDuringImport < ActiveRecord::Migration[7.0]
+  def change
+    add_column :competitions, :allow_competitor_creation_during_import_approval, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_14_024543) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_17_225306) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -206,6 +206,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_14_024543) do
     t.boolean "score_ineligible_competitors", default: false, null: false
     t.string "results_header"
     t.boolean "hide_max_laps_count", default: false, null: false
+    t.boolean "allow_competitor_creation_during_import_approval", default: false, null: false
     t.index ["base_age_group_type_id"], name: "index_competitions_on_base_age_group_type_id"
     t.index ["combined_competition_id"], name: "index_competitions_on_combined_competition_id", unique: true
     t.index ["event_id"], name: "index_competitions_event_id"


### PR DESCRIPTION
Only creates competitors when approving imported time results. Also, by setting to USA mode, it will enable this feature