### PR TITLE
Revert "Bump sidekiq from 7.3.10 to 8.1.3"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem 'request_store' # Supports EventConfiguration.singleton
 gem 'rollbar'
 gem 'rubyzip'
 gem 'sassc-rails' # needed for SCSS compilation (tolk dep + sprockets)
-gem 'sidekiq', '~> 8.1.3' # as per sidekiq recommendations, always lock like this
+gem 'sidekiq', '~> 7.3.0' # as per sidekiq recommendations, always lock like this
 gem 'stripe'
 gem 'webrick'
 gem 'whenever'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,7 +273,7 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     consistency_fail (0.3.7)
     countries (7.1.1)
       unaccent (~> 0.3)
@@ -557,7 +557,7 @@ GEM
     recaptcha (5.21.2)
     redis (5.4.1)
       redis-client (>= 0.22.0)
-    redis-client (0.28.0)
+    redis-client (0.26.4)
       connection_pool
     regexp_parser (2.10.0)
     reline (0.6.3)
@@ -648,12 +648,12 @@ GEM
     select2-rails (4.0.13)
     shoulda-matchers (6.5.0)
       activesupport (>= 5.2.0)
-    sidekiq (8.1.3)
-      connection_pool (>= 3.0.0)
-      json (>= 2.16.0)
-      logger (>= 1.7.0)
-      rack (>= 3.2.0)
-      redis-client (>= 0.26.0)
+    sidekiq (7.3.10)
+      base64
+      connection_pool (>= 2.3.0, < 3)
+      logger
+      rack (>= 2.2.4, < 3.3)
+      redis-client (>= 0.23.0, < 1)
     simple_form (5.4.1)
       actionpack (>= 7.0)
       activemodel (>= 7.0)
@@ -834,7 +834,7 @@ DEPENDENCIES
   sassc-rails
   select2-rails
   shoulda-matchers
-  sidekiq (~> 8.1.3)
+  sidekiq (~> 7.3.0)
   simple_form
   spreadsheet
   sprockets (~> 4.0)


### PR DESCRIPTION
Reverts rdunlop/unicycling-registration#2997
We don't have a sufficiently new version of redis running.