### PR TITLE
Add an exception to the ignore list for rollbar.

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -31,6 +31,7 @@ Rollbar.configure do |config|
   config.exception_level_filters.merge!("Errors::TenantNotFound" => "ignore",
                                         "ActionController::BadRequest" => "ignore",
                                         "ActiveRecord::RecordNotFound" => "ignore",
+                                        "ActionDispatch::Http::MimeNegotiation::InvalidType" => "ignore",
                                         "AbstractController::ActionNotFound" => "ignore",
                                         "ActionController::RoutingError" => "ignore",
                                         "ActionController::UnknownFormat" => "ignore",


### PR DESCRIPTION
I've never seen these errors as the result of a real user error, always due to crawlers/spammers