### PR TITLE
Always display batch import file importer

### DIFF
--- a/app/views/multiple_heat_review/index.html.haml
+++ b/app/views/multiple_heat_review/index.html.haml
@@ -19,8 +19,7 @@
         .small-6.columns
           = link_to "Import these Results", approve_results_competition_multiple_heat_review_index_path(@competition), method: :post, data: {:confirm => "Are you Sure?" }, class: "button success"
 
-    - else
-      = render "multiple_lif_import_form"
+    = render "multiple_lif_import_form"
 
     %br
 


### PR DESCRIPTION
After having imported a batch of LIFs, we can't import new files with this method:
<img width="400" height="379" alt="image" src="https://github.com/user-attachments/assets/d65354ac-5b35-45bf-8467-50dcab06cc78" />

This PR strives to fix this error. The importer should always be displayed:
<img width="400" height="524" alt="image" src="https://github.com/user-attachments/assets/dd5689a4-bbfd-4fcb-b070-ea9b856c8ef0" />
