### PR TITLE
Fix several Rollbar exceptions found in production

### DIFF
--- a/app/controllers/registrant_group_members_controller.rb
+++ b/app/controllers/registrant_group_members_controller.rb
@@ -25,7 +25,7 @@ class RegistrantGroupMembersController < ApplicationController
     @registrant_group_member = @registrant_group.registrant_group_members.build
 
     authorize @registrant_group_member
-    params[:registrant_ids].each do |registrant_id|
+    Array(params[:registrant_ids]).reject(&:blank?).each do |registrant_id|
       registrant_group_member = @registrant_group.registrant_group_members.build
       registrant_group_member.registrant_id = registrant_id
       manager.add_member(registrant_group_member) # this may add to the 'erors'

--- a/app/controllers/registrants/build_controller.rb
+++ b/app/controllers/registrants/build_controller.rb
@@ -40,9 +40,7 @@ class Registrants::BuildController < ApplicationController
     when :add_events
       skip_step unless @registrant.competitor?
     when :add_volunteers # rubocop:disable Lint/EmptyWhen
-    when :lodging
-      @selected_lodging = LodgingForm.selected_for(@registrant)
-      @paid_lodging = LodgingForm.paid_for(@registrant)
+    when :lodging # rubocop:disable Lint/EmptyWhen
     end
 
     render_wizard

--- a/app/controllers/tenants_controller.rb
+++ b/app/controllers/tenants_controller.rb
@@ -42,6 +42,6 @@ class TenantsController < ApplicationController
   private
 
   def tenant_params
-    params.require(:tenant).permit(:subdomain, :description, :admin_upgrade_code)
+    params.fetch(:tenant, {}).permit(:subdomain, :description, :admin_upgrade_code)
   end
 end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -54,11 +54,11 @@ class Tenant < ApplicationRecord
   private
 
   def trim_subdomain
-    self.subdomain = subdomain.strip
+    self.subdomain = subdomain&.strip
   end
 
   def lowercase_subdomain
-    self.subdomain = subdomain.downcase
+    self.subdomain = subdomain&.downcase
   end
 
   def subdomain_has_no_spaces

--- a/app/views/registrants/build/_existing_lodging.html.haml
+++ b/app/views/registrants/build/_existing_lodging.html.haml
@@ -1,4 +1,6 @@
-#{@registrant}'s chosen Lodging
+#{registrant}'s chosen Lodging
+- paid_lodging = LodgingForm.paid_for(registrant)
+- selected_lodging = LodgingForm.selected_for(registrant)
 %table
   %thead
     %tr
@@ -7,14 +9,14 @@
       %th Check-Out
       %th
   %tbody
-    - @paid_lodging.each do |lodging_package|
+    - paid_lodging.each do |lodging_package|
       %tr
         %td= lodging_package.location
         %td= lodging_package.check_in_day
         %td= lodging_package.check_out_day
         %td Paid
 
-    - @selected_lodging.each do |lodging_package|
+    - selected_lodging.each do |lodging_package|
       %tr
         %td= lodging_package.location
         %td= lodging_package.check_in_day

--- a/spec/controllers/registrant_group_members_controller_spec.rb
+++ b/spec/controllers/registrant_group_members_controller_spec.rb
@@ -41,6 +41,36 @@ describe RegistrantGroupMembersController do
         end.to change(RegistrantGroupMember, :count).by(1)
       end
     end
+
+    describe "when registrant_ids is nil (no selection made)" do
+      it "does not crash" do
+        expect do
+          post :create, params: { registrant_group_id: registrant_group.to_param }
+        end.not_to raise_error
+      end
+
+      it "creates no records" do
+        expect do
+          post :create, params: { registrant_group_id: registrant_group.to_param }
+        end.not_to change(RegistrantGroupMember, :count)
+      end
+    end
+
+    describe "when registrant_ids contains a blank entry (Rails hidden field)" do
+      let(:registrant) { FactoryBot.create(:competitor) }
+
+      it "does not crash" do
+        expect do
+          post :create, params: { registrant_ids: ["", registrant.id], registrant_group_id: registrant_group.to_param }
+        end.not_to raise_error
+      end
+
+      it "creates only the valid record" do
+        expect do
+          post :create, params: { registrant_ids: ["", registrant.id], registrant_group_id: registrant_group.to_param }
+        end.to change(RegistrantGroupMember, :count).by(1)
+      end
+    end
   end
 
   describe "DELETE destroy" do

--- a/spec/controllers/registrants/build_controller_spec.rb
+++ b/spec/controllers/registrants/build_controller_spec.rb
@@ -92,7 +92,7 @@ describe Registrants::BuildController do
         let(:payment) { FactoryBot.create(:payment, :completed) }
         let!(:payment_detail) do
           FactoryBot.create(:payment_detail, registrant: registrant, payment: payment,
-                            line_item: lodging_package)
+                                             line_item: lodging_package)
         end
 
         it "renders without error" do

--- a/spec/controllers/registrants/build_controller_spec.rb
+++ b/spec/controllers/registrants/build_controller_spec.rb
@@ -68,6 +68,43 @@ describe Registrants::BuildController do
           assert_select "legend", text: "Add Lodging"
         end
       end
+
+      context "when the registrant has a selected (unpaid) lodging package" do
+        let(:lodging_package) { FactoryBot.create(:lodging_package) }
+        let!(:lodging_package_day) { FactoryBot.create(:lodging_package_day, lodging_package: lodging_package) }
+        let!(:rei) { FactoryBot.create(:registrant_expense_item, registrant: registrant, line_item: lodging_package) }
+
+        it "renders without error" do
+          get :show, params: { registrant_id: registrant.to_param, id: "lodging" }
+          expect(response).to be_successful
+        end
+
+        it "displays the selected lodging" do
+          get :show, params: { registrant_id: registrant.to_param, id: "lodging" }
+          expect(response.body).to include(lodging_package.location)
+        end
+      end
+
+      context "when the registrant has a paid lodging package" do
+        let(:registrant) { FactoryBot.create(:competitor, status: "active", user: user) }
+        let(:lodging_package) { FactoryBot.create(:lodging_package) }
+        let!(:lodging_package_day) { FactoryBot.create(:lodging_package_day, lodging_package: lodging_package) }
+        let(:payment) { FactoryBot.create(:payment, :completed) }
+        let!(:payment_detail) do
+          FactoryBot.create(:payment_detail, registrant: registrant, payment: payment,
+                            line_item: lodging_package)
+        end
+
+        it "renders without error" do
+          get :show, params: { registrant_id: registrant.to_param, id: "lodging" }
+          expect(response).to be_successful
+        end
+
+        it "displays the paid lodging" do
+          get :show, params: { registrant_id: registrant.to_param, id: "lodging" }
+          expect(response.body).to include(lodging_package.location)
+        end
+      end
     end
 
     context "viewing the expenses page" do

--- a/spec/controllers/tenants_controller_spec.rb
+++ b/spec/controllers/tenants_controller_spec.rb
@@ -48,5 +48,16 @@ describe TenantsController do
         post :create, params: { code: code, tenant: { subdomain: "new_tenant", description: "My Tenant", admin_upgrade_code: "Hi" } }
       end.to change(Tenant, :count).by(1)
     end
+
+    it "does not crash when the tenant param is missing entirely" do
+      expect do
+        post :create, params: { code: code }
+      end.not_to raise_error
+    end
+
+    it "re-renders the form when the tenant param is missing" do
+      post :create, params: { code: code }
+      expect(response).to be_successful
+    end
   end
 end


### PR DESCRIPTION
- registrant_group_members: handle nil/blank registrant_ids param (Rails sends '' alongside multi-selects; no selection sends nil)
- lodging partial: compute paid/selected lodging from the local rather than controller instance variables, preventing a crash if the partial is ever rendered outside the show action
- tenants: use params.fetch instead of params.require so a missing tenant key re-renders the form rather than raising 500
- tenant model: guard subdomain callbacks against nil to avoid NoMethodError when subdomain is blank
