### PR TITLE
Add different rules for competitors with ineligible member(s)

### DIFF
--- a/app/controllers/competition_setup/competitions_controller.rb
+++ b/app/controllers/competition_setup/competitions_controller.rb
@@ -72,7 +72,7 @@ class CompetitionSetup::CompetitionsController < ApplicationController
                                         :sign_in_list_enabled, :time_entry_columns,
                                         :import_results_into_other_competition,
                                         :hide_max_laps_count, :allow_competitor_creation_during_import_approval,
-                                        :score_ineligible_competitors, :results_header,
+                                        :rule_for_ineligible_competitors, :results_header,
                                         competition_sources_attributes: %i[id event_category_id gender_filter min_age max_age competition_id max_place _destroy])
   end
 

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -28,10 +28,10 @@
 #  time_entry_columns                               :string           default("minutes_seconds_thousands")
 #  import_results_into_other_competition            :boolean          default(FALSE), not null
 #  base_age_group_type_id                           :integer
-#  score_ineligible_competitors                     :boolean          default(FALSE), not null
 #  results_header                                   :string
 #  hide_max_laps_count                              :boolean          default(FALSE), not null
 #  allow_competitor_creation_during_import_approval :boolean          default(FALSE), not null
+#  rule_for_ineligible_competitors                  :integer          default(100), not null
 #
 # Indexes
 #
@@ -144,6 +144,15 @@ class Competition < ApplicationRecord
             :can_eliminate_judges?, :freestyle_summary?,
             :result_description, :compete_in_order?, :scoring_description,
             :example_result, :imports_times?, :imports_points?, :results_path, :scoring_path, to: :scoring_helper
+
+  def self.rules_for_ineligible_competitors
+    [
+      [I18n.t("activerecord.attributes.competition.never_score"), 100],
+      [I18n.t("activerecord.attributes.competition.always_score"), 0],
+      [I18n.t("activerecord.attributes.competition.score_if_at_least_half_eligible"), 50]
+    ]
+  end
+  validates :rule_for_ineligible_competitors, presence: true, comparison: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
 
   after_commit :update_age_group_if_necessary, on: %i[create update]
 
@@ -508,6 +517,11 @@ class Competition < ApplicationRecord
     best_attempts_for_each_competitor = competitors.map(&:max_successful_distance_attempt).compact
 
     best_attempts_for_each_competitor.sort { |a, b| b.distance <=> a.distance }
+  end
+
+  # Backwards-compatibility hack
+  def score_ineligible_competitors?
+    rule_for_ineligible_competitors == 0
   end
 
   private

--- a/app/models/competitor.rb
+++ b/app/models/competitor.rb
@@ -418,15 +418,15 @@ class Competitor < ApplicationRecord
     Rails.cache.fetch("/competitor/#{id}-#{updated_at}/ineligible") do
       return true unless active?
 
-      if members.empty?
+      # If no member or always score, whatever the competitor ineligibility is
+      rule_for_ineligible_competitors = competition.rule_for_ineligible_competitors
+      if members.empty? || rule_for_ineligible_competitors == 0
         false
       else
-        eligibles = members.map(&:ineligible?)
-        if eligibles.uniq.count > 1
-          true # includes both eligible status AND ineligible status
-        else
-          eligibles.first
-        end
+        # If the percentage of ineligible members is greater than `rule_for_ineligible_competitors`,
+        # then the competitor is considered as ineligible
+        percentage = 100.0 * members.filter(&:ineligible?).count.to_f / members.count
+        percentage > (100 - rule_for_ineligible_competitors)
       end
     end
   end

--- a/app/views/competition_setup/competitions/_form.html.haml
+++ b/app/views/competition_setup/competitions/_form.html.haml
@@ -37,7 +37,7 @@
   = f.input :scheduled_completion_at, as: :datetime_picker, include_blank: true
 
   = f.input :scoring_class, collection: Competition.scoring_classes, include_blank: true, input_html: { class: "js--blockVisibleSource" }
-  = f.input :score_ineligible_competitors, label: "Score Ineligible Competitors as normal riders (no automatic ties)"
+  = f.input :rule_for_ineligible_competitors, collection: Competition.rules_for_ineligible_competitors, default: :never_score
   = f.input :results_header, label: "Text which should appear on each results page"
   %hr
 

--- a/config/locales/models/competition.da.yml
+++ b/config/locales/models/competition.da.yml
@@ -15,6 +15,10 @@ da:
         penalty_seconds: Secunder pr. Straf
         scheduled_completion_at: Planlagt tidspunkt for afslutning
         scoring_class: Scoring Type
+        rule_for_ineligible_competitors: Udelukkelse af deltagere
+        always_score: Bedøm de deltagere, der ikke er kvalificerede, som om de var kvalificerede
+        never_score: Giv aldrig point til deltagere, der ikke er kvalificerede
+        score_if_at_least_half_eligible: Der gives point, hvis mindst halvdelen af medlemmerne er valgbare
         start_data_type: Start Line Data Entry
         uses_lane_assignments: Konkurer i baner/heats
     models:

--- a/config/locales/models/competition.de.yml
+++ b/config/locales/models/competition.de.yml
@@ -15,6 +15,10 @@ de:
         penalty_seconds: Sekunden pro Strafe
         scheduled_completion_at: Geplante Vervollständigungszeit
         scoring_class: Wertungstyp
+        rule_for_ineligible_competitors: Ungeeignete Teilnehmer
+        always_score: Ungeeignete Teilnehmer so bewerten, als wären sie geeignet
+        never_score: Ungeeignete Teilnehmer niemals werten
+        score_if_at_least_half_eligible: Werten, wenn mindestens die Hälfte der Mitglieder geeignet ist
         start_data_type: Starliniendaten Eingabe
         uses_lane_assignments: Teilnahme in Reihen / Läufen
     models: 

--- a/config/locales/models/competition.en.yml
+++ b/config/locales/models/competition.en.yml
@@ -6,6 +6,10 @@ en:
         name: Competition Name
         scheduled_completion_at: Scheduled Completion Time
         scoring_class: Scoring Type
+        rule_for_ineligible_competitors: Competitors Ineligibility
+        always_score: Score ineligible competitors as if they were eligible
+        never_score: Never score ineligible competitors
+        score_if_at_least_half_eligible: Score if at least half of the members are eligible
         num_members_per_competitor: Team Size
         penalty_seconds: Seconds per Penalty
         uses_lane_assignments: Compete in Lanes/Heats

--- a/config/locales/models/competition.es.yml
+++ b/config/locales/models/competition.es.yml
@@ -14,6 +14,10 @@ es:
         penalty_seconds: Segundos por penalización
         scheduled_completion_at: Tiempo de finalización Programado
         scoring_class: Tipo de puntuación
+        rule_for_ineligible_competitors: Inelegibilidad de los participantes
+        always_score: Puntuar a los participantes no admisibles como si fueran admisibles
+        never_score: Nunca puntúes a participantes que no cumplan los requisitos
+        score_if_at_least_half_eligible: Se puntúa si al menos la mitad de los miembros cumplen los requisitos
         start_data_type: Entrada de datos de la Linea de Salida
         uses_lane_assignments: Compite en Carriles / Series
     models:

--- a/config/locales/models/competition.fr.yml
+++ b/config/locales/models/competition.fr.yml
@@ -16,6 +16,10 @@ fr:
         penalty_seconds: Secondes par pénalités
         scheduled_completion_at: Heure de fin prévue
         scoring_class: Type de score
+        rule_for_ineligible_competitors: Inéligibilité des compétiteurs
+        always_score: Classer les compétiteurs inéligibles comme s'ils étaient éligibles
+        never_score: Ne jamais classer les compétiteurs inéligibles
+        score_if_at_least_half_eligible: Classer les équipes si au moins la moitié des membres sont éligibles
         start_data_type: Donnée de départ
         uses_lane_assignments: Sera attribué à la ligne/vague
     models:

--- a/config/locales/models/competition.it.yml
+++ b/config/locales/models/competition.it.yml
@@ -14,6 +14,10 @@ it:
         penalty_seconds: Secondi di penalità
         scheduled_completion_at: Orario finale previsto
         scoring_class: Punteggio di categoria
+        rule_for_ineligible_competitors: Inammissibilità dei concorrenti
+        always_score: Valutare i concorrenti non ammessi come se fossero ammessi
+        never_score: Non assegnare mai punti a concorrenti non ammessi
+        score_if_at_least_half_eligible: Si ottiene un punto se almeno la metà dei membri soddisfa i requisiti
         start_data_type: Immissione dati della partenza
         uses_lane_assignments: Gara in corsie/in batterie
     models:

--- a/config/locales/models/competition.nl.yml
+++ b/config/locales/models/competition.nl.yml
@@ -15,6 +15,10 @@ nl:
         penalty_seconds: Secondes per strafpunt
         scheduled_completion_at: Geplande competietijd
         scoring_class: Score type
+        rule_for_ineligible_competitors: Uitsluiting van deelnemers
+        always_score: Beoordeel deelnemers die niet in aanmerking komen alsof ze dat wel doen
+        never_score: Geef nooit punten aan deelnemers die niet in aanmerking komen
+        score_if_at_least_half_eligible: Er wordt gescoord als ten minste de helft van de leden in aanmerking komt
         start_data_type: Manier van ingeven van de startdata
         uses_lane_assignments: Competitie in heats of banen
     models:

--- a/db/migrate/20260605112734_rules_for_teams_including_ineligible_members.rb
+++ b/db/migrate/20260605112734_rules_for_teams_including_ineligible_members.rb
@@ -1,0 +1,38 @@
+class RulesForTeamsIncludingIneligibleMembers < ActiveRecord::Migration[8.1]
+  def up
+    # Defaults match the previous behavior: 100% of members should be eligible (score_ineligible_competitors was false by default)
+    add_column :competitions, :rule_for_ineligible_competitors, :integer, null: false, default: 100
+    execute <<-SQL
+        UPDATE competitions c1
+        SET rule_for_ineligible_competitors = (
+            SELECT
+                -- If ineligible competitors were scored => 0% of members have to be eligible to score
+                CASE WHEN c2.score_ineligible_competitors THEN 0
+                -- If ineligible competitors weren't scored => 100% of members have to be eligible to score
+                    ELSE 100
+                END
+            FROM competitions c2
+            WHERE c1.id = c2.id
+        )
+    SQL
+    remove_column :competitions, :score_ineligible_competitors, :boolean, null: false
+  end
+
+  def down
+    add_column :competitions, :score_ineligible_competitors, :boolean, null: false, default: false
+    execute <<-SQL
+        UPDATE competitions c1
+        SET score_ineligible_competitors = (
+            SELECT
+                -- If 0% of members have to be eligible to score => score ineligible competitors
+                CASE WHEN c2.rule_for_ineligible_competitors = 0 THEN true
+                -- Otherwise => don't score ineligible competitors
+                    ELSE false
+                END
+            FROM competitions c2
+            WHERE c1.id = c2.id
+        )
+    SQL
+    remove_column :competitions, :rule_for_ineligible_competitors, :integer, null: false
+  end
+end

--- a/db/migrate/20260605112734_rules_for_teams_including_ineligible_members.rb
+++ b/db/migrate/20260605112734_rules_for_teams_including_ineligible_members.rb
@@ -12,17 +12,8 @@ class RulesForTeamsIncludingIneligibleMembers < ActiveRecord::Migration[8.1]
   def down
     add_column :competitions, :score_ineligible_competitors, :boolean, null: false, default: false
     execute <<-SQL
-        UPDATE competitions c1
-        SET score_ineligible_competitors = (
-            SELECT
-                -- If 0% of members have to be eligible to score => score ineligible competitors
-                CASE WHEN c2.rule_for_ineligible_competitors = 0 THEN true
-                -- Otherwise => don't score ineligible competitors
-                    ELSE false
-                END
-            FROM competitions c2
-            WHERE c1.id = c2.id
-        )
+        UPDATE competitions
+        SET score_ineligible_competitors = (rule_for_ineligible_competitors = 0)
     SQL
     remove_column :competitions, :rule_for_ineligible_competitors, :integer, null: false
   end

--- a/db/migrate/20260605112734_rules_for_teams_including_ineligible_members.rb
+++ b/db/migrate/20260605112734_rules_for_teams_including_ineligible_members.rb
@@ -3,17 +3,8 @@ class RulesForTeamsIncludingIneligibleMembers < ActiveRecord::Migration[8.1]
     # Defaults match the previous behavior: 100% of members should be eligible (score_ineligible_competitors was false by default)
     add_column :competitions, :rule_for_ineligible_competitors, :integer, null: false, default: 100
     execute <<-SQL
-        UPDATE competitions c1
-        SET rule_for_ineligible_competitors = (
-            SELECT
-                -- If ineligible competitors were scored => 0% of members have to be eligible to score
-                CASE WHEN c2.score_ineligible_competitors THEN 0
-                -- If ineligible competitors weren't scored => 100% of members have to be eligible to score
-                    ELSE 100
-                END
-            FROM competitions c2
-            WHERE c1.id = c2.id
-        )
+        UPDATE competitions
+        SET rule_for_ineligible_competitors = CASE WHEN score_ineligible_competitors THEN 0 ELSE 100 END
     SQL
     remove_column :competitions, :score_ineligible_competitors, :boolean, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_21_022913) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_05_112734) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -237,8 +237,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_21_022913) do
     t.integer "penalty_seconds"
     t.datetime "published_at", precision: nil
     t.string "results_header"
+    t.integer "rule_for_ineligible_competitors", default: 100, null: false
     t.datetime "scheduled_completion_at", precision: nil
-    t.boolean "score_ineligible_competitors", default: false, null: false
     t.string "scoring_class"
     t.boolean "sign_in_list_enabled", default: false, null: false
     t.string "start_data_type"

--- a/spec/factories/competitions.rb
+++ b/spec/factories/competitions.rb
@@ -28,10 +28,10 @@
 #  time_entry_columns                               :string           default("minutes_seconds_thousands")
 #  import_results_into_other_competition            :boolean          default(FALSE), not null
 #  base_age_group_type_id                           :integer
-#  score_ineligible_competitors                     :boolean          default(FALSE), not null
 #  results_header                                   :string
 #  hide_max_laps_count                              :boolean          default(FALSE), not null
 #  allow_competitor_creation_during_import_approval :boolean          default(FALSE), not null
+#  rule_for_ineligible_competitors                  :integer          default(100), not null
 #
 # Indexes
 #

--- a/spec/lib/ordered_result_calculator_spec.rb
+++ b/spec/lib/ordered_result_calculator_spec.rb
@@ -96,6 +96,55 @@ describe OrderedResultCalculator do
         expect(@tr3.competitor.place).to eq(2)
       end
     end
+
+    describe "with a 'Always Score' ineligibility policy" do
+      describe "with an ineligible registrant in first place" do
+        before do
+          @competition.rule_for_ineligible_competitors = 0
+          @competition.save!
+          r = @tr1.competitor.reload.members.first.registrant
+          r.ineligible = true
+          r.save!
+          @tr1.reload
+        end
+
+        it "sets the competitor places to same order as the points" do
+          recalc
+          @tr2.reload
+          @tr3.reload
+
+          expect(@tr1.competitor.place).to eq(1)
+          expect(@tr2.competitor.place).to eq(2)
+          expect(@tr3.competitor.place).to eq(3)
+          expect(@tr4.competitor.place).to eq(4)
+        end
+      end
+    end
+
+    describe "with a 'Score if at least half the team is eligible' ineligibility policy" do
+      describe "with an ineligible team in first place" do
+        before do
+          @competition.rule_for_ineligible_competitors = 50
+          @competition.save!
+          r = @tr1.competitor.reload.members.first.registrant
+          r.ineligible = true
+          r.save!
+          FactoryBot.create(:member, competitor: @tr1.competitor, registrant: FactoryBot.create(:registrant, ineligible: true))
+          @tr1.reload
+        end
+
+        it "places the first 2 competitors as first" do
+          recalc
+          @tr2.reload
+          @tr3.reload
+
+          expect(@tr1.competitor.place).to eq(1)
+          expect(@tr2.competitor.place).to eq(1)
+          expect(@tr3.competitor.place).to eq(2)
+          expect(@tr4.competitor.place).to eq(3)
+        end
+      end
+    end
   end
 
   describe "when calculating the placing of higher-points-is-better races" do

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -28,10 +28,10 @@
 #  time_entry_columns                               :string           default("minutes_seconds_thousands")
 #  import_results_into_other_competition            :boolean          default(FALSE), not null
 #  base_age_group_type_id                           :integer
-#  score_ineligible_competitors                     :boolean          default(FALSE), not null
 #  results_header                                   :string
 #  hide_max_laps_count                              :boolean          default(FALSE), not null
 #  allow_competitor_creation_during_import_approval :boolean          default(FALSE), not null
+#  rule_for_ineligible_competitors                  :integer          default(100), not null
 #
 # Indexes
 #

--- a/spec/models/competitor_spec.rb
+++ b/spec/models/competitor_spec.rb
@@ -250,8 +250,8 @@ describe Competitor do
     end
 
     it "returns the first registrant when two registrants" do
-      @comp.registrants << FactoryBot.create(:registrant)
-      @comp.save!
+      FactoryBot.create(:member, competitor: @comp)
+      expect(@comp.registrants.count).to eq(2)
       expect(@comp.registrants.map(&:external_id)).to include(@comp.export_id)
     end
   end
@@ -612,6 +612,61 @@ describe Competitor do
     end
 
     it "is ineligible itself" do
+      expect(@comp).to be_ineligible
+    end
+  end
+
+  describe "with an eligible registrant and an ineligible registrant" do
+    before do
+      FactoryBot.create(:member, registrant: FactoryBot.create(:registrant, ineligible: true), competitor: @comp)
+    end
+
+    it "is eligible if score whatever the proportion of ineligible members" do
+      competition = @comp.reload.competition
+      competition.rule_for_ineligible_competitors = 0
+      competition.save!
+      expect(@comp).not_to be_ineligible
+    end
+
+    it "is ineligible if score only if no ineligible member" do
+      competition = @comp.reload.competition
+      competition.rule_for_ineligible_competitors = 100
+      competition.save!
+      expect(@comp).to be_ineligible
+    end
+
+    it "is eligible if score if at least half the team is eligible" do
+      competition = @comp.reload.competition
+      competition.rule_for_ineligible_competitors = 50
+      competition.save!
+      expect(@comp).not_to be_ineligible
+    end
+  end
+
+  describe "with an eligible registrant and two ineligible registrants" do
+    before do
+      FactoryBot.create(:member, registrant: FactoryBot.create(:registrant, ineligible: true), competitor: @comp)
+      FactoryBot.create(:member, registrant: FactoryBot.create(:registrant, ineligible: true), competitor: @comp)
+    end
+
+    it "is eligible if score whatever the proportion of ineligible members" do
+      competition = @comp.reload.competition
+      competition.rule_for_ineligible_competitors = 0
+      competition.save!
+      expect(@comp).not_to be_ineligible
+    end
+
+    it "is ineligible if score only if no ineligible member" do
+      competition = @comp.reload.competition
+      competition.rule_for_ineligible_competitors = 100
+      competition.save!
+      expect(@comp).to be_ineligible
+    end
+
+    it "is ineligible if score if at least half the team is eligible" do
+      competition = @comp.reload.competition
+      competition.rule_for_ineligible_competitors = 50
+      competition.save!
       expect(@comp).to be_ineligible
     end
   end


### PR DESCRIPTION
During the French Cup, teams are marked as ineligible if more than half of their members are ineligible. This was not possible to do in UDA. We had to resort to hacks in order to be able to score such mixed teams.

This PR goal is to be able to set this rule on the competitions themselves. The "ineligibility score" rule can have any of these 3 values :
- Always score (value of 0, means that competitors whose registrants are marked as ineligible will be ranked amongst everyone) - equivalent of the old `score_ineligible_competitors == true`
- Never score (value of 100, means that competitors whose at least one registrant is marked as ineligible won't be ranked with eligible competitors) - equivalent of the old `score_ineligible_competitors == false`
- Score if at least half the team is eligible (value of 50, means that competitors whose at least half the team is eligible will be ranked with eligible competitors) - the new behavior

A new select input has been added to replace the old `score_ineligible_competitors` input during a competition creation/update.

<img width="333" height="75" alt="image" src="https://github.com/user-attachments/assets/bbaef989-a2ed-4f17-87a1-3ebe15aa464c" />
<img width="333" height="75" alt="image" src="https://github.com/user-attachments/assets/773c63b4-1b9d-44ae-b400-4895e1355def" />
<img width="333" height="75" alt="image" src="https://github.com/user-attachments/assets/101d204a-30e5-48c3-aca3-4d8c7c2f8973" />


---

Labels have been translated using Deepl, then checked with Claude. This led me to adjust some translations, so that the technical terms match across the code base. I sadly still don't speak any of these languages except English and French, so I couldn't check myself.

---

Fixes https://github.com/rdunlop/unicycling-registration/issues/2879.