### PR TITLE
Fix form-submission. Clicks the button because we care which button i…

### DIFF
--- a/app/assets/javascripts/competitors.js
+++ b/app/assets/javascripts/competitors.js
@@ -24,7 +24,7 @@ $(document).on("click", ".reg_group_create", function(e) {
   select_all_competitors(false);
   select_group_competitors(ids, false);
   enter_group_name(group_name);
-  submit_form("reg_create_form");
+  submit_form("reg_create_form_submit");
 });
 
 var enter_group_name = function(new_group_name) {
@@ -33,8 +33,8 @@ var enter_group_name = function(new_group_name) {
   });
 }
 
-var submit_form = function(form_class) {
-  $("form." + form_class).submit();
+var submit_form = function(form_submit_class) {
+  $("." + form_submit_class).first().click()
 }
 
 $(document).on("click", ".reg_group_select", function(e) {

--- a/app/views/competitors/_display_sign_ups.html.haml
+++ b/app/views/competitors/_display_sign_ups.html.haml
@@ -10,7 +10,8 @@
 
 %p Choose the registrants that you would like from the following list, and create competitors from those registrants. All registrants should be associated with competitors
 
-- @remaining_registrants = @registrants - (@competition.competitors.map{ |comp| comp.registrants }.flatten)
+- competition_registrants = @competition.competitors.filter(&:persisted?).map{|c| c.registrants}.flatten
+- remaining_registrants = @registrants - competition_registrants
 
 - group_types = RegistrantGroupType.where(source_element: @competition.event)
 - if group_types.any?
@@ -22,7 +23,6 @@
         %th # Members already Competitors
         %th Action
     %tbody
-      - competition_registrants = @competition.competitors.map{|c| c.registrants}.flatten
       - group_types.each do |group_type|
         - group_type.registrant_groups.each do |group|
           %tr
@@ -35,8 +35,8 @@
               %br
               = link_to "Create Competitor from members", "#", class: "reg_group_create", data: { registrant_ids: ids, group_name: group.name }
 
-- if @remaining_registrants.any?
-  = form_tag(add_competition_competitors_path(@competition), class: "reg_create_form", :method => :post) do
+- if remaining_registrants.any?
+  = form_tag(add_competition_competitors_path(@competition), :method => :post) do
     %a#competitor_select_all{:href => "#"}> All
     \/
     %a#competitor_unselect_all{:href => "#"} None
@@ -51,7 +51,7 @@
           %th Sign Up Details
           %th Assigned to another competition?
       %tbody
-        - @remaining_registrants.each do |reg|
+        - remaining_registrants.each do |reg|
           %tr
             - assigned_comp = reg.matching_competition_in_event(@competition.event)
             %td= check_box_tag "registrants[]", reg.id, !assigned_comp, :class => "registrant_checkbox"
@@ -65,12 +65,12 @@
       = submit_tag Competitor.single_selection_text, :class => "action_button", :data => { :confirm => "This will create a SEPARATE competitor for each chosen registrant. Continue?", disable_with: false }
       %br
     - if @competition.num_members_per_competitor == "Two"
-      = submit_tag Competitor.group_selection_text, :class => "action_button", :data => { :confirm => "This will create a Pair with the chosen registrants. Continue?", disable_with: false }
+      = submit_tag Competitor.group_selection_text, :class => "action_button reg_create_form_submit", :data => { :confirm => "This will create a Pair with the chosen registrants. Continue?", disable_with: false }
       %br
     - if display_all ||  @competition.num_members_per_competitor == "Three or more"
       = text_field_tag :group_name, nil, :placeholder => "Group Name (optional)"
       %br
-      = submit_tag Competitor.group_selection_text, :class => "action_button", :data => { :confirm => "This will create a Single competitor for all chosen registrants. Continue?", disable_with: false }
+      = submit_tag Competitor.group_selection_text, :class => "action_button reg_create_form_submit", :data => { :confirm => "This will create a Single competitor for all chosen registrants. Continue?", disable_with: false }
 
     = submit_tag Competitor.not_qualified_text, :class => "counter_action_button", :data => { :confirm => "This will create a Single competitor for each registrants, and mark these as 'not qualified'. Continue?", disable_with: false }
 - else


### PR DESCRIPTION
…s clicked.

If we only submit the form, it doesn't create a single competitor, because it's looking for the text of the button which was clicked.

Also fixes the re-display of the form when form-submission fails. (it was showing that the failed ids were added to a competitor, when they were not)