### PR TITLE
Add alb acm management path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ dump.rdb
 # Ignore simplecov report
 /coverage
 /config/initializers/wicked_pdf_osx.rb
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ gem "validates_timeliness"
 gem 'acme-client'
 gem 'apartment_acme_client', github: 'rdunlop/apartment_acme_client', branch: 'allow_rails_8'
 gem 'aws-actionmailer-ses'
+gem 'aws-sdk-acm'
+gem 'aws-sdk-elasticloadbalancingv2'
 gem 'aws-sdk-rails'
 gem 'dotenv-rails'
 gem 'eye'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,9 @@ GEM
       aws-sdk-sesv2 (~> 1, >= 1.34.0)
     aws-eventstream (1.4.0)
     aws-partitions (1.1252.0)
+    aws-sdk-acm (1.105.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-core (3.248.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -167,6 +170,9 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
+    aws-sdk-elasticloadbalancingv2 (1.153.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-kms (1.118.0)
       aws-sdk-core (~> 3, >= 3.239.1)
       aws-sigv4 (~> 1.5)
@@ -763,6 +769,8 @@ DEPENDENCIES
   autoprefixer-rails
   avo
   aws-actionmailer-ses
+  aws-sdk-acm
+  aws-sdk-elasticloadbalancingv2
   aws-sdk-rails
   breadcrumbs_on_rails
   bullet

--- a/app/controllers/convention_setup/tenant_aliases_controller.rb
+++ b/app/controllers/convention_setup/tenant_aliases_controller.rb
@@ -26,6 +26,7 @@ class ConventionSetup::TenantAliasesController < ConventionSetup::BaseConvention
   def create
     @tenant_alias = @tenant.tenant_aliases.build(tenant_alias_params)
     if @tenant_alias.save
+      RequestAcmCertificateJob.perform_later(@tenant_alias.id)
       flash[:notice] = "Created Alias"
       redirect_to tenant_aliases_path
     else

--- a/app/jobs/poll_acm_certificate_job.rb
+++ b/app/jobs/poll_acm_certificate_job.rb
@@ -1,0 +1,60 @@
+class PollAcmCertificateJob < ApplicationJob
+  queue_as :default
+
+  # Poll at most 48 times (every 1h → covers 48h for DNS propagation + validation)
+  MAX_ATTEMPTS = 48
+
+  def perform(tenant_alias_id, attempt: 1)
+    tenant_alias = TenantAlias.find_by(id: tenant_alias_id)
+    return unless tenant_alias
+    return if tenant_alias.acm_cert_issued?
+
+    acm = Aws::ACM::Client.new(region: ENV.fetch("AWS_REGION", "us-east-1"))
+    cert = acm.describe_certificate(certificate_arn: tenant_alias.acm_certificate_arn).certificate
+
+    # Pick up validation CNAME if it wasn't available when the cert was first requested
+    if !tenant_alias.acm_validation_configured? && cert.domain_validation_options&.first&.resource_record
+      option = cert.domain_validation_options.first
+      tenant_alias.update!(
+        acm_dns_validation_cname_name: option.resource_record.name,
+        acm_dns_validation_cname_value: option.resource_record.value
+      )
+    end
+
+    case cert.status
+    when "ISSUED"
+      tenant_alias.update!(acm_cert_status: "issued")
+      attach_cert_to_alb(tenant_alias.acm_certificate_arn)
+    when "FAILED", "REVOKED", "INACTIVE"
+      tenant_alias.update!(acm_cert_status: "failed")
+    else
+      # PENDING_VALIDATION or EXPIRED — keep polling
+      if attempt < MAX_ATTEMPTS
+        PollAcmCertificateJob.set(wait: 1.hour).perform_later(tenant_alias_id, attempt: attempt + 1)
+      else
+        Rails.logger.warn("ACM cert for TenantAlias #{tenant_alias_id} never issued after #{MAX_ATTEMPTS} attempts")
+      end
+    end
+  rescue Aws::ACM::Errors::ServiceError => e
+    Rails.logger.error("ACM poll failed for TenantAlias #{tenant_alias_id}: #{e.message}")
+  end
+
+  private
+
+  def attach_cert_to_alb(cert_arn)
+    listener_arn = ENV["ALB_LISTENER_ARN"]
+    if listener_arn.blank?
+      Rails.logger.info("ACM cert issued but ALB_LISTENER_ARN not configured — skipping ALB attachment")
+      return
+    end
+
+    elb = Aws::ElasticLoadBalancingV2::Client.new(region: ENV.fetch("AWS_REGION", "us-east-1"))
+    elb.add_listener_certificates(
+      listener_arn: listener_arn,
+      certificates: [{ certificate_arn: cert_arn }]
+    )
+    Rails.logger.info("ACM cert #{cert_arn} attached to ALB listener #{listener_arn}")
+  rescue Aws::ElasticLoadBalancingV2::Errors::ServiceError => e
+    Rails.logger.error("Failed to attach ACM cert to ALB: #{e.message}")
+  end
+end

--- a/app/jobs/request_acm_certificate_job.rb
+++ b/app/jobs/request_acm_certificate_job.rb
@@ -1,0 +1,48 @@
+class RequestAcmCertificateJob < ApplicationJob
+  queue_as :default
+
+  def perform(tenant_alias_id)
+    tenant_alias = TenantAlias.find_by(id: tenant_alias_id)
+    return unless tenant_alias
+    return if tenant_alias.acm_cert_issued?
+
+    acm = Aws::ACM::Client.new(region: ENV.fetch("AWS_REGION", "us-east-1"))
+
+    response = acm.request_certificate(
+      domain_name: tenant_alias.website_alias,
+      validation_method: "DNS",
+      subject_alternative_names: [tenant_alias.website_alias]
+    )
+    cert_arn = response.certificate_arn
+
+    # Retrieve the DNS validation CNAME record (may take a few seconds to populate)
+    cname_name, cname_value = fetch_validation_cname(acm, cert_arn)
+
+    tenant_alias.update!(
+      acm_certificate_arn: cert_arn,
+      acm_cert_status: "pending",
+      acm_dns_validation_cname_name: cname_name,
+      acm_dns_validation_cname_value: cname_value
+    )
+
+    PollAcmCertificateJob.set(wait: 5.minutes).perform_later(tenant_alias_id)
+  rescue Aws::ACM::Errors::ServiceError => e
+    Rails.logger.error("ACM certificate request failed for TenantAlias #{tenant_alias_id}: #{e.message}")
+    tenant_alias&.update(acm_cert_status: "failed")
+  end
+
+  private
+
+  def fetch_validation_cname(acm, cert_arn, attempts: 6)
+    attempts.times do
+      cert = acm.describe_certificate(certificate_arn: cert_arn).certificate
+      option = cert.domain_validation_options&.first
+      if option&.resource_record
+        return [option.resource_record.name, option.resource_record.value]
+      end
+
+      sleep 5
+    end
+    [nil, nil]
+  end
+end

--- a/app/models/tenant_alias.rb
+++ b/app/models/tenant_alias.rb
@@ -2,13 +2,17 @@
 #
 # Table name: public.tenant_aliases
 #
-#  id             :integer          not null, primary key
-#  tenant_id      :integer          not null
-#  website_alias  :string           not null
-#  primary_domain :boolean          default(FALSE), not null
-#  created_at     :datetime
-#  updated_at     :datetime
-#  verified       :boolean          default(FALSE), not null
+#  id                             :integer          not null, primary key
+#  tenant_id                      :integer          not null
+#  website_alias                  :string           not null
+#  primary_domain                 :boolean          default(FALSE), not null
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  verified                       :boolean          default(FALSE), not null
+#  acm_certificate_arn            :string
+#  acm_dns_validation_cname_name  :string
+#  acm_dns_validation_cname_value :string
+#  acm_cert_status                :string
 #
 # Indexes
 #
@@ -17,14 +21,33 @@
 #
 
 class TenantAlias < ApplicationRecord
+  ACM_STATUSES = %w[pending issued failed].freeze
+
   validates :website_alias, :tenant, presence: true
   validates :website_alias, uniqueness: true
   validates :primary_domain, uniqueness: { scope: :tenant_id }, if: :primary_domain?
+  validates :acm_cert_status, inclusion: { in: ACM_STATUSES }, allow_nil: true
 
   belongs_to :tenant, inverse_of: :tenant_aliases
 
   def self.primary
     where(primary_domain: true)
+  end
+
+  def acm_cert_pending?
+    acm_cert_status == "pending"
+  end
+
+  def acm_cert_issued?
+    acm_cert_status == "issued"
+  end
+
+  def acm_cert_failed?
+    acm_cert_status == "failed"
+  end
+
+  def acm_validation_configured?
+    acm_dns_validation_cname_name.present? && acm_dns_validation_cname_value.present?
   end
 
   # Determine whether this alias is properly configured

--- a/app/views/convention_setup/tenant_aliases/index.html.haml
+++ b/app/views/convention_setup/tenant_aliases/index.html.haml
@@ -43,3 +43,28 @@
           = t(".set_as_primary_domain")
   - else
     %p= t(".must_save_warning")
+
+- if @tenant_alias.persisted?
+  %hr
+  %h2= t(".acm_cert_header")
+  - if @tenant_alias.acm_cert_issued?
+    %p.success= t(".acm_cert_issued")
+  - elsif @tenant_alias.acm_cert_failed?
+    %p.alert= t(".acm_cert_failed")
+  - elsif @tenant_alias.acm_cert_pending?
+    %p= t(".acm_cert_pending")
+    - if @tenant_alias.acm_validation_configured?
+      %p= t(".acm_cname_instructions")
+      %table
+        %thead
+          %tr
+            %th= t(".acm_cname_name_header")
+            %th= t(".acm_cname_value_header")
+        %tbody
+          %tr
+            %td= @tenant_alias.acm_dns_validation_cname_name
+            %td= @tenant_alias.acm_dns_validation_cname_value
+    - else
+      %p= t(".acm_cname_not_ready")
+  - else
+    %p= t(".acm_cert_not_requested")

--- a/config/locales/views/convention_setup/tenant_aliases/index.en.yml
+++ b/config/locales/views/convention_setup/tenant_aliases/index.en.yml
@@ -24,3 +24,12 @@ en:
         must_save_warning: |
           Before you can activate the alias, you must "Save Record" it.
         alias_is_primary_domain: This Alias is now the primary domain.
+        acm_cert_header: SSL Certificate (AWS ACM)
+        acm_cert_issued: "✓ SSL certificate issued and active in AWS Certificate Manager."
+        acm_cert_failed: "SSL certificate request failed. Please contact support or retry via the admin panel."
+        acm_cert_pending: SSL certificate request is pending. AWS Certificate Manager is waiting for you to add a DNS validation record.
+        acm_cname_instructions: "Add the following CNAME record to your domain's DNS settings to validate the SSL certificate:"
+        acm_cname_name_header: CNAME Name
+        acm_cname_value_header: CNAME Value
+        acm_cname_not_ready: DNS validation record is being generated — please refresh this page in a few minutes.
+        acm_cert_not_requested: No SSL certificate has been requested yet. If you just saved this domain, a request will be made automatically within a few minutes.

--- a/db/migrate/20260609023608_add_acm_fields_to_tenant_aliases.rb
+++ b/db/migrate/20260609023608_add_acm_fields_to_tenant_aliases.rb
@@ -1,0 +1,8 @@
+class AddAcmFieldsToTenantAliases < ActiveRecord::Migration[8.1]
+  def change
+    add_column :tenant_aliases, :acm_certificate_arn, :string
+    add_column :tenant_aliases, :acm_dns_validation_cname_name, :string
+    add_column :tenant_aliases, :acm_dns_validation_cname_value, :string
+    add_column :tenant_aliases, :acm_cert_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_05_112734) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_09_023608) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -1255,6 +1255,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_05_112734) do
   end
 
   create_table "tenant_aliases", id: :serial, force: :cascade do |t|
+    t.string "acm_cert_status"
+    t.string "acm_certificate_arn"
+    t.string "acm_dns_validation_cname_name"
+    t.string "acm_dns_validation_cname_value"
     t.datetime "created_at", precision: nil
     t.boolean "primary_domain", default: false, null: false
     t.integer "tenant_id", null: false

--- a/lib/tasks/certs.rake
+++ b/lib/tasks/certs.rake
@@ -1,0 +1,28 @@
+namespace :certs do
+  desc "Request ACM certificates for all tenant aliases that don't have a pending or issued cert"
+  task request_all: :environment do
+    aliases = TenantAlias.where(acm_cert_status: [nil, "failed"])
+    puts "Enqueueing ACM certificate requests for #{aliases.count} domain(s)..."
+    aliases.find_each do |ta|
+      RequestAcmCertificateJob.perform_later(ta.id)
+      puts "  Enqueued: #{ta.website_alias} (id=#{ta.id})"
+    end
+    puts "Done."
+  end
+
+  desc "Show ACM certificate status for all tenant aliases"
+  task status: :environment do
+    counts = TenantAlias.group(:acm_cert_status).count
+    puts "ACM Certificate Status Summary:"
+    puts "  nil (not requested): #{counts[nil] || 0}"
+    puts "  pending:             #{counts['pending'] || 0}"
+    puts "  issued:              #{counts['issued'] || 0}"
+    puts "  failed:              #{counts['failed'] || 0}"
+    puts ""
+    puts "#{'Domain'.ljust(40)} #{'Status'.ljust(10)} Cert ARN"
+    puts "-" * 100
+    TenantAlias.order(:website_alias).each do |ta|
+      puts "#{ta.website_alias.ljust(40)} #{(ta.acm_cert_status || 'none').ljust(10)} #{ta.acm_certificate_arn || '-'}"
+    end
+  end
+end

--- a/spec/factories/tenant_aliases.rb
+++ b/spec/factories/tenant_aliases.rb
@@ -10,13 +10,17 @@ end
 #
 # Table name: public.tenant_aliases
 #
-#  id             :integer          not null, primary key
-#  tenant_id      :integer          not null
-#  website_alias  :string           not null
-#  primary_domain :boolean          default(FALSE), not null
-#  created_at     :datetime
-#  updated_at     :datetime
-#  verified       :boolean          default(FALSE), not null
+#  id                             :integer          not null, primary key
+#  tenant_id                      :integer          not null
+#  website_alias                  :string           not null
+#  primary_domain                 :boolean          default(FALSE), not null
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  verified                       :boolean          default(FALSE), not null
+#  acm_certificate_arn            :string
+#  acm_dns_validation_cname_name  :string
+#  acm_dns_validation_cname_value :string
+#  acm_cert_status                :string
 #
 # Indexes
 #

--- a/spec/jobs/poll_acm_certificate_job_spec.rb
+++ b/spec/jobs/poll_acm_certificate_job_spec.rb
@@ -1,0 +1,129 @@
+require "spec_helper"
+
+RSpec.describe PollAcmCertificateJob, sidekiq: :fake do
+  let(:tenant) { FactoryBot.create(:tenant, subdomain: "testorg") }
+  let(:cert_arn) { "arn:aws:acm:us-east-1:123456789:certificate/abc-123" }
+  let(:listener_arn) { "arn:aws:elasticloadbalancing:us-east-1:123456789:listener/app/my-alb/abc/xyz" }
+
+  let(:tenant_alias) do
+    FactoryBot.create(:tenant_alias,
+                      tenant: tenant,
+                      website_alias: "reg.example.com",
+                      acm_certificate_arn: cert_arn,
+                      acm_cert_status: "pending",
+                      acm_dns_validation_cname_name: "_abc.reg.example.com.",
+                      acm_dns_validation_cname_value: "_xyz.acm.amazon.com.")
+  end
+
+  let(:acm_client) { instance_double(Aws::ACM::Client) }
+  let(:elb_client) { instance_double(Aws::ElasticLoadBalancingV2::Client) }
+
+  before do
+    allow(Aws::ACM::Client).to receive(:new).and_return(acm_client)
+    allow(Aws::ElasticLoadBalancingV2::Client).to receive(:new).and_return(elb_client)
+    allow(acm_client).to receive(:describe_certificate)
+    allow(elb_client).to receive(:add_listener_certificates)
+  end
+
+  def acm_response(status)
+    double(certificate: double(
+      status: status,
+      domain_validation_options: [
+        double(resource_record: double(
+          name: "_abc.reg.example.com.",
+          value: "_xyz.acm.amazon.com."
+        ))
+      ]
+    ))
+  end
+
+  describe "#perform" do
+    context "when cert is ISSUED" do
+      before do
+        allow(acm_client).to receive(:describe_certificate)
+          .with(certificate_arn: cert_arn)
+          .and_return(acm_response("ISSUED"))
+      end
+
+      it "marks status as issued" do
+        described_class.new.perform(tenant_alias.id)
+
+        expect(tenant_alias.reload.acm_cert_status).to eq("issued")
+      end
+
+      it "attaches cert to ALB when ALB_LISTENER_ARN is set" do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("ALB_LISTENER_ARN").and_return(listener_arn)
+
+        described_class.new.perform(tenant_alias.id)
+
+        expect(elb_client).to have_received(:add_listener_certificates).with(
+          listener_arn: listener_arn,
+          certificates: [{ certificate_arn: cert_arn }]
+        )
+      end
+
+      it "skips ALB attachment when ALB_LISTENER_ARN is not set" do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("ALB_LISTENER_ARN").and_return(nil)
+
+        described_class.new.perform(tenant_alias.id)
+
+        expect(elb_client).not_to have_received(:add_listener_certificates)
+      end
+    end
+
+    context "when cert is FAILED" do
+      before do
+        allow(acm_client).to receive(:describe_certificate)
+          .with(certificate_arn: cert_arn)
+          .and_return(acm_response("FAILED"))
+      end
+
+      it "marks status as failed" do
+        described_class.new.perform(tenant_alias.id)
+
+        expect(tenant_alias.reload.acm_cert_status).to eq("failed")
+      end
+    end
+
+    context "when cert is still PENDING_VALIDATION" do
+      before do
+        allow(acm_client).to receive(:describe_certificate)
+          .with(certificate_arn: cert_arn)
+          .and_return(acm_response("PENDING_VALIDATION"))
+      end
+
+      it "re-enqueues itself with a 1-hour delay" do
+        requeue_double = double(perform_later: nil)
+        allow(described_class).to receive(:set).with(wait: 1.hour).and_return(requeue_double)
+
+        described_class.new.perform(tenant_alias.id, attempt: 1)
+
+        expect(described_class).to have_received(:set).with(wait: 1.hour)
+      end
+
+      it "does not re-enqueue after MAX_ATTEMPTS" do
+        allow(described_class).to receive(:set)
+
+        described_class.new.perform(tenant_alias.id, attempt: PollAcmCertificateJob::MAX_ATTEMPTS)
+
+        expect(described_class).not_to have_received(:set)
+      end
+    end
+
+    it "does nothing if tenant alias no longer exists" do
+      described_class.new.perform(99_999)
+
+      expect(acm_client).not_to have_received(:describe_certificate)
+    end
+
+    it "does nothing if cert is already issued on the record" do
+      tenant_alias.update!(acm_cert_status: "issued")
+
+      described_class.new.perform(tenant_alias.id)
+
+      expect(acm_client).not_to have_received(:describe_certificate)
+    end
+  end
+end

--- a/spec/jobs/request_acm_certificate_job_spec.rb
+++ b/spec/jobs/request_acm_certificate_job_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+
+RSpec.describe RequestAcmCertificateJob, sidekiq: :fake do
+  let(:tenant) { FactoryBot.create(:tenant, subdomain: "testorg") }
+  let(:tenant_alias) { FactoryBot.create(:tenant_alias, tenant: tenant, website_alias: "reg.example.com") }
+
+  describe "#perform" do
+    let(:acm_client) { instance_double(Aws::ACM::Client) }
+    let(:cert_arn) { "arn:aws:acm:us-east-1:123456789:certificate/abc-123" }
+
+    let(:validation_option) do
+      double(resource_record: double(name: "_abc.reg.example.com.", value: "_xyz.acm.amazon.com."))
+    end
+
+    let(:describe_response) do
+      double(certificate: double(
+        domain_validation_options: [validation_option]
+      ))
+    end
+
+    let(:poll_job_double) { double(perform_later: nil) }
+
+    before do
+      allow(Aws::ACM::Client).to receive(:new).and_return(acm_client)
+      allow(acm_client).to receive(:request_certificate)
+        .and_return(double(certificate_arn: cert_arn))
+      allow(acm_client).to receive(:describe_certificate)
+        .with(certificate_arn: cert_arn)
+        .and_return(describe_response)
+      allow(PollAcmCertificateJob).to receive(:set).and_return(poll_job_double)
+    end
+
+    it "requests a certificate and saves the ARN and CNAME validation record" do
+      described_class.new.perform(tenant_alias.id)
+
+      tenant_alias.reload
+      expect(tenant_alias.acm_certificate_arn).to eq(cert_arn)
+      expect(tenant_alias.acm_cert_status).to eq("pending")
+      expect(tenant_alias.acm_dns_validation_cname_name).to eq("_abc.reg.example.com.")
+      expect(tenant_alias.acm_dns_validation_cname_value).to eq("_xyz.acm.amazon.com.")
+    end
+
+    it "enqueues PollAcmCertificateJob after requesting the certificate" do
+      poll_double = double(perform_later: nil)
+      allow(PollAcmCertificateJob).to receive(:set).with(wait: 5.minutes).and_return(poll_double)
+
+      described_class.new.perform(tenant_alias.id)
+
+      expect(PollAcmCertificateJob).to have_received(:set).with(wait: 5.minutes)
+    end
+
+    it "does nothing if the tenant alias no longer exists" do
+      described_class.new.perform(99_999)
+
+      expect(acm_client).not_to have_received(:request_certificate)
+    end
+
+    it "does nothing if the cert is already issued" do
+      tenant_alias.update!(acm_cert_status: "issued", acm_certificate_arn: cert_arn)
+
+      described_class.new.perform(tenant_alias.id)
+
+      expect(acm_client).not_to have_received(:request_certificate)
+    end
+
+    it "marks status as failed on AWS error" do
+      allow(acm_client).to receive(:request_certificate)
+        .and_raise(Aws::ACM::Errors::ServiceError.new(nil, "throttled"))
+
+      described_class.new.perform(tenant_alias.id)
+
+      expect(tenant_alias.reload.acm_cert_status).to eq("failed")
+    end
+  end
+end

--- a/spec/models/tenant_alias_spec.rb
+++ b/spec/models/tenant_alias_spec.rb
@@ -2,13 +2,17 @@
 #
 # Table name: public.tenant_aliases
 #
-#  id             :integer          not null, primary key
-#  tenant_id      :integer          not null
-#  website_alias  :string           not null
-#  primary_domain :boolean          default(FALSE), not null
-#  created_at     :datetime
-#  updated_at     :datetime
-#  verified       :boolean          default(FALSE), not null
+#  id                             :integer          not null, primary key
+#  tenant_id                      :integer          not null
+#  website_alias                  :string           not null
+#  primary_domain                 :boolean          default(FALSE), not null
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  verified                       :boolean          default(FALSE), not null
+#  acm_certificate_arn            :string
+#  acm_dns_validation_cname_name  :string
+#  acm_dns_validation_cname_value :string
+#  acm_cert_status                :string
 #
 # Indexes
 #

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,177 @@
+# Terraform Infrastructure
+
+Manages ALB, ACM certificates, and Route53 DNS for prod and staging.
+
+- **Prod:** `registration.unicycling-software.com` + wildcard `*.unicycling-software.com` (all tenant subdomains)
+- **Staging:** `registrationtest.unicycling-software.com`
+
+State is stored in S3 (`unicycling-registration-terraform-state`), locked via `use_lockfile` (Terraform ≥ 1.10, no DynamoDB needed).
+
+## Prerequisites
+
+```bash
+brew install terraform   # or brew upgrade terraform
+terraform version        # must be >= 1.10
+aws sts get-caller-identity  # confirm AWS credentials are active
+```
+
+---
+
+## Step 1: Bootstrap (one-time only)
+
+Creates the S3 bucket used to store Terraform state. Run once; never run again.
+
+```bash
+cd terraform/bootstrap
+terraform init
+terraform apply
+cd -
+```
+
+---
+
+## Step 2: Gather AWS resource IDs
+
+Run these CLI commands to populate the `terraform.tfvars` files in `prod/` and `staging/`.
+
+```bash
+# Route53 hosted zone
+aws route53 list-hosted-zones \
+  --query "HostedZones[?contains(Name,'unicycling-software.com')].{Id:Id,Name:Name}" \
+  --output table
+
+# Prod EC2: instance ID, VPC ID, subnet, security group
+aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=*registration*prod*" \
+  --query "Reservations[].Instances[].[InstanceId,VpcId,SubnetId,SecurityGroups[0].GroupId,PublicIpAddress]" \
+  --output table
+
+# Staging EC2
+aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=*registration*stage*" \
+  --query "Reservations[].Instances[].[InstanceId,VpcId,SubnetId,SecurityGroups[0].GroupId,PublicIpAddress]" \
+  --output table
+
+# All subnets in the VPC — pick 2+ in different AZs for the ALB (use public subnets only)
+aws ec2 describe-subnets \
+  --filters "Name=vpc-id,Values=vpc-e113c084" \
+  --query "Subnets[].[SubnetId,AvailabilityZone,MapPublicIpOnLaunch,Tags[?Key=='Name'].Value|[0]]" \
+  --output table
+
+# Existing Route53 A records (to confirm what will be overwritten)
+aws route53 list-resource-record-sets \
+  --hosted-zone-id /hostedzone/Z1NYSHL8JOE6MN \
+  --query "ResourceRecordSets[?Type=='A']" --output json
+```
+
+Fill the results into `prod/terraform.tfvars` and `staging/terraform.tfvars`, replacing the `TODO` placeholders.
+
+---
+
+## Step 3: Apply (two-step, per environment)
+
+No import needed — `dns.tf` uses `allow_overwrite = true` so Terraform replaces the existing direct-to-EC2 A record automatically.
+
+The two-step approach is required because `aws_route53_record.acm_validation` uses `for_each` over the cert's domain validation options, which are only known after the cert is created.
+
+### Staging first
+
+```bash
+cd terraform
+
+terraform init -backend-config=staging/backend.tfvars -reconfigure
+
+# Step 3a: create the ACM cert so its validation records become known
+terraform apply -target=aws_acm_certificate.app -var-file=staging/terraform.tfvars
+
+# Step 3b: apply everything (ALB, listeners, DNS validation records, DNS cutover)
+terraform apply -var-file=staging/terraform.tfvars
+```
+
+### Prod (after staging is validated)
+
+```bash
+terraform init -backend-config=prod/backend.tfvars -reconfigure
+
+terraform apply -target=aws_acm_certificate.app -var-file=prod/terraform.tfvars
+
+terraform apply -var-file=prod/terraform.tfvars
+```
+
+---
+
+## Day-to-day usage
+
+### Apply to staging
+
+```bash
+cd terraform
+
+terraform init -backend-config=staging/backend.tfvars -reconfigure
+terraform plan  -var-file=staging/terraform.tfvars
+terraform apply -var-file=staging/terraform.tfvars
+```
+
+### Apply to prod
+
+```bash
+cd terraform
+
+terraform init -backend-config=prod/backend.tfvars -reconfigure
+terraform plan  -var-file=prod/terraform.tfvars
+terraform apply -var-file=prod/terraform.tfvars
+```
+
+> **Note:** `-reconfigure` is required when switching between environments because the S3 backend key changes. It does not destroy or migrate state.
+
+---
+
+## Verification after apply
+
+```bash
+# Check cert was issued
+aws acm list-certificates --region us-west-2 --output table
+
+# Check ALB target health (EC2 should show healthy)
+aws elbv2 describe-target-health \
+  --target-group-arn $(terraform output -raw target_group_arn)
+
+# End-to-end HTTPS smoke test via ALB (before DNS cutover, test directly):
+curl -I --resolve registrationtest.unicycling-software.com:443:<ALB-IP> \
+  https://registrationtest.unicycling-software.com
+
+# After DNS cutover:
+curl -I https://registrationtest.unicycling-software.com
+curl -I https://registration.unicycling-software.com
+```
+
+---
+
+## After apply: set ALB_LISTENER_ARN in the app
+
+The Rails app (`PollAcmCertificateJob`) uses `ALB_LISTENER_ARN` to attach per-tenant
+ACM certificates to the HTTPS listener at runtime. Get the ARN and store it:
+
+```bash
+# Get the listener ARN from Terraform output
+terraform output -raw https_listener_arn
+
+# Set it as an SSM parameter (run once per environment after apply)
+aws ssm put-parameter \
+  --name "/unicycling-registration/staging/ALB_LISTENER_ARN" \
+  --value "$(terraform output -raw https_listener_arn)" \
+  --type "String" \
+  --overwrite
+```
+
+---
+
+## After successful cutover to ECS
+
+Once all traffic has moved from EC2 to ECS (Phase 11 of the ECS migration plan),
+update the target group to use ECS instead of the EC2 instance. At that point
+`ec2_instance_id` and `ec2_security_group_id` become irrelevant and can be removed
+from the Terraform config in favour of ECS-managed target group attachments.
+
+The `apartment_acme_client` gem and its Let's Encrypt cron jobs can be removed from
+the EC2 instances — ACM auto-renews all certificates.

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -1,0 +1,36 @@
+resource "aws_acm_certificate" "app" {
+  domain_name               = var.domain
+  subject_alternative_names = var.subject_alt_names
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name        = "unicycling-registration-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_route53_record" "acm_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.app.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id         = var.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 60
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "app" {
+  certificate_arn         = aws_acm_certificate.app.arn
+  validation_record_fqdns = [for record in aws_route53_record.acm_validation : record.fqdn]
+}

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -1,0 +1,68 @@
+resource "aws_lb" "app" {
+  name               = "unicycling-registration-${var.environment}"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.subnet_ids
+
+  tags = {
+    Name        = "unicycling-registration-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_lb_target_group" "app" {
+  name     = "unicycling-registration-${var.environment}"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = var.vpc_id
+
+  health_check {
+    # "/" returns 302 for unauthenticated users; 200-399 accepts redirects.
+    path                = "/"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 30
+    timeout             = 5
+    matcher             = "200-399"
+  }
+
+  tags = {
+    Name        = "unicycling-registration-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_lb_target_group_attachment" "app" {
+  target_group_arn = aws_lb_target_group.app.arn
+  target_id        = var.ec2_instance_id
+  port             = 80
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.app.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.app.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = aws_acm_certificate_validation.app.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}

--- a/terraform/bootstrap/.terraform.lock.hcl
+++ b/terraform/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.49.0"
+  hashes = [
+    "h1:tijbk6K9J2XeFGDmXqPH0eTGq0cl47pTS6CV0rob0cs=",
+    "zh:11a636bb415bf780f0ad300cab83d687aebdc51381112ae7b29862e0bee43017",
+    "zh:2d6c4bb861c073d9900a2afc39cc1e38492c6996653e53c7a2083b526fb10ae9",
+    "zh:49f7ee4a7488f3d31342c5e9dbb577c40e0847a0cab152a0082e9aeef45f5c0f",
+    "zh:561283c9c9bd36b9d09832e50769b941eb45c43c6ab031f27c8bf78256af4af1",
+    "zh:576bf944e66d097b29fc45b25a5bbc53e7d4e71a486e2cb126304cf77b51fe79",
+    "zh:6c6bf8860773c121b9ca22743f733feea943f890fa3aba8740a59579dea16fc4",
+    "zh:88b963a659e42daac7384a6abb99b3383f9f6c8abad5dedafcd443536b122b84",
+    "zh:947e9404235ca094e39e7f3f464f99436320a168e1607c550e581fbc70553d48",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a9c5a37bd1e5e81e85ad3dc3141f1b453b96e9cb8e500bc15bfb9c488fc95dcc",
+    "zh:b7b8a028fb2eafb98c676f9438808318f7ff0ea76eba03a6653d0940848a31c7",
+    "zh:be29f31827d6d5567aaec26034e6cceb994460446778ba1d0a435fc7ccd8a9f5",
+    "zh:c24c60ecffe3a7d44c762e62a29a802aec604096715ad3110b7ca2207124eb3a",
+    "zh:e2a247c5c7815437969e87cdce1f27f323eea75b97ed53f7605fef05d6406071",
+    "zh:e590ce9aca3f4fd964f7bf908a24dc3bc88e0b03a8554ccc81b9edcc84690670",
+  ]
+}

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -1,0 +1,31 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_s3_bucket" "tf_state" {
+  bucket = "unicycling-registration-terraform-state"
+}
+
+resource "aws_s3_bucket_versioning" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tf_state" {
+  bucket                  = aws_s3_bucket.tf_state.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,3 @@
+data "aws_route53_zone" "main" {
+  zone_id = var.zone_id
+}

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,0 +1,32 @@
+# Primary domain A record (e.g. regtest.unicycling-software.com or
+# reg.unicycling-software.com)
+resource "aws_route53_record" "app" {
+  zone_id         = var.zone_id
+  name            = var.domain
+  type            = "A"
+  allow_overwrite = true
+
+  alias {
+    name                   = aws_lb.app.dns_name
+    zone_id                = aws_lb.app.zone_id
+    evaluate_target_health = true
+  }
+}
+
+# Wildcard record routing all tenant subdomains (*.regtest.unicycling-software.com)
+# to the ALB.
+# This allows tenants at myconvention.regtest.unicycling-software.com to resolve to the
+# production ALB without a per-tenant DNS record.
+resource "aws_route53_record" "wildcard" {
+  count           = var.wildcard_domain != null ? 1 : 0
+  zone_id         = var.zone_id
+  name            = var.wildcard_domain
+  type            = "A"
+  allow_overwrite = true
+
+  alias {
+    name                   = aws_lb.app.dns_name
+    zone_id                = aws_lb.app.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "alb_dns_name" {
+  description = "ALB DNS name — use this to smoke-test before DNS cutover"
+  value       = aws_lb.app.dns_name
+}
+
+output "acm_certificate_arn" {
+  description = "ARN of the ACM certificate"
+  value       = aws_acm_certificate_validation.app.certificate_arn
+}
+
+output "target_group_arn" {
+  description = "ARN of the ALB target group (EC2)"
+  value       = aws_lb_target_group.app.arn
+}
+
+output "https_listener_arn" {
+  description = "ARN of the HTTPS ALB listener — set as ALB_LISTENER_ARN in SSM/env so the Rails app can attach per-tenant ACM certs at runtime"
+  value       = aws_lb_listener.https.arn
+}

--- a/terraform/prod/backend.tfvars
+++ b/terraform/prod/backend.tfvars
@@ -1,0 +1,5 @@
+bucket       = "unicycling-registration-terraform-state"
+key          = "prod/terraform.tfstate"
+region       = "us-west-2"
+use_lockfile = true
+encrypt      = true

--- a/terraform/prod/terraform.tfvars
+++ b/terraform/prod/terraform.tfvars
@@ -1,0 +1,11 @@
+environment         = "prod"
+domain              = "reg.unicycling-software.com"
+subject_alt_names   = ["*.reg.unicycling-software.com"]
+wildcard_domain     = "*.reg.unicycling-software.com"
+
+# Run the CLI commands in the README Step 2 section to get these values.
+ec2_instance_id       = "i-0329bb3d406c09fee"
+ec2_security_group_id = "sg-e4640f81"
+vpc_id                = "vpc-e113c084"
+subnet_ids            = ["subnet-39963f5c", "subnet-16e82761", "subnet-1f6f8346", "subnet-ba154f92"]
+zone_id               = "Z1NYSHL8JOE6MN"

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "us-west-2"
+}

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -1,0 +1,45 @@
+resource "aws_security_group" "alb" {
+  name        = "unicycling-registration-${var.environment}-alb"
+  description = "ALB security group for ${var.environment}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "HTTP from internet"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS from internet"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "unicycling-registration-${var.environment}-alb"
+    Environment = var.environment
+  }
+}
+
+# Adds port 80 ingress from the ALB to the existing EC2 security group.
+# Does not import or replace the full security group — only appends a rule.
+resource "aws_security_group_rule" "ec2_from_alb" {
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  security_group_id        = var.ec2_security_group_id
+  source_security_group_id = aws_security_group.alb.id
+  description              = "Allow HTTP from ${var.environment} ALB"
+}

--- a/terraform/staging/backend.tfvars
+++ b/terraform/staging/backend.tfvars
@@ -1,0 +1,5 @@
+bucket       = "unicycling-registration-terraform-state"
+key          = "staging/terraform.tfstate"
+region       = "us-west-2"
+use_lockfile = true
+encrypt      = true

--- a/terraform/staging/terraform.tfvars
+++ b/terraform/staging/terraform.tfvars
@@ -1,0 +1,11 @@
+environment         = "staging"
+domain              = "regtest.unicycling-software.com"
+subject_alt_names   = ["*.regtest.unicycling-software.com"]
+wildcard_domain     = "*.regtest.unicycling-software.com"
+
+# Run the CLI commands in the README Step 2 section to get these values.
+ec2_instance_id       = "i-063e7da797198ba5c"
+ec2_security_group_id = "sg-e4640f81"
+vpc_id                = "vpc-e113c084"
+subnet_ids            = ["subnet-39963f5c", "subnet-16e82761", "subnet-1f6f8346", "subnet-ba154f92"]
+zone_id               = "Z1NYSHL8JOE6MN"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,51 @@
+variable "environment" {
+  type        = string
+  description = "Environment name (prod or staging)"
+
+  validation {
+    condition     = contains(["prod", "staging"], var.environment)
+    error_message = "environment must be prod or staging"
+  }
+}
+
+variable "domain" {
+  type        = string
+  description = "Primary domain for the ACM certificate and Route53 A record (e.g. registration.unicycling-software.com)"
+}
+
+variable "subject_alt_names" {
+  type        = list(string)
+  default     = []
+  description = "Additional SANs for the ACM certificate."
+}
+
+variable "zone_id" {
+  type        = string
+  description = "Route53 hosted zone ID for unicycling-software.com"
+}
+
+variable "ec2_instance_id" {
+  type        = string
+  description = "ID of the existing EC2 instance to register in the ALB target group"
+}
+
+variable "ec2_security_group_id" {
+  type        = string
+  description = "ID of the existing EC2 security group; an ingress rule will be added allowing port 80 from the ALB"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID where the ALB will be created"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "List of public subnet IDs (minimum 2, in different AZs) for the ALB"
+}
+
+variable "wildcard_domain" {
+  type        = string
+  default     = null
+  description = "What is the wildcard domain (*.regtest.unicycling-software.com) pointing to the ALB. Enable to route all tenant subdomains through the ALB."
+}


### PR DESCRIPTION
This changes from using self-managed Let's encrypt, to using ACM-managed certificate management.
Though, to do this, we do now need any custom-tenant systems to install additional DNS records to support this.