### PR TITLE
Ecs deployment

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -44,6 +44,7 @@ COPY --from=builder /app/lib ./lib
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/Gemfile .
 COPY --from=builder /app/Gemfile.lock .
+COPY --from=builder /app/.ruby-version .
 COPY --from=builder /app/Rakefile .
 COPY --from=builder /app/docker-entrypoint.sh .
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -31,7 +31,11 @@ RUN apt-get update -qq \
 RUN useradd -m -u 1000 app
 
 WORKDIR /app
-ENV BUNDLE_PATH=/gems RAILS_ENV=production RAILS_LOG_TO_STDOUT=1
+
+ENV BUNDLE_PATH=/gems \
+    RAILS_ENV=production \
+    RAILS_LOG_TO_STDOUT=1 \
+    BUNDLE_WITHOUT=development:test:cucumber
 
 COPY --from=builder /gems /gems
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,7 +68,7 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  if Rails.configuration.redis_host
+  if ENV["REDIS_CACHE_URL"] || Rails.configuration.redis_host
     config.cache_store = :redis_cache_store, Redis.cache_configuration
   end
 

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,18 +1,26 @@
 class Redis
   def self.cache_configuration
-    configuration do |config|
-      # Can be far out because it's main purpose is to mark it as evictable
-      # by Redis's volatile-lru setting.
-      # http://redis.io/topics/lru-cache
-      config[:expires_in] = 1.year
-      # Provided by redis-namespace gem
-      config[:namespace] = -> { "CACHE_#{Apartment::Tenant.current}" }
+    if ENV["REDIS_CACHE_URL"]
+      # ECS: dedicated cache sidecar (redis://127.0.0.1:6379/1 set by task definition)
+      { url: ENV["REDIS_CACHE_URL"], expires_in: 1.year, namespace: -> { "CACHE_#{Apartment::Tenant.current}" } }
+    else
+      # EC2: legacy host/port/db config
+      configuration do |config|
+        config[:expires_in] = 1.year
+        config[:namespace] = -> { "CACHE_#{Apartment::Tenant.current}" }
+      end
     end
   end
 
   def self.sidekiq_configuration
-    configuration do |config|
-      config[:db] += 1
+    if ENV["REDIS_URL"]
+      # ECS: ElastiCache via URL (shared across all containers)
+      { url: ENV["REDIS_URL"] }
+    else
+      # EC2: legacy host/port/db config; sidekiq uses db+1 to avoid colliding with cache
+      configuration do |config|
+        config[:db] += 1
+      end
     end
   end
 

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -54,6 +54,29 @@ resource "aws_lb_listener" "http" {
   }
 }
 
+# ECS target group — ip type required for Fargate awsvpc networking.
+resource "aws_lb_target_group" "ecs" {
+  name        = "unicycling-reg-${var.environment}-ecs"
+  port        = 3000
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+
+  health_check {
+    path                = "/"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 30
+    timeout             = 10
+    matcher             = "200-399"
+  }
+
+  tags = {
+    Name        = "unicycling-reg-${var.environment}-ecs"
+    Environment = var.environment
+  }
+}
+
 resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_lb.app.arn
   port              = 443
@@ -61,8 +84,19 @@ resource "aws_lb_listener" "https" {
   ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   certificate_arn   = aws_acm_certificate_validation.app.certificate_arn
 
+  # Weighted split between EC2 and ECS. Set ecs_traffic_weight=0 to keep all
+  # traffic on EC2, or raise it gradually during cutover (Phase 8/11).
   default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.app.arn
+    type = "forward"
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.app.arn
+        weight = 100 - var.ecs_traffic_weight
+      }
+      target_group {
+        arn    = aws_lb_target_group.ecs.arn
+        weight = var.ecs_traffic_weight
+      }
+    }
   }
 }

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,3 +1,5 @@
 data "aws_route53_zone" "main" {
   zone_id = var.zone_id
 }
+
+data "aws_caller_identity" "current" {}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,0 +1,248 @@
+resource "aws_ecs_cluster" "app" {
+  name = "unicycling-registration-${var.environment}"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = {
+    Name        = "unicycling-registration-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_cloudwatch_log_group" "web" {
+  name              = "/ecs/unicycling-registration-${var.environment}-web"
+  retention_in_days = 30
+  tags = { Environment = var.environment }
+}
+
+resource "aws_cloudwatch_log_group" "sidekiq" {
+  name              = "/ecs/unicycling-registration-${var.environment}-sidekiq"
+  retention_in_days = 30
+  tags = { Environment = var.environment }
+}
+
+# ---- Container definition helpers ----
+
+locals {
+  ssm_prefix = "/unicycling-registration/${var.environment}"
+
+  # Sensitive values injected from SSM Parameter Store at task launch.
+  # Populate each before scaling the services up:
+  #   aws ssm put-parameter --name "/unicycling-registration/{env}/SECRET_KEY_BASE" \
+  #     --type SecureString --value "..." --region us-west-2
+  ssm_secret_names = [
+    "SECRET_KEY_BASE",
+
+    # Database
+    "DATABASE_HOST", "POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB",
+
+    # Redis — REDIS_URL points to ElastiCache (Sidekiq + ActionCable).
+    # REDIS_CACHE_URL (sidecar) is set directly in container_environment_web, not SSM.
+    # REDIS_HOST / REDIS_PORT / REDIS_DB are EC2-only and not used on ECS.
+    "REDIS_URL",
+
+    # AWS
+    "AWS_REGION", "AWS_BUCKET", "AWS_ACCESS_KEY", "AWS_SECRET_ACCESS_KEY",
+
+    # Email
+    "MAIL_FULL_EMAIL", "MAIL_SKIP_CONFIRMATION",
+    "ERROR_EMAILS", "SERVER_ADMIN_EMAIL", "PAYMENT_NOTICE_EMAIL",
+
+    # Analytics
+    "GOOGLE_ANALYTICS_TRACKING_ID",
+    "GOOGLE_ANALYTICS_4_TRACKING_ID",
+
+    # Captcha
+    "HCAPTCHA_SECRET", "HCAPTCHA_SITE_KEY",
+    "RECAPTCHA_PUBLIC_KEY", "RECAPTCHA_PRIVATE_KEY",
+
+    # App config
+    "INSTANCE_CREATION_CODE",
+    "SUPER_ADMIN_UPGRADE_CODE",
+    "INDIVIDUAL_EMAIL_SENDING",
+    "CACHE_INSTRUMENTATION",
+    "ALB_LISTENER_ARN",
+
+    # Translations / i18n
+    "TRANSLATIONS_SUBDOMAIN", "TRANSLATION_WEBSITE_URL",
+
+    # IUF membership
+    "IUF_MEMBERSHIP_API_URL", "IUF_MEMBERSHIP_URL",
+
+    # WildApricot (USA membership)
+    "USA_WILDAPRICOT_ACCOUNT_ID", "USA_WILDAPRICOT_API_KEY",
+
+    # Monitoring
+    "ROLLBAR_ACCESS_TOKEN",
+  ]
+
+  container_secrets = [
+    for name in local.ssm_secret_names : {
+      name      = name
+      valueFrom = "arn:aws:ssm:us-west-2:${data.aws_caller_identity.current.account_id}:parameter${local.ssm_prefix}/${name}"
+    }
+  ]
+
+  # Non-sensitive config shared by both web and sidekiq containers.
+  container_environment_base = [
+    { name = "RAILS_ENV",                value = var.rails_env },
+    { name = "PORT",                     value = "3000" },
+    { name = "RAILS_LOG_TO_STDOUT",      value = "1" },
+    { name = "RAILS_SERVE_STATIC_FILES", value = "true" },
+    { name = "RAILS_MAX_THREADS",        value = "5" },
+    { name = "DOMAIN",                   value = var.domain },
+    { name = "SSL_ENABLED",              value = "false" },
+  ]
+
+  # Web only: cache sidecar URL. Sidekiq uses ElastiCache (REDIS_URL from SSM) for all Redis.
+  container_environment_web = concat(local.container_environment_base, [
+    { name = "REDIS_CACHE_URL", value = "redis://127.0.0.1:6379/1" },
+  ])
+
+  # Redis sidecar — web task only (Rails cache store). Sidekiq uses ElastiCache via REDIS_URL.
+  # essential=false so a cache restart does not kill the web container.
+  redis_sidecar = {
+    name      = "redis-cache"
+    image     = "redis:7-alpine"
+    essential = false
+    command   = ["redis-server", "--bind", "127.0.0.1", "--maxmemory", "128mb", "--maxmemory-policy", "allkeys-lru"]
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.web.name
+        "awslogs-region"        = "us-west-2"
+        "awslogs-stream-prefix" = "redis-cache"
+      }
+    }
+  }
+}
+
+# ---- Task definitions ----
+
+resource "aws_ecs_task_definition" "web" {
+  family                   = "unicycling-registration-${var.environment}-web"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 512
+  memory                   = 1024
+  execution_role_arn       = aws_iam_role.ecs_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "web"
+      image     = "${var.ecr_repository_url}:${var.image_tag}"
+      essential = true
+
+      portMappings    = [{ containerPort = 3000, protocol = "tcp" }]
+      linuxParameters = { initProcessEnabled = true }
+      dependsOn       = [{ containerName = "redis-cache", condition = "START" }]
+
+      environment = local.container_environment_web
+      secrets     = local.container_secrets
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.web.name
+          "awslogs-region"        = "us-west-2"
+          "awslogs-stream-prefix" = "web"
+        }
+      }
+    },
+    local.redis_sidecar,
+  ])
+
+  tags = { Environment = var.environment }
+}
+
+resource "aws_ecs_task_definition" "sidekiq" {
+  family                   = "unicycling-registration-${var.environment}-sidekiq"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 512
+  memory                   = 1024
+  execution_role_arn       = aws_iam_role.ecs_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "sidekiq"
+      image     = "${var.ecr_repository_url}:${var.image_tag}"
+      essential = true
+      command   = ["bundle", "exec", "sidekiq", "-C", "config/sidekiq.yml"]
+
+      linuxParameters = { initProcessEnabled = true }
+
+      environment = local.container_environment_base
+      secrets     = local.container_secrets
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.sidekiq.name
+          "awslogs-region"        = "us-west-2"
+          "awslogs-stream-prefix" = "sidekiq"
+        }
+      }
+    },
+  ])
+
+  tags = { Environment = var.environment }
+}
+
+# ---- ECS services ----
+# desired_count starts at 0 — scale up after SSM parameters are populated.
+# task_definition and desired_count are excluded from lifecycle management so
+# that CircleCI deployments can update them without terraform reverting.
+
+resource "aws_ecs_service" "web" {
+  name                   = "unicycling-registration-${var.environment}-web"
+  cluster                = aws_ecs_cluster.app.id
+  task_definition        = aws_ecs_task_definition.web.arn
+  desired_count          = 0
+  launch_type            = "FARGATE"
+  enable_execute_command = true
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.ecs.arn
+    container_name   = "web"
+    container_port   = 3000
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count, task_definition]
+  }
+
+  tags = { Environment = var.environment }
+}
+
+resource "aws_ecs_service" "sidekiq" {
+  name                   = "unicycling-registration-${var.environment}-sidekiq"
+  cluster                = aws_ecs_cluster.app.id
+  task_definition        = aws_ecs_task_definition.sidekiq.arn
+  desired_count          = 0
+  launch_type            = "FARGATE"
+  enable_execute_command = true
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    assign_public_ip = true
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count, task_definition]
+  }
+
+  tags = { Environment = var.environment }
+}

--- a/terraform/ecs_iam.tf
+++ b/terraform/ecs_iam.tf
@@ -1,0 +1,96 @@
+# Execution role — assumed by the ECS agent to pull images from ECR,
+# read SSM parameters, and ship logs to CloudWatch.
+resource "aws_iam_role" "ecs_execution" {
+  name = "unicycling-registration-${var.environment}-ecs-execution"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_execution_managed" {
+  role       = aws_iam_role.ecs_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "ecs_execution_ssm" {
+  name = "ssm-read"
+  role = aws_iam_role.ecs_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = ["ssm:GetParameters", "ssm:GetParameter"]
+      Resource = "arn:aws:ssm:us-west-2:${data.aws_caller_identity.current.account_id}:parameter/unicycling-registration/${var.environment}/*"
+    }]
+  })
+}
+
+# Task role — assumed by the Rails app itself for AWS API calls.
+resource "aws_iam_role" "ecs_task" {
+  name = "unicycling-registration-${var.environment}-ecs-task"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "ecs_task_permissions" {
+  name = "app-permissions"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = ["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket"]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["ses:SendRawEmail", "ses:SendEmail"]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "acm:RequestCertificate",
+          "acm:DescribeCertificate",
+          "acm:ListCertificates",
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:AddListenerCertificates",
+          "elasticloadbalancing:DescribeListenerCertificates",
+        ]
+        Resource = "*"
+      },
+      {
+        # Required for ECS Exec (interactive debugging).
+        Effect = "Allow"
+        Action = [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/ecs_security_groups.tf
+++ b/terraform/ecs_security_groups.tf
@@ -1,0 +1,28 @@
+# Security group for ECS Fargate tasks (web + sidekiq).
+# Inbound restricted to the ALB only; egress open so tasks can reach
+# RDS, ElastiCache, ECR, SSM, and external APIs.
+resource "aws_security_group" "ecs_tasks" {
+  name        = "unicycling-registration-${var.environment}-ecs-tasks"
+  description = "ECS Fargate tasks for ${var.environment}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "App port from ALB"
+    from_port       = 3000
+    to_port         = 3000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "unicycling-registration-${var.environment}-ecs-tasks"
+    Environment = var.environment
+  }
+}

--- a/terraform/elasticache.tf
+++ b/terraform/elasticache.tf
@@ -1,0 +1,11 @@
+# Allow ECS tasks to reach ElastiCache (used for Sidekiq queue + ActionCable).
+# The endpoint URL is stored in SSM as REDIS_URL — no data source needed here.
+resource "aws_security_group_rule" "redis_from_ecs" {
+  type                     = "ingress"
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  security_group_id        = var.elasticache_security_group_id
+  source_security_group_id = aws_security_group.ecs_tasks.id
+  description              = "Redis from ECS tasks (${var.environment})"
+}

--- a/terraform/global/main.tf
+++ b/terraform/global/main.tf
@@ -28,16 +28,29 @@ resource "aws_ecr_lifecycle_policy" "app" {
   repository = aws_ecr_repository.app.name
 
   policy = jsonencode({
-    rules = [{
-      rulePriority = 1
-      description  = "Keep last 20 images"
-      selection = {
-        tagStatus   = "any"
-        countType   = "imageCountMoreThan"
-        countNumber = 20
-      }
-      action = { type = "expire" }
-    }]
+    rules = [
+      {
+        rulePriority = 10
+        description  = "Keep last 5 prod deployments (rollback buffer)"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["prod-"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 5
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 20
+        description  = "Keep last 10 images (current staging + recent undeployed builds)"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = { type = "expire" }
+      },
+    ]
   })
 }
 
@@ -55,9 +68,8 @@ resource "aws_iam_access_key" "circleci" {
   user = aws_iam_user.circleci.name
 }
 
-resource "aws_iam_user_policy" "circleci_ecr" {
-  name = "ecr-push"
-  user = aws_iam_user.circleci.name
+resource "aws_iam_policy" "circleci" {
+  name = "circleci-unicycling-registration"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -81,8 +93,59 @@ resource "aws_iam_user_policy" "circleci_ecr" {
         ]
         Resource = aws_ecr_repository.app.arn
       },
+      {
+        Sid      = "EC2DescribeSGs"
+        Effect   = "Allow"
+        Action   = "ec2:DescribeSecurityGroups"
+        Resource = "*"
+      },
+      {
+        Sid    = "ECSTaskDefs"
+        Effect = "Allow"
+        Action = [
+          "ecs:DescribeTaskDefinition",
+          "ecs:RegisterTaskDefinition",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "ECSRunTask"
+        Effect = "Allow"
+        Action = "ecs:RunTask"
+        Resource = [
+          "arn:aws:ecs:us-west-2:*:task-definition/unicycling-registration-*:*",
+          "arn:aws:ecs:us-west-2:*:cluster/unicycling-registration-*",
+        ]
+      },
+      {
+        Sid    = "ECSInspect"
+        Effect = "Allow"
+        Action = [
+          "ecs:DescribeTasks",
+          "ecs:DescribeServices",
+          "ecs:WaitUntilTasksStopped",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid      = "ECSUpdateService"
+        Effect   = "Allow"
+        Action   = "ecs:UpdateService"
+        Resource = "arn:aws:ecs:us-west-2:*:service/unicycling-registration-*/*"
+      },
+      {
+        Sid      = "PassECSRoles"
+        Effect   = "Allow"
+        Action   = "iam:PassRole"
+        Resource = "arn:aws:iam::*:role/unicycling-registration-*-ecs-*"
+      },
     ]
   })
+}
+
+resource "aws_iam_user_policy_attachment" "circleci" {
+  user       = aws_iam_user.circleci.name
+  policy_arn = aws_iam_policy.circleci.arn
 }
 
 output "circleci_access_key_id" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -17,3 +17,23 @@ output "https_listener_arn" {
   description = "ARN of the HTTPS ALB listener — set as ALB_LISTENER_ARN in SSM/env so the Rails app can attach per-tenant ACM certs at runtime"
   value       = aws_lb_listener.https.arn
 }
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name"
+  value       = aws_ecs_cluster.app.name
+}
+
+output "ecs_web_service_name" {
+  description = "ECS web service name"
+  value       = aws_ecs_service.web.name
+}
+
+output "ecs_sidekiq_service_name" {
+  description = "ECS sidekiq service name"
+  value       = aws_ecs_service.sidekiq.name
+}
+
+output "ecs_target_group_arn" {
+  description = "ARN of the ECS ALB target group"
+  value       = aws_lb_target_group.ecs.arn
+}

--- a/terraform/prod/terraform.tfvars
+++ b/terraform/prod/terraform.tfvars
@@ -1,5 +1,13 @@
 environment         = "prod"
 iam_user_name       = "uniregistration"
+rails_env           = "production"
+ecs_traffic_weight  = 0
+image_tag           = "4246e544b974801240704881994dc3134c2c864e"
+
+ecr_repository_url = "197931692346.dkr.ecr.us-west-2.amazonaws.com/unicycling-registration"
+elasticache_security_group_id = "sg-e4640f81"
+rds_security_group_id = "sg-d51560b0"
+
 domain              = "reg.unicycling-software.com"
 subject_alt_names   = ["*.reg.unicycling-software.com"]
 wildcard_domain     = "*.reg.unicycling-software.com"

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,0 +1,11 @@
+# Allow ECS tasks to reach the shared RDS instance on port 5432.
+# Appends a rule to the existing security group rather than importing it.
+resource "aws_security_group_rule" "rds_from_ecs" {
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = var.rds_security_group_id
+  source_security_group_id = aws_security_group.ecs_tasks.id
+  description              = "PostgreSQL from ECS tasks (${var.environment})"
+}

--- a/terraform/scheduled_tasks.tf
+++ b/terraform/scheduled_tasks.tf
@@ -1,0 +1,80 @@
+# Replaces the whenever/cron setup that ran on EC2.
+# EventBridge triggers one-off ECS tasks on a schedule; each task exits when done.
+# Note: encryption:renew_and_update_certificate (Let's Encrypt) is NOT replicated
+# here — ACM handles certificate renewal automatically.
+
+resource "aws_iam_role" "eventbridge_ecs" {
+  name = "unicycling-registration-${var.environment}-eventbridge-ecs"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "events.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "eventbridge_ecs" {
+  name = "run-ecs-task"
+  role = aws_iam_role.eventbridge_ecs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "ecs:RunTask"
+        Resource = "arn:aws:ecs:us-west-2:${data.aws_caller_identity.current.account_id}:task-definition/${aws_ecs_task_definition.web.family}"
+        Condition = {
+          ArnLike = { "ecs:cluster" = aws_ecs_cluster.app.arn }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = "iam:PassRole"
+        Resource = [
+          aws_iam_role.ecs_execution.arn,
+          aws_iam_role.ecs_task.arn,
+        ]
+      },
+    ]
+  })
+}
+
+# ---- rake update_registration_period ----
+# Mirrors: every 1.day, at: '12am' in config/schedule.rb
+
+resource "aws_cloudwatch_event_rule" "update_registration_period" {
+  name                = "unicycling-registration-${var.environment}-update-registration-period"
+  description         = "Daily rake update_registration_period (replaces whenever cron)"
+  schedule_expression = "cron(0 0 * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "update_registration_period" {
+  rule     = aws_cloudwatch_event_rule.update_registration_period.name
+  arn      = aws_ecs_cluster.app.arn
+  role_arn = aws_iam_role.eventbridge_ecs.arn
+
+  ecs_target {
+    # No revision number — EventBridge picks up the latest active task definition
+    # after each deployment.
+    task_definition_arn = "arn:aws:ecs:us-west-2:${data.aws_caller_identity.current.account_id}:task-definition/${aws_ecs_task_definition.web.family}"
+    task_count          = 1
+    launch_type         = "FARGATE"
+
+    network_configuration {
+      subnets          = var.subnet_ids
+      security_groups  = [aws_security_group.ecs_tasks.id]
+      assign_public_ip = true
+    }
+  }
+
+  input = jsonencode({
+    containerOverrides = [{
+      name    = "web"
+      command = ["bundle", "exec", "rake", "update_registration_period"]
+    }]
+  })
+}

--- a/terraform/staging/terraform.tfvars
+++ b/terraform/staging/terraform.tfvars
@@ -1,5 +1,13 @@
 environment         = "staging"
 iam_user_name       = "uniregtest"
+rails_env           = "stage"
+ecs_traffic_weight  = 0
+image_tag           = "4246e544b974801240704881994dc3134c2c864e"
+
+ecr_repository_url = "197931692346.dkr.ecr.us-west-2.amazonaws.com/unicycling-registration"
+elasticache_security_group_id = "sg-e4640f81"
+rds_security_group_id = "sg-d51560b0"
+
 domain              = "regtest.unicycling-software.com"
 subject_alt_names   = ["*.regtest.unicycling-software.com"]
 wildcard_domain     = "*.regtest.unicycling-software.com"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -54,3 +54,39 @@ variable "iam_user_name" {
   type        = string
   description = "Name of the existing IAM user the app runs as (uniregtest for staging, uniregistration for prod)"
 }
+
+variable "rails_env" {
+  type        = string
+  description = "RAILS_ENV value inside the container (stage for staging, production for prod)"
+}
+
+variable "elasticache_security_group_id" {
+  type        = string
+  description = "Security group ID attached to the ElastiCache instance; ECS tasks will be granted port 6379 ingress"
+}
+
+variable "rds_security_group_id" {
+  type        = string
+  description = "Security group ID attached to the shared RDS instance; ECS tasks will be granted port 5432 ingress"
+}
+
+variable "ecr_repository_url" {
+  type        = string
+  description = "ECR repository URL without tag — from terraform/global output ecr_repository_url"
+}
+
+variable "image_tag" {
+  type        = string
+  description = "Image tag to deploy (git SHA from CircleCI, or 'latest' for initial apply)"
+}
+
+variable "ecs_traffic_weight" {
+  type        = number
+  default     = 0
+  description = "Percentage of ALB traffic sent to ECS (0–100). EC2 receives the remainder. Start at 0, raise gradually during cutover."
+
+  validation {
+    condition     = var.ecs_traffic_weight >= 0 && var.ecs_traffic_weight <= 100
+    error_message = "ecs_traffic_weight must be between 0 and 100."
+  }
+}


### PR DESCRIPTION
Also splits redis into 2 instances, one on the ec2 instance (or sidecar for ecs), and another as AWS Valkey instance for sidekiq.