### PR TITLE
Change papertrail storage format for versions history.

### DIFF
--- a/db/migrate/20241110154540_update_papertrail_storage.rb
+++ b/db/migrate/20241110154540_update_papertrail_storage.rb
@@ -1,0 +1,27 @@
+class UpdatePapertrailStorage < ActiveRecord::Migration[7.0]
+  def change
+    add_column :versions, :new_object, :json
+    add_column :versions, :new_object_changes, :json
+
+    # PaperTrail::Version.reset_column_information # needed for rails < 6
+
+    PaperTrail::Version.find_each do |version|
+      version.update_column(:new_object, YAML.unsafe_load(version.object)) if version.object?
+
+      if version.object_changes
+        version.update_column(
+          :new_object_changes,
+          YAML.unsafe_load(version.object_changes)
+        )
+      end
+    end
+
+    # Remove old data:
+    remove_column :versions, :object
+    remove_column :versions, :object_changes
+
+    # Rename new columns to correct(expected) names
+    rename_column :versions, :new_object, :object
+    rename_column :versions, :new_object_changes, :object_changes
+  end
+end

--- a/db/migrate/20241110154540_update_papertrail_storage.rb
+++ b/db/migrate/20241110154540_update_papertrail_storage.rb
@@ -1,5 +1,5 @@
 class UpdatePapertrailStorage < ActiveRecord::Migration[7.0]
-  def change
+  def up
     add_column :versions, :new_object, :json
     add_column :versions, :new_object_changes, :json
 
@@ -23,5 +23,9 @@ class UpdatePapertrailStorage < ActiveRecord::Migration[7.0]
     # Rename new columns to correct(expected) names
     rename_column :versions, :new_object, :object
     rename_column :versions, :new_object_changes, :object_changes
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_17_225306) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_10_154540) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1360,11 +1360,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_17_225306) do
     t.integer "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
-    t.text "object"
     t.datetime "created_at", precision: nil
-    t.text "object_changes"
     t.integer "registrant_id"
     t.integer "user_id"
+    t.json "object"
+    t.json "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 


### PR DESCRIPTION
Necesesary to address security issues with yaml storage, and papertrail's newer versions require safer storage