### PR TITLE
Add 'paid' to ignored columns.

### DIFF
--- a/app/models/registrant.rb
+++ b/app/models/registrant.rb
@@ -184,6 +184,8 @@ class Registrant < ApplicationRecord
   scope :started, -> { where.not(status: "blank").active_or_incomplete }
   scope :not_deleted, -> { where(deleted: false) }
 
+  self.ignored_columns += [:paid]
+
   def validated?
     status == "active"
   end


### PR DESCRIPTION
This is an attempt to address the recurring resurrection of errors due to the fact that we once had a 'paid' column..and every once in a while our application seems to remember that, and get confused, and start asking for 'paid' things.