### PR TITLE
Remove truncated activerecord.models/attributes stub keys from locale files

### DIFF
--- a/config/locales/models/age_group_entry.da.yml
+++ b/config/locales/models/age_group_entry.da.yml
@@ -11,4 +11,3 @@
           Minimum Alder
         "wheel_size": >-
           Hjul Størelse (valgfri)
-    "models":

--- a/config/locales/models/age_group_entry.de.yml
+++ b/config/locales/models/age_group_entry.de.yml
@@ -11,4 +11,3 @@
           mindest Alter
         "wheel_size": >-
           Erforderliche Radgröße (optional)
-    "models":

--- a/config/locales/models/age_group_entry.es.yml
+++ b/config/locales/models/age_group_entry.es.yml
@@ -11,4 +11,3 @@
           Edad de inicio
         "wheel_size": >-
           Tamaño de rueda requerido
-    "models":

--- a/config/locales/models/age_group_type.de.yml
+++ b/config/locales/models/age_group_type.de.yml
@@ -7,4 +7,3 @@
           Beschreibung
         "name": >-
           Name
-    "models":

--- a/config/locales/models/age_group_type.es.yml
+++ b/config/locales/models/age_group_type.es.yml
@@ -7,4 +7,3 @@
           Descripción
         "name": >-
           Nombre
-    "models":

--- a/config/locales/models/award_label.de.yml
+++ b/config/locales/models/award_label.de.yml
@@ -7,4 +7,3 @@
           ID
         "place": >-
           Platzierung
-    "models":

--- a/config/locales/models/award_label.es.yml
+++ b/config/locales/models/award_label.es.yml
@@ -7,4 +7,3 @@
           Cuenta
         "place": >-
           Lugar
-    "models":

--- a/config/locales/models/award_label.nl.yml
+++ b/config/locales/models/award_label.nl.yml
@@ -7,4 +7,3 @@
           ID
         "place": >-
           Plaats
-    "models":

--- a/config/locales/models/category.es.yml
+++ b/config/locales/models/category.es.yml
@@ -5,4 +5,3 @@
       "category":
         "name": >-
           Nombre
-    "models":

--- a/config/locales/models/combined_competition.de.yml
+++ b/config/locales/models/combined_competition.de.yml
@@ -7,4 +7,3 @@
           Prozent basierte Kalkulationen
         "use_age_group_places": >-
           Verwende Altersklassen Platzierungen
-    "models":

--- a/config/locales/models/combined_competition.es.yml
+++ b/config/locales/models/combined_competition.es.yml
@@ -9,4 +9,3 @@
           Muerte súbita por primeros
         "use_age_group_places": >-
           Usar lugares en grupos de edad
-    "models":

--- a/config/locales/models/combined_competition_entry.da.yml
+++ b/config/locales/models/combined_competition_entry.da.yml
@@ -9,4 +9,3 @@
           Base Points
         "tie_breaker": >-
           Tie Breaker
-    "models":

--- a/config/locales/models/combined_competition_entry.de.yml
+++ b/config/locales/models/combined_competition_entry.de.yml
@@ -9,4 +9,3 @@
           Basis Punkte
         "tie_breaker": >-
           Stechen
-    "models":

--- a/config/locales/models/combined_competition_entry.es.yml
+++ b/config/locales/models/combined_competition_entry.es.yml
@@ -9,4 +9,3 @@
           Puntos base
         "tie_breaker": >-
           Muerte Súbita
-    "models":

--- a/config/locales/models/competition.de.yml
+++ b/config/locales/models/competition.de.yml
@@ -37,4 +37,3 @@
           Starliniendaten Eingabe
         "uses_lane_assignments": >-
           Teilnahme in Reihen / Läufen
-    "models":

--- a/config/locales/models/competitor.es.yml
+++ b/config/locales/models/competitor.es.yml
@@ -11,4 +11,3 @@
           Género
         "name": >-
           Nombre
-    "models":

--- a/config/locales/models/coupon_code.de.yml
+++ b/config/locales/models/coupon_code.de.yml
@@ -17,4 +17,3 @@
           Name
         "price": >-
           Preis
-    "models":

--- a/config/locales/models/coupon_code.es.yml
+++ b/config/locales/models/coupon_code.es.yml
@@ -17,4 +17,3 @@
           Nombre
         "price": >-
           Precio
-    "models":

--- a/config/locales/models/distance_attempt.de.yml
+++ b/config/locales/models/distance_attempt.de.yml
@@ -7,4 +7,3 @@
           Distanz
         "fault": >-
           Fehler
-    "models":

--- a/config/locales/models/distance_attempt.es.yml
+++ b/config/locales/models/distance_attempt.es.yml
@@ -7,4 +7,3 @@
           Distancia
         "fault": >-
           Falta
-    "models":

--- a/config/locales/models/event.es.yml
+++ b/config/locales/models/event.es.yml
@@ -15,4 +15,3 @@
           Habilidad estandar
         "visible": >-
           Visible
-    "models":

--- a/config/locales/models/event_category.da.yml
+++ b/config/locales/models/event_category.da.yml
@@ -11,4 +11,3 @@
           Navn
         "warning_on_registration_summary": >-
           Advarsel på tilmeldings resumé
-    "models":

--- a/config/locales/models/event_category.de.yml
+++ b/config/locales/models/event_category.de.yml
@@ -11,4 +11,3 @@
           Name
         "warning_on_registration_summary": >-
           Warnung bei der Anmelde Zusammenfasung
-    "models":

--- a/config/locales/models/event_category.es.yml
+++ b/config/locales/models/event_category.es.yml
@@ -11,4 +11,3 @@
           Nombre
         "warning_on_registration_summary": >-
           Advertencia en resumen de registro
-    "models":

--- a/config/locales/models/event_choice.da.yml
+++ b/config/locales/models/event_choice.da.yml
@@ -11,4 +11,3 @@
           Valgfrig hvis dette event_choice er valgt
         "required_if_event_choice_id": >-
           Påkrævet hvis dette event_choice er valgt
-    "models":

--- a/config/locales/models/event_choice.es.yml
+++ b/config/locales/models/event_choice.es.yml
@@ -11,4 +11,3 @@
           Opcional si se elige este evento/elección
         "required_if_event_choice_id": >-
           Requerido si se elige este evento/elección
-    "models":

--- a/config/locales/models/event_configuration.de.yml
+++ b/config/locales/models/event_configuration.de.yml
@@ -85,7 +85,6 @@
           wird gerade überarbeitet
         "waiver_file_name": >-
           Druckbare Verzichtsdatei PDF
-    "models":
   "helpers":
     "submit":
       "event_configuration":

--- a/config/locales/models/event_configuration.es.yml
+++ b/config/locales/models/event_configuration.es.yml
@@ -83,7 +83,6 @@
           En construcción
         "waiver_file_name": >-
           Archivo de Renuncia imprimible PDF
-    "models":
   "helpers":
     "submit":
       "event_configuration":

--- a/config/locales/models/expense_group.es.yml
+++ b/config/locales/models/expense_group.es.yml
@@ -5,4 +5,3 @@
       "expense_group":
         "group_name": >-
           Nombre del grupo
-    "models":

--- a/config/locales/models/expense_item.de.yml
+++ b/config/locales/models/expense_item.de.yml
@@ -23,4 +23,3 @@
           Gesammt
         "total_cost": >-
           Gesammt (berechnet)
-    "models":

--- a/config/locales/models/expense_item.es.yml
+++ b/config/locales/models/expense_item.es.yml
@@ -23,4 +23,3 @@
           total
         "total_cost": >-
           Total(calculado)
-    "models":

--- a/config/locales/models/expense_item.nl.yml
+++ b/config/locales/models/expense_item.nl.yml
@@ -23,4 +23,3 @@
           Totaal
         "total_cost": >-
           Totaal (opgeteld)
-    "models":

--- a/config/locales/models/external_result.de.yml
+++ b/config/locales/models/external_result.de.yml
@@ -7,4 +7,3 @@
           Details
         "points": >-
           Punkte
-    "models":

--- a/config/locales/models/external_result.es.yml
+++ b/config/locales/models/external_result.es.yml
@@ -7,4 +7,3 @@
           Detalles
         "points": >-
           Puntos
-    "models":

--- a/config/locales/models/external_result.nl.yml
+++ b/config/locales/models/external_result.nl.yml
@@ -7,4 +7,3 @@
           Details
         "points": >-
           Punten
-    "models":

--- a/config/locales/models/feedback.de.yml
+++ b/config/locales/models/feedback.de.yml
@@ -7,4 +7,3 @@
           Nachricht
         "subject": >-
           Betreff
-    "models":

--- a/config/locales/models/feedback.es.yml
+++ b/config/locales/models/feedback.es.yml
@@ -7,4 +7,3 @@
           Mensaje
         "subject": >-
           Tema
-    "models":

--- a/config/locales/models/feedback.it.yml
+++ b/config/locales/models/feedback.it.yml
@@ -1,7 +1,6 @@
 ---
 "it":
   "activerecord":
-    "attributes":
     "models":
       "feedback":
         "one": >-

--- a/config/locales/models/lane_assignment.de.yml
+++ b/config/locales/models/lane_assignment.de.yml
@@ -7,4 +7,3 @@
           Runde
         "lane": >-
           Bahn
-    "models":

--- a/config/locales/models/lane_assignment.es.yml
+++ b/config/locales/models/lane_assignment.es.yml
@@ -7,4 +7,3 @@
           Calor
         "lane": >-
           Carril
-    "models":

--- a/config/locales/models/lodging_room_type.de.yml
+++ b/config/locales/models/lodging_room_type.de.yml
@@ -5,4 +5,3 @@
       "lodging_room_type":
         "minimum_duration_days": >-
           Minimale Anzahl an Tagen für eine Buchung
-    "models":

--- a/config/locales/models/lodging_room_type.es.yml
+++ b/config/locales/models/lodging_room_type.es.yml
@@ -5,4 +5,3 @@
       "lodging_room_type":
         "minimum_duration_days": >-
           Número mínimo de días requeridos para una reservación
-    "models":

--- a/config/locales/models/organization_membership.de.yml
+++ b/config/locales/models/organization_membership.de.yml
@@ -7,4 +7,3 @@
           Mitgliedsnummer des Einrad Verbandes
         "system_status": >-
           Mitglieds Status
-    "models":

--- a/config/locales/models/organization_membership.es.yml
+++ b/config/locales/models/organization_membership.es.yml
@@ -7,4 +7,3 @@
           Número de membresía de Organización de Monociclismo
         "system_status": >-
           Estado de la membresía
-    "models":

--- a/config/locales/models/organization_membership.it.yml
+++ b/config/locales/models/organization_membership.it.yml
@@ -7,4 +7,3 @@
           Numero di membro dell'organizzazione monociclistica
         "system_status": >-
           Stato dell'associato
-    "models":

--- a/config/locales/models/organization_membership.nl.yml
+++ b/config/locales/models/organization_membership.nl.yml
@@ -7,4 +7,3 @@
           IUF lidnummer
         "system_status": >-
           Status van je lidmaatschap
-    "models":

--- a/config/locales/models/page.de.yml
+++ b/config/locales/models/page.de.yml
@@ -13,4 +13,3 @@
           Benahmung der URL
         "title": >-
           Titel
-    "models":

--- a/config/locales/models/page.es.yml
+++ b/config/locales/models/page.es.yml
@@ -13,4 +13,3 @@
           slug (url)
         "title": >-
           Título
-    "models":

--- a/config/locales/models/page.nl.yml
+++ b/config/locales/models/page.nl.yml
@@ -13,4 +13,3 @@
           URL
         "title": >-
           Titel
-    "models":

--- a/config/locales/models/payment.nl.yml
+++ b/config/locales/models/payment.nl.yml
@@ -17,4 +17,3 @@
           Totaal
         "transaction_id": >-
           OverschrijvingsID
-    "models":

--- a/config/locales/models/payment_detail.de.yml
+++ b/config/locales/models/payment_detail.de.yml
@@ -5,4 +5,3 @@
       "payment_detail":
         "details": >-
           Details
-    "models":

--- a/config/locales/models/payment_detail.es.yml
+++ b/config/locales/models/payment_detail.es.yml
@@ -5,4 +5,3 @@
       "payment_detail":
         "details": >-
           Detalles
-    "models":

--- a/config/locales/models/payment_detail.nl.yml
+++ b/config/locales/models/payment_detail.nl.yml
@@ -5,4 +5,3 @@
       "payment_detail":
         "details": >-
           Details
-    "models":

--- a/config/locales/models/refund.de.yml
+++ b/config/locales/models/refund.de.yml
@@ -11,4 +11,3 @@
           Rückerstattungs ID
         "user_id": >-
           Rückerstattet von
-    "models":

--- a/config/locales/models/refund.es.yml
+++ b/config/locales/models/refund.es.yml
@@ -11,4 +11,3 @@
           Código de reembolso
         "user_id": >-
           Reembolsado por
-    "models":

--- a/config/locales/models/refund.nl.yml
+++ b/config/locales/models/refund.nl.yml
@@ -11,4 +11,3 @@
           TerugbetalingsID
         "user_id": >-
           Terug betaald door
-    "models":

--- a/config/locales/models/registrant.nl.yml
+++ b/config/locales/models/registrant.nl.yml
@@ -15,4 +15,3 @@
           Handtekening
         "wheel_size_id": >-
           Basis wielomtrek voor op de piste
-    "models":

--- a/config/locales/models/registrant_best_time.de.yml
+++ b/config/locales/models/registrant_best_time.de.yml
@@ -7,4 +7,3 @@
           Beste Zeit
         "source_location": >-
           Veranstaltungs Name
-    "models":

--- a/config/locales/models/registrant_best_time.es.yml
+++ b/config/locales/models/registrant_best_time.es.yml
@@ -7,4 +7,3 @@
           Mejor tiempo
         "source_location": >-
           Nombre de convención
-    "models":

--- a/config/locales/models/registrant_best_time.nl.yml
+++ b/config/locales/models/registrant_best_time.nl.yml
@@ -7,4 +7,3 @@
           Beste tijd
         "source_location": >-
           Evenementsnaam
-    "models":

--- a/config/locales/models/registrant_expense_item.nl.yml
+++ b/config/locales/models/registrant_expense_item.nl.yml
@@ -5,4 +5,3 @@
       "registrant_expense_item":
         "tax": >-
           Tax
-    "models":

--- a/config/locales/models/registrant_group.de.yml
+++ b/config/locales/models/registrant_group.de.yml
@@ -5,4 +5,3 @@
       "registrant_group":
         "name": >-
           Gruppen Name
-    "models":

--- a/config/locales/models/registrant_group.es.yml
+++ b/config/locales/models/registrant_group.es.yml
@@ -5,4 +5,3 @@
       "registrant_group":
         "name": >-
           Nombre de grupo
-    "models":

--- a/config/locales/models/registrant_group.nl.yml
+++ b/config/locales/models/registrant_group.nl.yml
@@ -5,4 +5,3 @@
       "registrant_group":
         "name": >-
           Groepsnaam
-    "models":

--- a/config/locales/models/registration_cost.es.yml
+++ b/config/locales/models/registration_cost.es.yml
@@ -13,4 +13,3 @@
           Tipo de registro
         "start_date": >-
           Fecha de inicio
-    "models":

--- a/config/locales/models/registration_cost.nl.yml
+++ b/config/locales/models/registration_cost.nl.yml
@@ -13,4 +13,3 @@
           Deelnemerstype
         "start_date": >-
           Aanvangsdatum
-    "models":

--- a/config/locales/models/registration_cost_entry.da.yml
+++ b/config/locales/models/registration_cost_entry.da.yml
@@ -7,4 +7,3 @@
           Max Alder
         "min_age": >-
           Minimun Alderq
-    "models":

--- a/config/locales/models/registration_cost_entry.de.yml
+++ b/config/locales/models/registration_cost_entry.de.yml
@@ -7,4 +7,3 @@
           Max Alter
         "min_age": >-
           Min Alter
-    "models":

--- a/config/locales/models/registration_cost_entry.es.yml
+++ b/config/locales/models/registration_cost_entry.es.yml
@@ -7,4 +7,3 @@
           Edad máxima
         "min_age": >-
           Edad mínima
-    "models":

--- a/config/locales/models/registration_cost_entry.nl.yml
+++ b/config/locales/models/registration_cost_entry.nl.yml
@@ -7,4 +7,3 @@
           Maximum leeftijd
         "min_age": >-
           Minimum leeftijd
-    "models":

--- a/config/locales/models/song.de.yml
+++ b/config/locales/models/song.de.yml
@@ -11,4 +11,3 @@
           Zuletzt Aktualisiert
         "uploaded_by_guest": >-
           Gast?
-    "models":

--- a/config/locales/models/song.es.yml
+++ b/config/locales/models/song.es.yml
@@ -11,4 +11,3 @@
           Última actualización
         "uploaded_by_guest": >-
           invitado?
-    "models":

--- a/config/locales/models/song.nl.yml
+++ b/config/locales/models/song.nl.yml
@@ -11,4 +11,3 @@
           Laatste update
         "uploaded_by_guest": >-
           Gast?
-    "models":

--- a/config/locales/models/standard_skill_entry.da.yml
+++ b/config/locales/models/standard_skill_entry.da.yml
@@ -11,4 +11,3 @@
           Trick Nummer
         "points": >-
           Point
-    "models":

--- a/config/locales/models/standard_skill_entry.de.yml
+++ b/config/locales/models/standard_skill_entry.de.yml
@@ -11,4 +11,3 @@
           Skill Nummer
         "points": >-
           Punkte
-    "models":

--- a/config/locales/models/standard_skill_entry.es.yml
+++ b/config/locales/models/standard_skill_entry.es.yml
@@ -11,4 +11,3 @@
           número de habilidad
         "points": >-
           puntos
-    "models":

--- a/config/locales/models/standard_skill_entry.nl.yml
+++ b/config/locales/models/standard_skill_entry.nl.yml
@@ -11,4 +11,3 @@
           Skill nummer
         "points": >-
           Punten
-    "models":

--- a/config/locales/models/standard_skill_routine_entry.da.yml
+++ b/config/locales/models/standard_skill_routine_entry.da.yml
@@ -5,4 +5,3 @@
       "standard_skill_routine_entry":
         "position": >-
           Placering
-    "models":

--- a/config/locales/models/standard_skill_routine_entry.de.yml
+++ b/config/locales/models/standard_skill_routine_entry.de.yml
@@ -5,4 +5,3 @@
       "standard_skill_routine_entry":
         "position": >-
           Position #
-    "models":

--- a/config/locales/models/standard_skill_routine_entry.es.yml
+++ b/config/locales/models/standard_skill_routine_entry.es.yml
@@ -5,4 +5,3 @@
       "standard_skill_routine_entry":
         "position": >-
           Posición #
-    "models":

--- a/config/locales/models/standard_skill_routine_entry.nl.yml
+++ b/config/locales/models/standard_skill_routine_entry.nl.yml
@@ -5,4 +5,3 @@
       "standard_skill_routine_entry":
         "position": >-
           Positie #
-    "models":

--- a/config/locales/models/tenant_alias.da.yml
+++ b/config/locales/models/tenant_alias.da.yml
@@ -5,4 +5,3 @@
       "tenant_alias":
         "website_alias": >-
           Website Alias
-    "models":

--- a/config/locales/models/tenant_alias.de.yml
+++ b/config/locales/models/tenant_alias.de.yml
@@ -5,4 +5,3 @@
       "tenant_alias":
         "website_alias": >-
           Webseiten Alias
-    "models":

--- a/config/locales/models/tenant_alias.es.yml
+++ b/config/locales/models/tenant_alias.es.yml
@@ -5,4 +5,3 @@
       "tenant_alias":
         "website_alias": >-
           Alias de sitio web
-    "models":

--- a/config/locales/models/tenant_alias.nl.yml
+++ b/config/locales/models/tenant_alias.nl.yml
@@ -5,4 +5,3 @@
       "tenant_alias":
         "website_alias": >-
           Website alias
-    "models":

--- a/config/locales/models/time_result.de.yml
+++ b/config/locales/models/time_result.de.yml
@@ -21,4 +21,3 @@
           Sekunden
         "thousands": >-
           Tausender
-    "models":

--- a/config/locales/models/time_result.es.yml
+++ b/config/locales/models/time_result.es.yml
@@ -21,4 +21,3 @@
           Segundos
         "thousands": >-
           Miles
-    "models":

--- a/config/locales/models/time_result.nl.yml
+++ b/config/locales/models/time_result.nl.yml
@@ -21,4 +21,3 @@
           Seconden
         "thousands": >-
           Duizenden
-    "models":

--- a/config/locales/models/user.de.yml
+++ b/config/locales/models/user.de.yml
@@ -7,4 +7,3 @@
           Benutzer Email
         "name": >-
           Name
-    "models":

--- a/config/locales/models/user.es.yml
+++ b/config/locales/models/user.es.yml
@@ -7,4 +7,3 @@
           Mail de Cuenta de ususario
         "name": >-
           Nombre
-    "models":

--- a/config/locales/models/user.nl.yml
+++ b/config/locales/models/user.nl.yml
@@ -7,4 +7,3 @@
           Deelnemers account email
         "name": >-
           Naam
-    "models":

--- a/config/locales/models/volunteer_opportunity.es.yml
+++ b/config/locales/models/volunteer_opportunity.es.yml
@@ -5,4 +5,3 @@
       "volunteer_opportunity":
         "description": >-
           Rol de voluntario
-    "models":

--- a/config/locales/models/volunteer_opportunity.nl.yml
+++ b/config/locales/models/volunteer_opportunity.nl.yml
@@ -5,4 +5,3 @@
       "volunteer_opportunity":
         "description": >-
           Vrijwilligers rol
-    "models":


### PR DESCRIPTION
Summary: ~90 config/locales/models/*.yml files (mostly da/de/es/nl, plus a few others) had an empty models: (or attributes:) key with nothing nested under it — a leftover from an incomplete translation pass. Since I18n's Simple backend deep-merges all locale files into one hash per locale, and replaces rather than merges a Hash with a nil value, whichever such file happened to load last for a given locale silently wiped out every activerecord.models entry accumulated so far for that locale.
 

Confirmed impact: before this fix, es/nl had zero working model-name translations, de had 1 of ~59, da had 5. After removing the dead stub keys (no new translations needed — an absent key simply doesn't participate in the merge), da recovers to 48/59, nl to 27/59, es to 6/59, de to 13/59, it to 57/59 (remaining gaps are genuinely untranslated models for those locales, not a bug).

This surfaced while working on PR #3103, which started using model_name.human/human_attribute_name for the registrant-group-type pages — that's when the missing translations became visible in the UI (mixed English/translated text).