### PR TITLE
Split closing of competitor and noncompetitor registrations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,8 +44,9 @@ class ApplicationController < ActionController::Base
     @pundit_user ||= UserContext.new(
       current_user,
       EventConfiguration.singleton,
-      EventConfiguration.closed?,
-      EventConfiguration.singleton.new_registration_closed?,
+      EventConfiguration.singleton.competitor_registration_closed?,
+      EventConfiguration.singleton.noncompetitor_registration_closed?,
+      EventConfiguration.singleton.new_registration_closed_for_limit?,
       allow_reg_modifications?,
       translation_domain?
     )

--- a/app/models/user_context.rb
+++ b/app/models/user_context.rb
@@ -1,11 +1,12 @@
 class UserContext
-  attr_reader :user, :config, :reg_closed, :new_reg_closed, :authorized_laptop, :translation_domain
+  attr_reader :user, :config, :comp_reg_closed, :noncomp_reg_closed, :reg_closed_for_limit, :authorized_laptop, :translation_domain
 
-  def initialize(user, config, reg_closed, new_reg_closed, authorized_laptop, translation_domain = false)
+  def initialize(user, config, comp_reg_closed, noncomp_reg_closed, reg_closed_for_limit, authorized_laptop, translation_domain = false)
     @user = user
     @config = config
-    @reg_closed = reg_closed
-    @new_reg_closed = new_reg_closed
+    @comp_reg_closed = comp_reg_closed
+    @noncomp_reg_closed = noncomp_reg_closed
+    @reg_closed_for_limit = reg_closed_for_limit
     @authorized_laptop = authorized_laptop
     @translation_domain = translation_domain
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -152,7 +152,7 @@ class ApplicationPolicy
   end
 
   # Allows to modify your own records as long as you're a `late_registrant` or registration is still open
-  def registration_closed?(competitor_type)
+  def registration_closed?(competitor_type = nil)
     reg_closed = case competitor_type
                  when "competitor"
                    comp_reg_closed
@@ -167,9 +167,9 @@ class ApplicationPolicy
 
   # Are new registrations allowed?
   def new_registration_closed?(competitor_type)
-    return false if reg_closed_for_limit
+    return true if registration_closed?(competitor_type)
 
-    registration_closed?(competitor_type)
+    reg_closed_for_limit
   end
 
   def scope

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,13 +1,14 @@
 class ApplicationPolicy
-  attr_reader :user, :record, :reg_closed, :new_reg_closed, :authorized_laptop, :translation_domain
+  attr_reader :user, :record, :comp_reg_closed, :noncomp_reg_closed, :reg_closed_for_limit, :authorized_laptop, :translation_domain
   attr_reader :config
 
   def initialize(user_context, record)
     if user_context.is_a?(UserContext)
       @user = user_context.user
       @config = user_context.config
-      @reg_closed = user_context.reg_closed
-      @new_reg_closed = user_context.new_reg_closed
+      @comp_reg_closed = user_context.comp_reg_closed
+      @noncomp_reg_closed = user_context.noncomp_reg_closed
+      @reg_closed_for_limit = user_context.reg_closed_for_limit
       @authorized_laptop = user_context.authorized_laptop
       @translation_domain = user_context.translation_domain
     else
@@ -15,8 +16,9 @@ class ApplicationPolicy
       # in the actual system, we will always encapsulate the user in a UserContext object
       @user = user_context
       @config = OpenStruct.new(music_submission_ended?: true, wheel_size_configuration_max_age: 10)
-      @reg_closed = false
-      @new_reg_closed = false
+      @comp_reg_closed = false
+      @noncomp_reg_closed = false
+      @reg_closed_for_limit = false
       @authorized_laptop = false
     end
 
@@ -150,13 +152,24 @@ class ApplicationPolicy
   end
 
   # Allows to modify your own records as long as you're a `late_registrant` or registration is still open
-  def registration_closed?
+  def registration_closed?(competitor_type)
+    reg_closed = case competitor_type
+                 when "competitor"
+                   comp_reg_closed
+                 when "noncompetitor"
+                   noncomp_reg_closed
+                 else
+                   comp_reg_closed && noncomp_reg_closed
+                 end
+
     reg_closed && !authorized_laptop && !late_registrant?
   end
 
-  # are new registrations allowed
-  def new_registration_closed?
-    new_reg_closed && !authorized_laptop && !late_registrant?
+  # Are new registrations allowed?
+  def new_registration_closed?(competitor_type)
+    return false if reg_closed_for_limit
+
+    registration_closed?(competitor_type)
   end
 
   def scope

--- a/app/policies/payment_policy.rb
+++ b/app/policies/payment_policy.rb
@@ -12,7 +12,7 @@ class PaymentPolicy < ApplicationPolicy
   end
 
   def new?
-    !registration_closed? || super_admin?
+    !registration_closed? || super_admin? # should we prevent this when comp is closed, but noncomp is not?
   end
 
   %i[create advanced_stripe complete pay_offline apply_coupon].each do |meth|
@@ -39,7 +39,9 @@ class PaymentPolicy < ApplicationPolicy
   private
 
   def manage?
-    (user_record? && (!registration_closed? || payment_admin?)) || super_admin?
+    return true if super_admin?
+
+    user_record? && (!registration_closed? || payment_admin?) # should we prevent this when comp is closed, but noncomp is not?
   end
 
   def user_record?

--- a/app/policies/registrant_policy.rb
+++ b/app/policies/registrant_policy.rb
@@ -3,7 +3,7 @@ class RegistrantPolicy < ApplicationPolicy
   def create?
     return true if super_admin?
 
-    user_record? && !new_registration_closed? && registration_type_for_sale?(record.registrant_type)
+    user_record? && !new_registration_closed?(record.registrant_type) && registration_type_for_sale?(record.registrant_type)
   end
 
   def create_from_previous?
@@ -35,7 +35,7 @@ class RegistrantPolicy < ApplicationPolicy
     return false unless record.competitor?
     return true if event_planner? || super_admin?
 
-    my_record? && (!config.event_sign_up_closed? || !registration_closed?)
+    my_record? && (!config.event_sign_up_closed? || !registration_closed?(record.registrant_type))
     # change this to allow add_events when registration is closed, but events date is open
     # !config.event_sign_up_closed?
     # BUT, still allow viewing of the events page after events have closed, but registration is open?
@@ -92,7 +92,7 @@ class RegistrantPolicy < ApplicationPolicy
   def update?
     return true if event_planner? || super_admin?
 
-    my_record? && !registration_closed?
+    my_record? && !registration_closed?(record.registrant_type)
   end
 
   def my_record?
@@ -109,7 +109,7 @@ class RegistrantPolicy < ApplicationPolicy
   end
 
   def destroy?
-    (user_record? && !registration_closed?) || event_planner? || super_admin?
+    (user_record? && !registration_closed?(record.registrant_type)) || event_planner? || super_admin?
   end
 
   def waiver?
@@ -152,18 +152,4 @@ class RegistrantPolicy < ApplicationPolicy
   def shared_editable_record?
     user.editable_registrants.include?(record)
   end
-
-  # class Scope < Scope
-  #   def resolve
-  #     if payment_admin?
-  #       scope.all
-  #     end
-
-  #     if registration_closed?
-  #       scope.none
-  #     else
-  #       scope.where(user_id: user.id)
-  #     end
-  #   end
-  # end
 end

--- a/app/views/registrants/index.html.haml
+++ b/app/views/registrants/index.html.haml
@@ -5,7 +5,7 @@
 
 - if EventConfiguration.under_construction?
   = render "reg_under_construction"
-- elsif EventConfiguration.closed?
+- elsif EventConfiguration.singleton.competitor_registration_closed? && EventConfiguration.singleton.noncompetitor_registration_closed?
   = render "reg_closed_banner"
 
 = render :partial => "registrants_list", :locals => {:shared_list => @shared_registrants, :my_registrants_list => @my_registrants}

--- a/spec/controllers/registrants/build_controller_spec.rb
+++ b/spec/controllers/registrants/build_controller_spec.rb
@@ -6,7 +6,8 @@ describe Registrants::BuildController do
   before do
     sign_in user
 
-    allow_any_instance_of(EventConfiguration).to receive(:registration_closed?).and_return(false)
+    allow_any_instance_of(EventConfiguration).to receive(:competitor_registration_closed?).and_return(false)
+    allow_any_instance_of(EventConfiguration).to receive(:noncompetitor_registration_closed?).and_return(false)
     allow_any_instance_of(EventConfiguration).to receive(:organization_membership_config?).and_return(true)
     allow_any_instance_of(EventConfiguration).to receive(:organization_membership_config).and_return(Organization::Usa.new)
   end

--- a/spec/models/event_configuration_spec.rb
+++ b/spec/models/event_configuration_spec.rb
@@ -246,7 +246,7 @@ describe EventConfiguration do
     it "is closed if registration_closed?" do
       travel_to(Date.new(2013, 5, 4)) do
         expect(ev).to be_competitor_registration_closed
-        expect(ev).to be_new_registration_closed_for_limit
+        expect(ev).not_to be_new_registration_closed_for_limit
       end
     end
 

--- a/spec/policies/payment_policy_spec.rb
+++ b/spec/policies/payment_policy_spec.rb
@@ -5,7 +5,7 @@ describe PaymentPolicy do
 
   let(:user) { FactoryBot.create(:user) }
   let(:my_payment) { FactoryBot.build(:payment, user: user) }
-  let(:user_context) { UserContext.new(user, config, reg_closed?, reg_closed?, authorized_laptop?) }
+  let(:user_context) { UserContext.new(user, config, reg_closed?, reg_closed?, reg_closed?, authorized_laptop?) }
   let(:reg_closed?) { false }
   let(:authorized_laptop?) { false }
 

--- a/spec/policies/registrant_policy_spec.rb
+++ b/spec/policies/registrant_policy_spec.rb
@@ -29,7 +29,7 @@ describe RegistrantPolicy do
     let(:new_reg_closed?) { false }
     let(:authorized_laptop?) { false }
     let(:user) { my_user }
-    let(:user_context) { UserContext.new(user, false, reg_closed?, new_reg_closed?, authorized_laptop?) }
+    let(:user_context) { UserContext.new(user, false, reg_closed?, reg_closed?, new_reg_closed?, authorized_laptop?) }
 
     describe "while registration is open" do
       it "allows creation" do
@@ -134,7 +134,7 @@ describe RegistrantPolicy do
     let(:user) { my_user }
     let(:event_sign_up_closed?) { false }
     let(:config) { double(event_sign_up_closed?: event_sign_up_closed?, volunteer_option: "generic", volunteer?: true, wheel_size_configuration_max_age: 10) }
-    let(:user_context) { UserContext.new(user, config, reg_closed?, reg_closed?, authorized_laptop?) }
+    let(:user_context) { UserContext.new(user, config, reg_closed?, reg_closed?, reg_closed?, authorized_laptop?) }
 
     permissions :add_volunteers? do
       describe "when event_configuration has volunteers set by default" do

--- a/spec/policies/registrant_policy_spec.rb
+++ b/spec/policies/registrant_policy_spec.rb
@@ -26,18 +26,18 @@ describe RegistrantPolicy do
 
   permissions :create? do
     let(:reg_closed?) { false }
-    let(:new_reg_closed?) { false }
+    let(:new_reg_closed_for_limit?) { false }
     let(:authorized_laptop?) { false }
     let(:user) { my_user }
-    let(:user_context) { UserContext.new(user, false, reg_closed?, reg_closed?, new_reg_closed?, authorized_laptop?) }
+    let(:user_context) { UserContext.new(user, false, reg_closed?, reg_closed?, new_reg_closed_for_limit?, authorized_laptop?) }
 
     describe "while registration is open" do
       it "allows creation" do
         expect(subject).to permit(user_context, my_registrant)
       end
 
-      context "but new_reg is closed" do
-        let(:new_reg_closed?) { true }
+      context "but reg is closed" do
+        let(:reg_closed?) { true }
 
         it "disallows creation" do
           expect(subject).not_to permit(user_context, my_registrant)
@@ -59,7 +59,7 @@ describe RegistrantPolicy do
 
     describe "when registration is closed" do
       let(:reg_closed?) { true }
-      let(:new_reg_closed?) { true }
+      let(:new_reg_closed_for_limit?) { false }
 
       describe "on a normal laptop" do
         it { expect(subject).not_to permit(user_context, my_registrant) }

--- a/spec/policies/sample_data_policy_spec.rb
+++ b/spec/policies/sample_data_policy_spec.rb
@@ -7,7 +7,7 @@ describe SampleDataPolicy do
   let(:config) { FactoryBot.create(:event_configuration, test_mode: test_mode) }
   let(:reg_closed?) { false }
   let(:authorized_laptop?) { false }
-  let(:user_context) { UserContext.new(user, config, reg_closed?, reg_closed?, authorized_laptop?) }
+  let(:user_context) { UserContext.new(user, config, reg_closed?, reg_closed?, reg_closed?, authorized_laptop?) }
 
   context "a normal user" do
     let(:user) { FactoryBot.create(:user) }

--- a/spec/policies/song_policy_spec.rb
+++ b/spec/policies/song_policy_spec.rb
@@ -12,7 +12,7 @@ describe SongPolicy do
     let(:user) { my_user }
     let(:reg_closed?) { false }
     let(:authorized_laptop?) { false }
-    let(:user_context) { UserContext.new(user, config, reg_closed?, reg_closed?, authorized_laptop?) }
+    let(:user_context) { UserContext.new(user, config, reg_closed?, reg_closed?, reg_closed?, authorized_laptop?) }
 
     it "can update my own song" do
       expect(subject).to permit(user_context, my_song)

--- a/spec/policies/standard_skill_routine_policy_spec.rb
+++ b/spec/policies/standard_skill_routine_policy_spec.rb
@@ -35,7 +35,7 @@ describe StandardSkillRoutinePolicy do
     let(:user) { my_user }
     let(:standard_skill_closed?) { false }
     let(:config) { double(standard_skill_closed?: standard_skill_closed?) }
-    let(:user_context) { UserContext.new(user, config, reg_closed?, reg_closed?, authorized_laptop?) }
+    let(:user_context) { UserContext.new(user, config, reg_closed?, reg_closed?, reg_closed?, authorized_laptop?) }
 
     permissions :create? do
       it { expect(subject).to permit(user_context, my_routine) }


### PR DESCRIPTION
Adds ability for competitor registration to be closed, while the non-comp registration remains open.
If you assign "late_registrant" to a user account, they will still be able to register to periods which have current "on-site" registration costs.