### PR TITLE
Allow EC2 prod deploy without Ec2 staging deploy.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,7 +333,10 @@ workflows:
       - approve-prod-cap:
           type: approval
           requires:
-            - release_stage
+            - rspec
+            - tablexi/rubocop
+            - tablexi/bundle_audit
+            - tablexi/check_db_schema
           filters:
             branches:
               only:


### PR DESCRIPTION
EC2 staging is deprecated in favor of ECS