### PR TITLE
Fix legal-waiver download link.

### DIFF
--- a/app/controllers/legal_waivers_controller.rb
+++ b/app/controllers/legal_waivers_controller.rb
@@ -1,0 +1,10 @@
+class LegalWaiversController < ApplicationController
+  before_action :skip_authorization
+
+  # redirect to s3 file, so that the link doesn't expire
+  def show
+    raise ActiveRecord::RecordNotFound unless @config.waiver_file_name?
+
+    redirect_to @config.waiver_file_name_url
+  end
+end

--- a/app/views/registrants/_waiver.html.haml
+++ b/app/views/registrants/_waiver.html.haml
@@ -6,4 +6,4 @@
         %b= t(".headline")
         %br
         = t(".parent_guardian_blurb")
-      = link_to t(".print_legal_waiver"), @config.waiver_file_name_url, { class: "print_waiver_link", target: "_blank" }
+      = link_to t(".print_legal_waiver"), legal_waivers_path, { class: "print_waiver_link", target: "_blank" }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,6 +259,7 @@ Rails.application.routes.draw do
     resources :coupon_code_summaries, only: [:show]
 
     resource :convention_specific_rules, only: :show
+    resource :legal_waivers, only: :show
 
     # This concern is exposed to the public for describing the system
     # as well as to Competition Admins for creating competitions

--- a/spec/controllers/legal_waivers_controller_spec.rb
+++ b/spec/controllers/legal_waivers_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe LegalWaiversController do
+  context "with a waiver pdf" do
+    before do
+      @config = FactoryBot.create(:event_configuration, :with_waiver_pdf)
+    end
+
+    it "can download the waiver" do
+      get :show
+      expect(response).to be_redirect
+    end
+  end
+
+  it "raises error if no record found" do
+    expect { get :show }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+end


### PR DESCRIPTION
Make this go through an action so that we don't cache the amazon S3 link content.

This was causing issue because the registrant#index page was caching this block, and not refreshing the s3 credentials