### PR TITLE
Fix rounding error when paying with stripe.

### DIFF
--- a/app/models/payment_detail_summary.rb
+++ b/app/models/payment_detail_summary.rb
@@ -38,7 +38,7 @@ class PaymentDetailSummary
   end
 
   def amount_cents
-    (amount.to_i * 100).round
+    (amount.to_f * 100).round
   end
 
   def ==(other)

--- a/spec/models/payment_detail_summary_spec.rb
+++ b/spec/models/payment_detail_summary_spec.rb
@@ -8,4 +8,14 @@ describe PaymentDetailSummary do
   it "has the to_s of the associated expense_item" do
     expect(@pds.to_s).to eq(@pds.line_item.to_s)
   end
+
+  context "when detail_summary has fractions of dollar" do
+    before do
+      @pds = FactoryBot.create(:payment_detail_summary, amount: "9.99")
+    end
+
+    it "doesn't round things to the nearest dollar" do
+      expect(@pds.amount_cents).to eq(999)
+    end
+  end
 end


### PR DESCRIPTION
It was incorrectly rounding to the dollar