### PR TITLE
Add batch import for LIF files

### DIFF
--- a/app/controllers/multiple_heat_review_controller.rb
+++ b/app/controllers/multiple_heat_review_controller.rb
@@ -1,0 +1,137 @@
+class MultipleHeatReviewController < ApplicationController
+  before_action :authenticate_user!
+  before_action :load_competition
+  before_action :authorize_competition_data
+
+  before_action :set_breadcrumbs
+
+  # GET /competitions/#/multiple_heat_review
+  def index
+    @lane_assignments = LaneAssignment.where(competition: @competition)
+    @heat_lane_results = HeatLaneResult.where(competition: @competition)
+    @heat_lane_judge_notes = HeatLaneJudgeNote.where(competition: @competition)
+    @time_results = @competition.time_results.joins(:heat_lane_result).merge(HeatLaneResult.all)
+
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  # FOR LIF (track racing) data:
+  # POST /competitions/#/multiple_heat_review/import_lif_files
+  def import_lif_files
+    unless @competition.uses_lane_assignments?
+      flash[:alert] = "Competition not set for lane assignments"
+      redirect_to competition_multiple_heat_review_index_path(@competition)
+      return
+    end
+
+    uploaded_files = UploadedFile.process_params_multiple(params, competition: @competition, user: current_user)
+
+    if uploaded_files.nil?
+      flash[:alert] = "Please specify at least a file"
+      redirect_to competition_multiple_heat_review_index_path(@competition)
+      return
+    end
+
+    uploaded_files.each do |file|
+      parser = Importers::Parsers::Lif.new(file.original_file.file)
+      importer = Importers::HeatLaneLifImporter.new(@competition, current_user)
+
+      # Extracting the heat from the filename
+      match_data = /(\d+).lif$/.match(file.filename)
+      if match_data == nil
+        flash[:alert] = "Error importing rows. Filename '#{file.filename}' does not finish with '{dd}.lif' ('{dd}' being any integer)."
+        redirect_to competition_multiple_heat_review_index_path(@competition)
+        return
+      end
+      heat = match_data.captures[0]
+
+      if importer.process(heat, parser)
+        flash[:notice] = "Successfully imported #{importer.num_rows_processed} rows"
+      else
+        flash[:alert] = "Error importing rows. Errors: #{importer.errors}."
+      end
+    end
+    redirect_to competition_multiple_heat_review_index_path(@competition)
+  end
+
+  # POST /competitions/#/multiple_heat_review/approve_results
+  def approve_results
+    authorize @competition, :create_preliminary_result?
+
+    heat_lane_results = HeatLaneResult.where(competition_id: @competition)
+
+    begin
+      HeatLaneResult.transaction do
+        heat_lane_results.each do |hlr|
+          hlr.import!
+        end
+      end
+    rescue Exception => e
+      errors = e
+    end
+
+    if errors
+      flash[:alert] = "Errors: #{errors}"
+      redirect_back(fallback_location: competition_multiple_heat_review_index_path(@competition))
+    else
+      redirect_to competition_multiple_heat_review_index_path(@competition), notice: "Added results"
+    end
+  end
+
+  # DELETE /competitions/#/multiple_heat_review/
+  def destroy
+    heat_lane_results = HeatLaneResult.where(competition_id: @competition)
+    heat_lane_results.destroy_all
+
+    redirect_to competition_multiple_heat_review_index_path(@competition), notice: "Deleted results. Try Again?"
+  end
+
+  private
+
+  def authorize_competition_data
+    authorize @competition, :create_preliminary_result?
+  end
+
+  def import_result_params
+    params.require(:import_result).permit(:bib_number, :status, :minutes, :raw_data,
+                                          :number_of_penalties, :seconds, :thousands, :points, :details, :is_start_time)
+  end
+
+  def load_user
+    @user = User.this_tenant.find(params[:user_id])
+  end
+
+  def load_competition
+    @competition = Competition.find(params[:competition_id])
+  end
+
+  def load_import_result
+    @import_result = ImportResult.find(params[:id])
+    @competition = @import_result.competition
+  end
+
+  def load_import_results
+    @import_results = @user.import_results.where(competition_id: @competition).includes(:competition)
+  end
+
+  def load_results_for_competition
+    @import_results = ImportResult.where(competition_id: @competition)
+  end
+
+  def filter_import_results_by_start_times
+    @is_start_time = params[:is_start_times] || false
+    @import_results = @import_results.where(is_start_time: @is_start_time)
+  end
+
+  def load_new_import_result
+    @import_result = ImportResult.new(import_result_params)
+    @import_result.user = @user
+    @import_result.competition = @competition
+  end
+
+  def set_breadcrumbs
+    add_to_competition_breadcrumb(@competition)
+  end
+end

--- a/app/lib/local_resource.rb
+++ b/app/lib/local_resource.rb
@@ -14,6 +14,16 @@ class LocalResource
     end
   end
 
+  def files
+    @files ||= Array(ios).map do |input_io|
+      Tempfile.new(tmp_filename, tmp_folder, encoding: encoding).tap do |f|
+        input_io.rewind
+        f.write(input_io.read)
+        f.close
+      end
+    end
+  end
+
   def io
     @io ||= uri.open
   end

--- a/app/models/uploaded_file.rb
+++ b/app/models/uploaded_file.rb
@@ -46,6 +46,20 @@ class UploadedFile < ApplicationRecord
     end
   end
 
+  def self.process_params_multiple(params, user:, competition: nil)
+    if params[:files].present?
+      params[:files].map do |file|
+        p file
+        uploaded_file = UploadedFile.new(user: user)
+        uploaded_file.competition = competition if competition.present?
+        uploaded_file.original_file = file
+        uploaded_file.filename = file.original_filename
+        uploaded_file.save!
+        uploaded_file
+      end
+    end
+  end
+
   def to_s_with_date
     "#{created_at.to_formatted_s(:short)} - #{filename} (#{user})"
   end

--- a/app/views/heat_review/index.html.haml
+++ b/app/views/heat_review/index.html.haml
@@ -5,7 +5,9 @@
   Please ensure that the E-Timer has their camera set to THOUSANDS precision.
   (this system expects 3 decimal places of precision)
 
-%p Choose which heat to import:
+%p= link_to  "Import a batch of files", competition_multiple_heat_review_index_path(@competition)
+
+%p Or choose which heat to import:
 
 %ul
   - @min_heat.upto(@max_heat) do |heat|

--- a/app/views/multiple_heat_review/_multiple_heat_lane_judge_results_details.html.haml
+++ b/app/views/multiple_heat_review/_multiple_heat_lane_judge_results_details.html.haml
@@ -1,0 +1,24 @@
+%h3 DQ Details
+
+%table.sortable
+  %thead
+    %tr
+      %th Heat #
+      %th Lane #
+      %th ID
+      %th Competitor
+      %th DQ
+      %th Comments
+      %th Entered By
+      %th Entered At
+  %tbody
+    - @heat_lane_judge_notes.each do |heat_lane_note|
+      %tr
+        %td= heat_lane_note.heat
+        %td= heat_lane_note.lane
+        %td= heat_lane_note.bib_number
+        %td= heat_lane_note.competitor_name
+        %td= heat_lane_note.disqualified?
+        %td= heat_lane_note.comments
+        %td= heat_lane_note.entered_by
+        %td= heat_lane_note.entered_at

--- a/app/views/multiple_heat_review/_multiple_heat_lane_judge_results_summary.html.haml
+++ b/app/views/multiple_heat_review/_multiple_heat_lane_judge_results_summary.html.haml
@@ -1,0 +1,21 @@
+%h3 DQ Summary
+
+%table.sortable
+  %thead
+    %tr
+      %th Heat #
+      %th Lane #
+      %th DQ
+      %th Comments
+      %th Entered By
+      %th
+  %tbody
+    - @heat_lane_judge_notes.each do |heat_lane_note|
+      %tr
+        %td= heat_lane_note.heat
+        %td= heat_lane_note.lane
+        %td= heat_lane_note.disqualified?
+        %td= heat_lane_note.comments
+        %td= heat_lane_note.entered_by
+        %td
+          = link_to "Merge", merge_competition_heat_lane_judge_note_path(@competition, heat_lane_note), method: :put, class: "button tiny"

--- a/app/views/multiple_heat_review/_multiple_heat_lane_results_details.html.haml
+++ b/app/views/multiple_heat_review/_multiple_heat_lane_results_details.html.haml
@@ -1,0 +1,23 @@
+%h3 E-Timer Imported Details
+%table.sortable
+  %thead
+    %tr
+      %th Heat #
+      %th Lane #
+      %th Raw Data
+      %th Full Time
+      %th DQ
+      %th Entered By
+      %th Entered At
+      %th
+  %tbody
+    - @heat_lane_results.each do |heat_lane_result|
+      %tr
+        %td= heat_lane_result.heat
+        %td= heat_lane_result.lane
+        %td= heat_lane_result.raw_data
+        %td= heat_lane_result.full_time
+        %td= heat_lane_result.disqualified? ? "DQ" : ""
+        %td= heat_lane_result.entered_by
+        %td= heat_lane_result.entered_at
+        %td= link_to t("delete"), heat_lane_result, method: :delete, data: { confirm: t("are_you_sure") }

--- a/app/views/multiple_heat_review/_multiple_heat_lane_results_summary.html.haml
+++ b/app/views/multiple_heat_review/_multiple_heat_lane_results_summary.html.haml
@@ -1,0 +1,17 @@
+%h3 E-Timer Summary
+%table.sortable
+  %thead
+    %tr
+      %th Heat #
+      %th Lane #
+      %th Full Time
+      %th DQ
+      %th
+  %tbody
+    - @heat_lane_results.each do |heat_lane_result|
+      %tr
+        %td= heat_lane_result.heat
+        %td= heat_lane_result.lane
+        %td= heat_lane_result.full_time
+        %td= heat_lane_result.disqualified? ? "DQ" : ""
+        %td= link_to t("delete"), heat_lane_result, method: :delete, data: { confirm: t("are_you_sure") }

--- a/app/views/multiple_heat_review/_multiple_lane_assignments_details.html.haml
+++ b/app/views/multiple_heat_review/_multiple_lane_assignments_details.html.haml
@@ -1,0 +1,15 @@
+%h3 Lane Assignments
+%table.sortable
+  %thead
+    %tr
+      %th Heat #
+      %th Lane #
+      %th ID
+      %th Competitor
+  %tbody
+    - @lane_assignments.each do |lane_assignment|
+      %tr
+        %td= lane_assignment.heat
+        %td= lane_assignment.lane
+        %td= lane_assignment.competitor.bib_number
+        %td= lane_assignment.competitor.to_s

--- a/app/views/multiple_heat_review/_multiple_lif_import_form.html.haml
+++ b/app/views/multiple_heat_review/_multiple_lif_import_form.html.haml
@@ -1,0 +1,6 @@
+%h3 Load Lif
+= form_tag(import_lif_files_competition_multiple_heat_review_index_path(@competition), {:method => :post, :multipart=>true}) do
+  = render partial: "shared/upload_files_for_competition", locals: { competition: @competition }
+  .row
+    .small-6.columns
+      = submit_tag "Load LIF Data", class: "button"

--- a/app/views/multiple_heat_review/_multiple_summary.html.haml
+++ b/app/views/multiple_heat_review/_multiple_summary.html.haml
@@ -1,0 +1,58 @@
+- max_heat = @heat_lane_results.maximum(:heat) || 0
+
+- max_assigned_lane = @lane_assignments.maximum(:lane) || 0
+- max_import_lane = @heat_lane_results.maximum(:lane) || 0
+- max_dq_lane = @heat_lane_judge_notes.maximum(:lane) || 0
+
+- max_lane = [max_assigned_lane, max_import_lane, max_dq_lane].max
+
+%h3 Judging Summary
+%table.sortable.import_results.js--shouldNotMatchSet
+  %thead
+    %tr
+      %th
+      %th
+      %th{ colspan: 2 } Lane Assignments
+      %th{ colspan: 2 } Entered Results
+      %th Warnings
+      %th{ colspan: 1 } Judge Notes
+    %tr
+      %th Heat #
+      %th Lane #
+      %th ID
+      %th Competitor
+      %th Time
+      %th Disqualified
+      %th
+      %th
+  %tbody
+    - 1.upto(max_heat) do |heat_number|
+      - 1.upto(max_lane) do |lane_number|
+        - matching_lane_assignment = @lane_assignments.find_by(heat: heat_number, lane: lane_number)
+        - matching_import_result = @heat_lane_results.find_by(heat: heat_number, lane: lane_number)
+        - judges_notes = @heat_lane_judge_notes.where(heat: heat_number, lane: lane_number)
+        %tr
+          %td= heat_number
+          %td= lane_number
+          - if matching_lane_assignment.present?
+            %td= matching_lane_assignment.competitor.bib_number
+            %td= matching_lane_assignment.competitor.to_s
+          - else
+            %td.missing_data
+            %td.missing_data
+
+          - if matching_import_result.present?
+            %td= matching_import_result.full_time
+            %td= matching_import_result.disqualified? ? "DQ" : ""
+            %td.js--highlightIfNotBlank= matching_import_result.competitor_has_results? ? "WARN: Competitor already has result" : ""
+          - else
+            %td.missing_data
+            %td.missing_data
+            %td
+          - if judges_notes.any?
+            %td
+              - judges_notes.each do |note|
+                = note
+                %br
+          - else
+            %td

--- a/app/views/multiple_heat_review/_multiple_time_results_details.html.haml
+++ b/app/views/multiple_heat_review/_multiple_time_results_details.html.haml
@@ -1,0 +1,23 @@
+%h3 Official Results
+%table.sortable
+  %thead
+    %tr
+      %th Heat #
+      %th Lane #
+      %th ID
+      %th Competitor
+      %th Full Time
+      %th DQ
+      %th
+      %th
+  %tbody
+    - @time_results.each do |time_result|
+      %tr
+        %td= time_result.heat_lane_result.heat
+        %td= time_result.heat_lane_result.lane
+        %td= time_result.bib_number
+        %td= time_result.competitor
+        %td= time_result.full_time
+        %td= time_result.disqualified? ? "DQ" : ""
+        %td= link_to t("edit"), edit_time_result_path(time_result), target: "_blank"
+        %td= link_to t("delete"), time_result, method: :delete, data: { confirm: t("are_you_sure") }

--- a/app/views/multiple_heat_review/index.html.haml
+++ b/app/views/multiple_heat_review/index.html.haml
@@ -1,0 +1,45 @@
+%h1
+  Review Data for #{@competition}
+
+.row
+  .small-12.columns
+    = render "multiple_time_results_details"
+  .small-12.columns
+    = render "multiple_summary"
+%hr
+.row
+  .small-12.medium-6.large-4.columns
+    = render "multiple_lane_assignments_details"
+  .small-12.medium-6.large-4.columns
+    = render "multiple_heat_lane_results_summary"
+    - if @heat_lane_results.any?
+      .row
+        .small-6.columns
+          = link_to "Delete The Imported Resuls without Approving", competition_multiple_heat_review_index_path(@competition), method: :delete, data: { confirm: "Deleting, Are you sure?" }, class: "button alert small"
+        .small-6.columns
+          = link_to "Import these Results", approve_results_competition_multiple_heat_review_index_path(@competition), method: :post, data: {:confirm => "Are you Sure?" }, class: "button success"
+
+    - else
+      = render "multiple_lif_import_form"
+
+    %br
+
+  .small-12.medium-6.large-4.columns
+    = render "multiple_heat_lane_judge_results_summary"
+
+%hr
+
+.row
+  .small-12.columns
+    = render "multiple_heat_lane_judge_results_details"
+  .small-12.columns
+    = render "multiple_heat_lane_results_details"
+
+%hr
+%hr
+%h3 Calculate Age Group Places
+= render "competitions/set_age_group_places"
+
+= render "competitions/publish_age_group_entries"
+
+= link_to "Back to Heat Chooser", competition_multiple_heat_review_index_path(@competition)

--- a/app/views/shared/_upload_files_for_competition.html.haml
+++ b/app/views/shared/_upload_files_for_competition.html.haml
@@ -1,0 +1,5 @@
+.row
+  .small-6.columns
+    = label_tag "files[]", "Source Files"
+  .small-6.columns
+    = file_field_tag "files[]", multiple: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -708,6 +708,14 @@ Rails.application.routes.draw do
         end
       end
 
+      resources :multiple_heat_review, only: %i[index] do
+        collection do
+          post :approve_results
+          post :import_lif_files
+          delete :destroy
+        end
+      end
+
       resources :heat_review, param: :heat, only: %i[index show destroy] do
         member do
           post :approve_heat

--- a/spec/controllers/multiple_heats_review_controller_spec.rb
+++ b/spec/controllers/multiple_heats_review_controller_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe MultipleHeatReviewController do
+  before do
+    @competition = FactoryBot.create(:timed_competition, uses_lane_assignments: true)
+    director = FactoryBot.create(:user)
+    director.add_role(:director, @competition.event)
+    sign_in director
+    @reg = FactoryBot.create(:registrant)
+    @competitor = FactoryBot.create(:event_competitor, competition: @competition)
+    @competitor.members.first.update_attribute(:registrant_id, @reg.id)
+    @lane_assignment = FactoryBot.create(:lane_assignment, competition: @competition, competitor: @competitor)
+  end
+
+  describe "GET index" do
+    before { get :index, params: { competition_id: @competition.id } }
+
+    it do
+      header = "Review Data for " + @competition.name
+      assert_select "h1", text: header
+    end
+  end
+
+  describe "POST import_lif_files" do
+    describe "with valid params" do
+      let(:test_file_name) { "#{fixture_path}/test2.lif" }
+      let(:test_file) { Rack::Test::UploadedFile.new(test_file_name, "text/plain") }
+
+      it "calls the creator" do
+        allow_any_instance_of(Importers::HeatLaneLifImporter).to receive(:process).and_return(true)
+        post :import_lif_files, params: { competition_id: @competition.id, files: [test_file] }
+
+        expect(flash[:notice]).to match(/Successfully imported/)
+      end
+    end
+
+    describe "with invalid params" do
+      describe "when the file is missing" do
+        def do_action
+          post :import_lif_files, params: { competition_id: @competition.id, file: nil }
+        end
+
+        it "returns an error" do
+          do_action
+          assert_match(/Please specify at least a file/, flash[:alert])
+        end
+      end
+    end
+  end
+
+  describe "POST approve_results" do
+    describe "with valid params" do
+      let(:test_file) { "stubbed" }
+
+      it "calls the creator" do
+        post :approve_results, params: { competition_id: @competition.id }
+
+        expect(flash[:notice]).to match(/Added results/)
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    let!(:result) { FactoryBot.create(:heat_lane_result, competition: @competition) }
+
+    it "removes all heat lane results" do
+      expect do
+        delete :destroy, params: { competition_id: @competition.id }
+      end.to change(HeatLaneResult, :count).by(-1)
+    end
+  end
+end


### PR DESCRIPTION
We sometimes can't upload LIF files one after the other, because it can take lots of time. Here's a new page that makes it possible to upload a batch of LIF files instead.

This is a copy of the one-heat import page, which adds the "heat" column for each table, and lets the user import multiple files at once.

<img width="1138" height="256" alt="image" src="https://github.com/user-attachments/assets/6a54b5f6-2a3f-4157-8f60-d57dac78a77b" />

<img width="2376" height="2100" alt="image" src="https://github.com/user-attachments/assets/fa1e3c2a-6dd2-4786-b74d-a8620bc30e12" />

<img width="2376" height="2919" alt="image" src="https://github.com/user-attachments/assets/e74d5d2d-73e7-4b5b-801b-3acccb526cca" />

(Names don't match in the imported files and in the registration because I didn't take the time to make everything clean.)

This PR includes a lot of duplication. It may be great to clean it later on, when we have time.