### PR TITLE
Add convention title to navigation

### DIFF
--- a/app/assets/stylesheets/new_styles/15_navbar.scss
+++ b/app/assets/stylesheets/new_styles/15_navbar.scss
@@ -29,6 +29,23 @@ $height: 50px;
   color: white;
 }
 
+.top-bar-left {
+  display: flex;
+  align-items: center;
+}
+
+// Badge showing the current event's short name, so it's always
+// obvious which event you're registering for/managing.
+.nav-event-badge {
+  background-color: white;
+  color: black;
+  font-weight: bold;
+  white-space: nowrap;
+  padding: 0.4em 0.9em;
+  margin: 0.4em 0.75em;
+  border-radius: 4px;
+}
+
 .breadcrumbs {
   padding: 0.5em 1em;
 }
@@ -63,10 +80,6 @@ $height: 50px;
 // To make the text white
 .top-bar {
   padding: 0;
-
-  .menu-text {
-    color: white;
-  }
 
   a {
     color: white;

--- a/app/assets/stylesheets/new_styles/15_navbar.scss
+++ b/app/assets/stylesheets/new_styles/15_navbar.scss
@@ -64,6 +64,10 @@ $height: 50px;
 .top-bar {
   padding: 0;
 
+  .menu-text {
+    color: white;
+  }
+
   a {
     color: white;
 

--- a/app/views/nav_bar/_top_nav.html.haml
+++ b/app/views/nav_bar/_top_nav.html.haml
@@ -7,6 +7,7 @@
 %nav.top-bar#responsive-menu
   .top-bar-left
     %ul.menu.vertical.large-horizontal
+      %li.menu-text= @config.short_name
       = render "nav_bar/my_links"
   - if user_signed_in?
     .top-bar-right

--- a/app/views/nav_bar/_top_nav.html.haml
+++ b/app/views/nav_bar/_top_nav.html.haml
@@ -6,8 +6,8 @@
       Menu
 %nav.top-bar#responsive-menu
   .top-bar-left
+    .nav-event-badge= @config.short_name
     %ul.menu.vertical.large-horizontal
-      %li.menu-text= @config.short_name
       = render "nav_bar/my_links"
   - if user_signed_in?
     .top-bar-right


### PR DESCRIPTION
based on feedback. this is useful when multiple conventions are active the same summer (unicon + naucc, for example)