### PR TITLE
Allow importing LIF file from a URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,8 @@ gem 'faker' # to support 'sample_data'
 
 gem 'pg'
 
+gem 'down'  # to download external files
+
 # deployment
 gem 'capistrano', require: false
 gem 'capistrano-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,6 +315,8 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    down (5.4.2)
+      addressable (~> 2.8)
     drb (2.2.3)
     equalizer (0.0.11)
     erb (4.0.4)
@@ -772,6 +774,7 @@ DEPENDENCIES
   devise
   devise-i18n
   dotenv-rails
+  down
   eye
   factory_bot_rails
   faker

--- a/app/views/heat_review/_lif_import_form.html.haml
+++ b/app/views/heat_review/_lif_import_form.html.haml
@@ -2,5 +2,10 @@
 = form_tag(import_lif_competition_heat_review_path(@competition, @heat), {:method => :post, :multipart=>true}) do
   = render partial: "shared/upload_file_for_competition", locals: { competition: @competition }
   .row
-    .small-6.columns
-      = submit_tag "Load LIF Data", class: "button"
+    = submit_tag "Load LIF Data", class: "button"
+
+= form_tag(import_lif_from_url_competition_heat_review_path(@competition, @heat), {:method => :post}) do
+  .row
+    = text_field_tag :file_url
+  .row
+    = submit_tag "Import from an URL", class: "button"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -721,6 +721,7 @@ Rails.application.routes.draw do
         member do
           post :approve_heat
           post :import_lif
+          post :import_lif_from_url
         end
       end
       resources :distance_attempts, only: [] do


### PR DESCRIPTION
We have just learned that our result files will be automatically uploaded onto a server, and that we won't have to get them from a USB key as last years. So, to avoid having to download them one after the other and then upload them onto UDA, here's a simple way to give UDA the file URL and let it automatically download the file.

I hope this file inclusion does not pose any security issue. `Down.download` checks that the URL starts with `http` or `https`, so it should not lead to any local file inclusion. Besides that consideration, I don't think we offer more possibilities to an attacker, compared to what already exists.