### PR TITLE
Allow float wheel size (e.g. 27.5)

### DIFF
--- a/app/models/competitor.rb
+++ b/app/models/competitor.rb
@@ -11,7 +11,7 @@
 #  status                   :integer          default("active")
 #  lowest_member_bib_number :integer
 #  geared                   :boolean          default(FALSE), not null
-#  riding_wheel_size        :integer
+#  riding_wheel_size        :float
 #  notes                    :string
 #  wave                     :integer
 #  riding_crank_size        :integer
@@ -68,6 +68,7 @@ class Competitor < ApplicationRecord
   validate :must_have_3_members_for_custom_name
   validates :tier_number, presence: true
   validates :tier_number, numericality: { greater_than_or_equal_to: 1, less_than: 10 }
+  validates :riding_wheel_size, numericality: { greater_than_or_equal_to: 8, less_than: 100, allow_nil: true }
 
   enum :status, %i[active not_qualified dns withdrawn dnf]
   after_save :touch_members

--- a/app/views/compete/sign_ins/edit.html.haml
+++ b/app/views/compete/sign_ins/edit.html.haml
@@ -57,7 +57,7 @@
               %Th= comp_f.number_field :tier_number, class: "sign_in_heat"
               %Th= comp_f.text_field :tier_description, class: "sign_in_heat"
               %td= comp_f.check_box :geared
-              %td= comp_f.number_field :riding_wheel_size, class: "sign_in_wheel_size"
+              %td= comp_f.number_field :riding_wheel_size, step: 0.5, min: 8, max: 100, class: "sign_in_wheel_size"
               %td= comp_f.number_field :riding_crank_size, class: "sign_in_crank_size"
               %td= comp_f.text_field :notes, class: "sign_in_notes"
     = f.button :submit

--- a/db/migrate/20260704122530_change_riding_wheel_size_float.rb
+++ b/db/migrate/20260704122530_change_riding_wheel_size_float.rb
@@ -1,0 +1,8 @@
+class ChangeRidingWheelSizeFloat < ActiveRecord::Migration[8.1]
+  def up
+    change_column :competitors, :riding_wheel_size, :float
+  end
+  def down
+    change_column :competitors, :riding_wheel_size, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_19_025017) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_04_122530) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -260,7 +260,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_19_025017) do
     t.string "notes"
     t.integer "position"
     t.integer "riding_crank_size"
-    t.integer "riding_wheel_size"
+    t.float "riding_wheel_size"
     t.integer "status", default: 0
     t.string "tier_description"
     t.integer "tier_number", default: 1, null: false

--- a/spec/controllers/compete/sign_ins_controller_spec.rb
+++ b/spec/controllers/compete/sign_ins_controller_spec.rb
@@ -33,7 +33,7 @@ describe Compete::SignInsController do
 
     let!(:competitor1) { FactoryBot.create(:event_competitor, competition: competition, bib_number: 101) }
 
-    it "updates the sign_ins" do
+    it "updates the sign_ins with wave" do
       params = {
         competitors_attributes: {
           "0" => {
@@ -45,6 +45,76 @@ describe Compete::SignInsController do
       expect(competitor1.wave).to be_nil
       put :update, params: { competition_id: competition.id, competition: params }
       expect(competitor1.reload.wave).to eq(1)
+    end
+
+    it "updates the sign_ins with minimum wheel size" do
+      params = {
+        competitors_attributes: {
+          "0" => {
+            id: competitor1.id,
+            riding_wheel_size: 8
+          }
+        }
+      }
+      expect(competitor1.riding_wheel_size).to be_nil
+      put :update, params: { competition_id: competition.id, competition: params }
+      expect(competitor1.reload.riding_wheel_size).to eq(8)
+    end
+
+    it "updates the sign_ins with maximum wheel size" do
+      params = {
+        competitors_attributes: {
+          "0" => {
+            id: competitor1.id,
+            riding_wheel_size: 99.99
+          }
+        }
+      }
+      expect(competitor1.riding_wheel_size).to be_nil
+      put :update, params: { competition_id: competition.id, competition: params }
+      expect(competitor1.reload.riding_wheel_size).to eq(99.99)
+    end
+
+    it "updates the sign_ins with float wheel size" do
+      params = {
+        competitors_attributes: {
+          "0" => {
+            id: competitor1.id,
+            riding_wheel_size: 27.5
+          }
+        }
+      }
+      expect(competitor1.riding_wheel_size).to be_nil
+      put :update, params: { competition_id: competition.id, competition: params }
+      expect(competitor1.reload.riding_wheel_size).to eq(27.5)
+    end
+
+    it "fails to update the sign_ins with too small wheel size" do
+      params = {
+        competitors_attributes: {
+          "0" => {
+            id: competitor1.id,
+            riding_wheel_size: 7
+          }
+        }
+      }
+      expect(competitor1.riding_wheel_size).to be_nil
+      put :update, params: { competition_id: competition.id, competition: params }
+      expect(competitor1.reload.riding_wheel_size).to be_nil
+    end
+
+    it "fails to update the sign_ins with too big wheel size" do
+      params = {
+        competitors_attributes: {
+          "0" => {
+            id: competitor1.id,
+            riding_wheel_size: 101
+          }
+        }
+      }
+      expect(competitor1.riding_wheel_size).to be_nil
+      put :update, params: { competition_id: competition.id, competition: params }
+      expect(competitor1.reload.riding_wheel_size).to be_nil
     end
   end
 end

--- a/spec/factories/competitors.rb
+++ b/spec/factories/competitors.rb
@@ -11,7 +11,7 @@
 #  status                   :integer          default("active")
 #  lowest_member_bib_number :integer
 #  geared                   :boolean          default(FALSE), not null
-#  riding_wheel_size        :integer
+#  riding_wheel_size        :float
 #  notes                    :string
 #  wave                     :integer
 #  riding_crank_size        :integer

--- a/spec/models/competitor_spec.rb
+++ b/spec/models/competitor_spec.rb
@@ -11,7 +11,7 @@
 #  status                   :integer          default("active")
 #  lowest_member_bib_number :integer
 #  geared                   :boolean          default(FALSE), not null
-#  riding_wheel_size        :integer
+#  riding_wheel_size        :float
 #  notes                    :string
 #  wave                     :integer
 #  riding_crank_size        :integer


### PR DESCRIPTION
Wheel size are usually integers, but can also be floats - such as 27.5". In that case, it is impossible to specify the exact size and we have to resort to the nearest integer - in that case, usually 27".
This PR's goal is to fix the issue.