### PR TITLE
Delete any associated best-time entries when the event is destroy.

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -31,6 +31,7 @@ class Event < ApplicationRecord
     has_many :event_categories, -> { order "event_categories.position" }
     has_many :registrant_event_sign_ups
     has_many :competitions, -> { order "competitions.name" }
+    has_many :registrant_best_times
   end
 
   has_many :competitors, through: :competitions

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -98,6 +98,13 @@ describe Event do
     end.to change(EventCategory, :count).by(-1)
   end
 
+  it "destroys associated best times upon destroy" do
+    FactoryBot.create(:registrant_best_time, event: @ev)
+    expect do
+      @ev.destroy
+    end.to change(RegistrantBestTime, :count).by(-1)
+  end
+
   it "creates an associated event_category automatically" do
     expect(@ev.event_categories.count).to eq(1)
     @category = @ev.event_categories.first


### PR DESCRIPTION
This happens if admins change the event list after folks have registered. As a result, some users cannot update their events because of the orphaned records