### PR TITLE
Rails 7.1 deprecates usage of alias_attributes for non-attributes.

### DIFF
--- a/app/models/lodging_package.rb
+++ b/app/models/lodging_package.rb
@@ -60,7 +60,7 @@ class LodgingPackage < ApplicationRecord
 
   def has_details?; end
 
-  alias_method :cost, :total_cost
+  alias :cost, :total_cost
 
   def tax
     0

--- a/app/models/lodging_package.rb
+++ b/app/models/lodging_package.rb
@@ -60,7 +60,7 @@ class LodgingPackage < ApplicationRecord
 
   def has_details?; end
 
-  alias :cost, :total_cost
+  alias cost total_cost
 
   def tax
     0

--- a/app/models/lodging_package.rb
+++ b/app/models/lodging_package.rb
@@ -60,7 +60,7 @@ class LodgingPackage < ApplicationRecord
 
   def has_details?; end
 
-  alias_attribute :cost, :total_cost
+  alias_method :cost, :total_cost
 
   def tax
     0

--- a/app/models/registration_cost.rb
+++ b/app/models/registration_cost.rb
@@ -38,7 +38,7 @@ class RegistrationCost < ApplicationRecord
   after_save :clear_cache
   after_destroy :clear_cache
 
-  alias_method :to_s, :name
+  alias :to_s, :name
 
   # ##################### Class-level ##############
   def self.for_type(registrant_type)

--- a/app/models/registration_cost.rb
+++ b/app/models/registration_cost.rb
@@ -38,7 +38,7 @@ class RegistrationCost < ApplicationRecord
   after_save :clear_cache
   after_destroy :clear_cache
 
-  alias_attribute :to_s, :name
+  alias_method :to_s, :name
 
   # ##################### Class-level ##############
   def self.for_type(registrant_type)

--- a/app/models/registration_cost.rb
+++ b/app/models/registration_cost.rb
@@ -38,7 +38,7 @@ class RegistrationCost < ApplicationRecord
   after_save :clear_cache
   after_destroy :clear_cache
 
-  alias :to_s, :name
+  alias to_s name
 
   # ##################### Class-level ##############
   def self.for_type(registrant_type)


### PR DESCRIPTION
If these were ActiveRecord attributes, that'd be one thing, but since they are not, we should use alias_method instead of alias_attribute