### PR TITLE
Support "AB" and "NP" in LIF files

### DIFF
--- a/app/actions/importers/parsers/lif.rb
+++ b/app/actions/importers/parsers/lif.rb
@@ -29,7 +29,9 @@ class Importers::Parsers::Lif < Importers::Parsers::Base
 
     full_time = arr[6].to_s
     # TODO: Extract this into a StatusTranslation
-    if full_time == "DQ" || arr[0] == "DQ" || arr[0] == "DNS" || arr[0] == "DNF"
+    # "NP" stands for "Non-Partant" (DNS) in French
+    # "AB" stands for "Absent" (not there) in French
+    if full_time == "DQ" || arr[0].in?(%w[DQ DNS DNF NP AB])
       results[:disqualified] = true
       results[:minutes] = 0
       results[:seconds] = 0

--- a/spec/actions/importers/parsers/lif_spec.rb
+++ b/spec/actions/importers/parsers/lif_spec.rb
@@ -55,6 +55,26 @@ describe Importers::Parsers::Lif do
     expect(hash[:disqualified]).to eq(true)
   end
 
+  it "can convert a French AB into data" do
+    arr = ['AB', 0, 4, 'Rosen', 'Matthew', 'Bloomington Jefferson', '', '', '', '', '', '18:47:30.471', 'M', '', '', '', '']
+
+    hash = up.convert_lif_to_hash(arr)
+    expect(hash[:minutes]).to eq(0)
+    expect(hash[:seconds]).to eq(0)
+    expect(hash[:thousands]).to eq(0)
+    expect(hash[:disqualified]).to eq(true)
+  end
+
+  it "can convert a French NP into data" do
+    arr = ['NP', 0, 4, 'Rosen', 'Matthew', 'Bloomington Jefferson', '', '', '', '', '', '18:47:30.471', 'M', '', '', '', '']
+
+    hash = up.convert_lif_to_hash(arr)
+    expect(hash[:minutes]).to eq(0)
+    expect(hash[:seconds]).to eq(0)
+    expect(hash[:thousands]).to eq(0)
+    expect(hash[:disqualified]).to eq(true)
+  end
+
   it "can convert an array of data into minutes, seconds, thousands, dq" do
     arr = [3, '', 7, '', '', '', "32.490", '', 12.142, '', '', '', '', '', '']
 


### PR DESCRIPTION
Our French tools can yield "AB" and "NP" instead of "DQ", "DNS" or "DNF". We'd like to support it as soon as possible. As the TODO says, we'll have to extract this test into something better.