### PR TITLE
Allow custom labels

### DIFF
--- a/app/controllers/award_labels_controller.rb
+++ b/app/controllers/award_labels_controller.rb
@@ -25,7 +25,7 @@ class AwardLabelsController < ApplicationController
   before_action :authenticate_ability
   before_action :load_award_label, only: %i[edit update destroy]
 
-  before_action :load_label_definitions, only: [:index]
+  before_action :load_label_definitions, only: %i[index create]
   before_action :set_label_types, only: [:normal_labels]
   before_action :load_user, except: %i[edit update destroy]
 

--- a/app/controllers/award_labels_controller.rb
+++ b/app/controllers/award_labels_controller.rb
@@ -378,7 +378,7 @@ class AwardLabelsController < ApplicationController
     custom_types = {}
     CustomLabelType.all.each do |custom_label_type|
       custom_types[custom_label_type.name] = {
-        "paper_size" => custom_label_type.paper_size,
+        "paper_size" => custom_label_type.paper_size_value,
         "top_margin" => custom_label_type.top_margin,
         "bottom_margin" => custom_label_type.bottom_margin,
         "left_margin" => custom_label_type.left_margin,

--- a/app/controllers/award_labels_controller.rb
+++ b/app/controllers/award_labels_controller.rb
@@ -344,19 +344,20 @@ class AwardLabelsController < ApplicationController
 
   def load_label_definitions
     @built_in_labels = [
-      { name: "Avery5160padded", description: "Square Labels"},
+      { name: "Avery5160padded", description: "Square Labels" },
       { name: "Avery8293", description: "Round Labels" },
-      { name: "Avery5434", description: "Square Labels"},
+      { name: "Avery5434", description: "Square Labels" },
       { name: "Spanish4716", description: "Square Labels 4716 (A4 Paper)" },
       { name: "LS3639", description: "Round Korean Labels" },
       { name: "Avery5293", description: "Round Labels" },
-      { name: "Avery5293padded", description: "Round Labels Avery (slightly padded)"},
-      { name: "Avery5293smallsquare", description: "Round Labels Avery (heavily padded)"},
-      { name: "L7651", description: "Square Labels Avery"}
+      { name: "Avery5293padded", description: "Round Labels Avery (slightly padded)" },
+      { name: "Avery5293smallsquare", description: "Round Labels Avery (heavily padded)" },
+      { name: "L7651", description: "Square Labels Avery" }
     ]
     @built_in_labels.each do |bil|
       label_definition = Prawn::Labels.types[bil[:name]]
       next if label_definition.nil?
+
       bil[:columns] = label_definition["columns"]
       bil[:rows] = label_definition["rows"]
     end
@@ -385,7 +386,7 @@ class AwardLabelsController < ApplicationController
         "columns" => custom_label_type.columns,
         "rows" => custom_label_type.rows,
         "column_gutter" => custom_label_type.column_gutter,
-        "row_gutter" => custom_label_type.row_gutter,
+        "row_gutter" => custom_label_type.row_gutter
       }
     end
     Prawn::Labels.types = base_types.merge(custom_types)

--- a/app/controllers/award_labels_controller.rb
+++ b/app/controllers/award_labels_controller.rb
@@ -25,6 +25,8 @@ class AwardLabelsController < ApplicationController
   before_action :authenticate_ability
   before_action :load_award_label, only: %i[edit update destroy]
 
+  before_action :load_label_definitions, only: [:index]
+  before_action :set_label_types, only: [:normal_labels]
   before_action :load_user, except: %i[edit update destroy]
 
   # GET /users/#/award_labels
@@ -338,5 +340,54 @@ class AwardLabelsController < ApplicationController
       names << lines_from_award_label(label)
     end
     names
+  end
+
+  def load_label_definitions
+    @built_in_labels = [
+      { name: "Avery5160padded", description: "Square Labels"},
+      { name: "Avery8293", description: "Round Labels" },
+      { name: "Avery5434", description: "Square Labels"},
+      { name: "Spanish4716", description: "Square Labels 4716 (A4 Paper)" },
+      { name: "LS3639", description: "Round Korean Labels" },
+      { name: "Avery5293", description: "Round Labels" },
+      { name: "Avery5293padded", description: "Round Labels Avery (slightly padded)"},
+      { name: "Avery5293smallsquare", description: "Round Labels Avery (heavily padded)"},
+      { name: "L7651", description: "Square Labels Avery"}
+    ]
+    @built_in_labels.each do |bil|
+      label_definition = Prawn::Labels.types[bil[:name]]
+      next if label_definition.nil?
+      bil[:columns] = label_definition["columns"]
+      bil[:rows] = label_definition["rows"]
+    end
+
+    @custom_label_types = CustomLabelType.all.map do |custom_label_type|
+      {
+        name: custom_label_type.name,
+        description: custom_label_type.description,
+        columns: custom_label_type.columns,
+        rows: custom_label_type.rows
+      }
+    end
+  end
+
+  # Load custom label types into prawn, for use
+  def set_label_types
+    base_types = Prawn::Labels.types
+    custom_types = {}
+    CustomLabelType.all.each do |custom_label_type|
+      custom_types[custom_label_type.name] = {
+        "paper_size" => custom_label_type.paper_size,
+        "top_margin" => custom_label_type.top_margin,
+        "bottom_margin" => custom_label_type.bottom_margin,
+        "left_margin" => custom_label_type.left_margin,
+        "right_margin" => custom_label_type.right_margin,
+        "columns" => custom_label_type.columns,
+        "rows" => custom_label_type.rows,
+        "column_gutter" => custom_label_type.column_gutter,
+        "row_gutter" => custom_label_type.row_gutter,
+      }
+    end
+    Prawn::Labels.types = base_types.merge(custom_types)
   end
 end

--- a/app/controllers/custom_label_types_controller.rb
+++ b/app/controllers/custom_label_types_controller.rb
@@ -1,0 +1,71 @@
+class CustomLabelTypesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :authenticate_ability
+  before_action :load_custom_label_type, only: %i[edit update destroy]
+  before_action :add_breadcrumbs
+
+  # GET /custom_label_types
+  def index
+    @custom_label_types = CustomLabelType.all
+  end
+
+  def new
+    @custom_label_type = CustomLabelType.new
+  end
+
+  # GET /custom_label_types/1/edit
+  def edit
+  end
+
+  # POST /custom_label_types
+  def create
+    @custom_label_type = CustomLabelType.new(custom_label_type_params)
+    @custom_label_type.created_by = current_user
+
+    if @custom_label_type.save
+      redirect_to custom_label_types_path, notice: 'Custom Label was successfully created'
+    else
+      render action: "new"
+    end
+  end
+
+  # PUT /custom_label_types/1
+  def update
+    if @custom_label_type.update(custom_label_type_params)
+      redirect_to custom_label_types_path, notice: 'Custom Label Type was successfully updated.'
+    else
+      render action: "edit"
+    end
+  end
+
+  # DELETE /custom_label_types/1
+  def destroy
+    @custom_label_type.destroy
+    redirect_to custom_label_types_path
+  end
+
+  private
+
+  def load_custom_label_type
+    @custom_label_type = CustomLabelType.find(params[:id])
+  end
+
+  def authenticate_ability
+    authorize current_user, :manage_awards?
+  end
+
+  def custom_label_type_params
+    params.require(:custom_label_type).permit(
+      :name, :paper_size, :paper_size_custom,
+      :columns, :rows,
+      :top_margin, :bottom_margin, :left_margin, :right_margin,
+      :column_gutter, :row_gutter,
+      :description
+    )
+  end
+
+  def add_breadcrumbs
+    add_breadcrumb "Print/Create Awards", user_award_labels_path(current_user)
+    add_breadcrumb "Custom Label Type"
+  end
+end

--- a/app/controllers/custom_label_types_controller.rb
+++ b/app/controllers/custom_label_types_controller.rb
@@ -14,8 +14,7 @@ class CustomLabelTypesController < ApplicationController
   end
 
   # GET /custom_label_types/1/edit
-  def edit
-  end
+  def edit; end
 
   # POST /custom_label_types
   def create

--- a/app/models/custom_label_type.rb
+++ b/app/models/custom_label_type.rb
@@ -1,0 +1,39 @@
+# When specified, these custom labels types
+# are available for use when creating award labels
+# == Schema Information
+#
+# Table name: custom_label_types
+#
+#  id                :bigint           not null, primary key
+#  name              :string           not null
+#  paper_size        :string           not null
+#  paper_size_custom :string
+#  columns           :integer          not null
+#  rows              :integer          not null
+#  top_margin        :float            not null
+#  bottom_margin     :float            not null
+#  left_margin       :float            not null
+#  right_margin      :float            not null
+#  column_gutter     :float            not null
+#  row_gutter        :float            not null
+#  created_by_id     :integer          not null
+#  description       :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+class CustomLabelType < ApplicationRecord
+  validates :name, presence: true
+  PAPER_SIZES = ['A4', 'LETTER', 'CUSTOM'].freeze
+  validates :paper_size, inclusion: { in: PAPER_SIZES }
+  validates :paper_size_custom, presence: true, if: proc { |el| el.paper_size == 'CUSTOM' }
+
+  validates :columns, :rows, presence: true, numericality: { greater_than: 0, less_than_or_equal_to: 20 }
+
+  validates :left_margin, :right_margin, :bottom_margin, :top_margin, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 120}
+
+
+  validates :created_by_id, presence: true
+  validates :column_gutter, presence: true
+
+  belongs_to :created_by, class_name: "User", optional: true
+end

--- a/app/models/custom_label_type.rb
+++ b/app/models/custom_label_type.rb
@@ -35,4 +35,12 @@ class CustomLabelType < ApplicationRecord
   validates :column_gutter, presence: true
 
   belongs_to :created_by, class_name: "User", optional: true
+
+  def paper_size_value
+    if paper_size == "CUSTOM"
+      paper_size_custom.split(",").map(&:to_i)
+    else
+      paper_size
+    end
+  end
 end

--- a/app/models/custom_label_type.rb
+++ b/app/models/custom_label_type.rb
@@ -29,8 +29,7 @@ class CustomLabelType < ApplicationRecord
 
   validates :columns, :rows, presence: true, numericality: { greater_than: 0, less_than_or_equal_to: 20 }
 
-  validates :left_margin, :right_margin, :bottom_margin, :top_margin, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 120}
-
+  validates :left_margin, :right_margin, :bottom_margin, :top_margin, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 120 }
 
   validates :created_by_id, presence: true
   validates :column_gutter, presence: true

--- a/app/views/award_labels/_label_sheet_button.html.haml
+++ b/app/views/award_labels/_label_sheet_button.html.haml
@@ -1,0 +1,5 @@
+.small-12.medium-4.columns
+  = description
+  = "(#{columns} columns, #{rows} rows)"
+  %br
+  = submit_tag description, name: "label_type", value: name, :class => "button", data: { disable_with: false }

--- a/app/views/award_labels/index.html.haml
+++ b/app/views/award_labels/index.html.haml
@@ -22,10 +22,14 @@
         = submit_tag "Create Labels (Generic) for Selected Competition", class: "button success"
   %hr
   %h2 Print Labels Sheet
+
   = link_to "Announcer Sheet (pdf)", announcer_sheet_user_award_labels_path(@user, format: :pdf)
   .row
     .small-12.columns
       = form_tag(normal_labels_user_award_labels_path(@user), {:method => :get}) do
+        .row
+          .small-12.columns
+            %a.js--toggle{ href: "#", data: { toggle_target: "#advanced_square"} } Show Advanced Options
         .row#advanced_square.is--hidden
           .small-6.columns
             = label_tag :separate_registrants, "Separate each registrant with a row of blank labels"
@@ -37,45 +41,18 @@
             = label_tag :show_gridlines, "Show Gridlines"
             = check_box_tag :show_gridlines
         .row
-          .small-12.medium-4.columns
-            Square Labels (3 columns, 10 rows)
-            %br
-            = submit_tag "Square Labels Avery", name: "label_type", value: "Avery5160padded", :class => "button", data: { disable_with: false }
-          .small-12.medium-4.columns
-            Round Labels (4 columns, 5 rows)
-            %br
-            = submit_tag "Round Labels Avery", name: "label_type", value: "Avery8293", :class => "button round", data: { disable_with: false }
-          .small-12.medium-4.columns
-            Square Labels (2 columns, 5 rows)
-            %br
-            = submit_tag "Square Labels Avery", name: "label_type", value: "Avery5434", :class => "button", data: { disable_with: false }
-          .small-12.medium-4.columns
-            Square Labels (5 columns, 13 rows)
-            %br
-            = submit_tag "Square Labels 4716 (A4 Paper)", name: "label_type", value: "Spanish4716", :class => "button", data: { disable_with: false }
-          .small-12.medium-4.columns
-            Round Labels (4 columns, 5 rows)
-            %br
-            = submit_tag "Round Korean Labels", name: "label_type", value: "LS3639", :class => "button", data: { disable_with: false }
-          .small-12.medium-4.columns
-            Round Labels (4 columns, 6 rows)
-            %br
-            = submit_tag "Round Labels Avery", name: "label_type", value: "Avery5293", :class => "button", data: { disable_with: false }
-          .small-12.medium-4.columns
-            Round Labels (4 columns, 6 rows)
-            %br
-            = submit_tag "Round Labels Avery (slightly padded)", name: "label_type", value: "Avery5293padded", :class => "button", data: { disable_with: false }
-          .small-12.medium-4.columns
-            Round Labels (4 columns, 6 rows)
-            %br
-            = submit_tag "Round Labels Avery (heavily padded)", name: "label_type", value: "Avery5293smallsquare", :class => "button", data: { disable_with: false }
-          .small-12.medium-4.columns
-            Square Labels (5 columns, 13 rows)
-            %br
-            = submit_tag "Square Labels Avery", name: "label_type", value: "L7651", :class => "button", data: { disable_with: false }
+          %h4 Standard Label Types
         .row
-          .small-12.columns
-            %a.js--toggle{ href: "#", data: { toggle_target: "#advanced_square"} } Advanced Options
+          - @built_in_labels.each do |h|
+            = render "label_sheet_button", name: h[:name], description: h[:description], rows: h[:rows], columns: h[:columns]
+          %hr
+        %row
+          %h4 Custom Label Types
+          = link_to "Manage Custom Label Types", custom_label_types_path
+          %br
+        %row
+          - @custom_label_types.each do |h|
+            = render "label_sheet_button", name: h[:name], description: h[:description], rows: h[:rows], columns: h[:columns]
   %hr
   %a.js--toggle{ href: "#", data: { toggle_target: "#advanced_labels" } } Show Advanced Options
 #advanced_labels.is--hidden

--- a/app/views/award_labels/index.html.haml
+++ b/app/views/award_labels/index.html.haml
@@ -45,7 +45,6 @@
         .row
           - @built_in_labels.each do |h|
             = render "label_sheet_button", name: h[:name], description: h[:description], rows: h[:rows], columns: h[:columns]
-          %hr
         %row
           %h4 Custom Label Types
           = link_to "Manage Custom Label Types", custom_label_types_path
@@ -54,7 +53,7 @@
           - @custom_label_types.each do |h|
             = render "label_sheet_button", name: h[:name], description: h[:description], rows: h[:rows], columns: h[:columns]
   %hr
-  %a.js--toggle{ href: "#", data: { toggle_target: "#advanced_labels" } } Show Advanced Options
+  %a.js--toggle{ href: "#", data: { toggle_target: "#advanced_labels" } } Show Advanced Creation Options
 #advanced_labels.is--hidden
   %h2 Create Labels For a specific Registrant/Registrant-Group/Competition
   = form_tag(create_labels_user_award_labels_path(@user), {:method => :post}) do

--- a/app/views/custom_label_types/_form.html.haml
+++ b/app/views/custom_label_types/_form.html.haml
@@ -1,0 +1,50 @@
+= simple_form_for(@custom_label_type) do |f|
+  - if @custom_label_type.errors.any?
+    #error_explanation
+      %h2
+        = pluralize(@custom_label_type.errors.count, "error")
+        prohibited this custom_label_type from being saved:
+      %ul
+        - @custom_label_type.errors.full_messages.each do |msg|
+          %li= msg
+  %div
+    .row
+      .columns
+        = f.input :name
+    .row
+      .columns
+        = f.input :description
+    .row
+      .small-3.columns
+        = f.input :paper_size, collection: CustomLabelType::PAPER_SIZES
+      .small-9.columns
+        = f.input :paper_size_custom
+    .row
+      .small-6.columns
+        = f.input :columns
+      .small-6.columns
+        = f.input :rows
+    .row
+      %p
+        %b NOTE
+        The following values (margin, gutter) must be specified in PTS values.
+        %ul
+          %li 0.1 Inch = 7.2 PTS,
+          %li 1mm = 2.835 PTS
+    .row
+      .small-3.columns
+        = f.input :top_margin
+      .small-3.columns
+        = f.input :bottom_margin
+      .small-3.columns
+        = f.input :left_margin
+      .small-3.columns
+        = f.input :right_margin
+    .row
+      .small-3.columns
+        = f.input :column_gutter
+      .small-3.columns
+        = f.input :row_gutter
+    .row
+      .small-3.columns
+        = f.button :submit

--- a/app/views/custom_label_types/_table.html.haml
+++ b/app/views/custom_label_types/_table.html.haml
@@ -1,0 +1,42 @@
+
+%table
+  %thead
+    %tr
+      %th= CustomLabelType.human_attribute_name(:name)
+      %th= CustomLabelType.human_attribute_name(:paper_size)
+      %th= CustomLabelType.human_attribute_name(:paper_size_custom)
+      %th= CustomLabelType.human_attribute_name(:columns)
+      %th= CustomLabelType.human_attribute_name(:rows)
+      %th= CustomLabelType.human_attribute_name(:top_margin)
+      %th= CustomLabelType.human_attribute_name(:bottom_margin)
+      %th= CustomLabelType.human_attribute_name(:left_margin)
+      %th= CustomLabelType.human_attribute_name(:right_margin)
+      %th= CustomLabelType.human_attribute_name(:column_gutter)
+      %th= CustomLabelType.human_attribute_name(:row_gutter)
+      %th= CustomLabelType.human_attribute_name(:created_by_id)
+      %th= CustomLabelType.human_attribute_name(:description)
+      %th Created At
+      %th Updated At
+      %th
+      %th
+  %tbody
+    - @custom_label_types.each do |custom_label_type|
+      - next unless custom_label_type.persisted?
+      %tr
+        %td= custom_label_type.name
+        %td= custom_label_type.paper_size
+        %td= custom_label_type.paper_size_custom
+        %td= custom_label_type.columns
+        %td= custom_label_type.rows
+        %td= custom_label_type.top_margin
+        %td= custom_label_type.bottom_margin
+        %td= custom_label_type.left_margin
+        %td= custom_label_type.right_margin
+        %td= custom_label_type.column_gutter
+        %td= custom_label_type.row_gutter
+        %td= custom_label_type.created_by
+        %td= custom_label_type.description
+        %td= custom_label_type.created_at.to_fs(:short)
+        %td= custom_label_type.updated_at.to_fs(:short)
+        %td= link_to t("edit"), edit_custom_label_type_path(custom_label_type)
+        %td= link_to t("delete"), custom_label_type, method: :delete, data: { confirm: t("are_you_sure") }

--- a/app/views/custom_label_types/edit.html.haml
+++ b/app/views/custom_label_types/edit.html.haml
@@ -1,0 +1,3 @@
+%h1 Editing Custom Label Type
+= render 'form'
+= link_to 'Back', custom_label_types_path

--- a/app/views/custom_label_types/index.html.haml
+++ b/app/views/custom_label_types/index.html.haml
@@ -1,0 +1,16 @@
+%h1 Custom Label Types
+
+%p.left_aligned
+  When creating new Label Types, we recommend the following process:
+  %ol.left_aligned
+    %li Measure the label spacings, and convert to PTS (0.1 INCH = 7.2 Pts, 1 mm = 2.835 Pts)
+    %li Create a custom label
+    %li On Award Labels page, choose "Show Advanced Options" and "Show Gridlines" in order to print PDF with squares
+    %li Print frequent test pages (on plain paper) and compare them (hold them up to bright lights) to see their positioning.
+    %li Adjust custom label values until the squuares are mostly within the target label areas.
+
+= render "table"
+
+%hr
+
+= link_to "New", new_custom_label_type_path, class: "button"

--- a/app/views/custom_label_types/new.html.haml
+++ b/app/views/custom_label_types/new.html.haml
@@ -1,0 +1,3 @@
+#h1 New Custom Label Type
+
+= render 'form'

--- a/config/locales/models/custom_label_type.en.yml
+++ b/config/locales/models/custom_label_type.en.yml
@@ -1,0 +1,32 @@
+---
+en:
+  activerecord:
+    attributes:
+      custom_label_type:
+        name: Name
+        description: Description
+        paper_size: Paper Size
+        paper_size_custom: Custom Paper Size (w,h)
+        columns: Columns
+        rows: Rows
+        top_margin: Top Margin
+        bottom_margin: Bottom Margin
+        left_margin: Left Margin
+        right_margin: Right Margin
+        column_gutter: Column Gutter
+        row_gutter: Row Gutter
+        created_by_id: Created By
+    models:
+      custom_label_type:
+        one: Custom Label Type
+        other: Custom Label Types
+  simple_form:
+      hints:
+        custom_label_type:
+          paper_size_custom: Must be specified in PTS (see below). Format "w,h". E.g. "288,432" (for 4inch x 6inch)
+          top_margin: In PTS
+          bottom_margin: In PTS
+          left_margin: In PTS
+          right_margin: In PTS
+          column_gutter: In PTS
+          row_gutter: In PTS

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -591,6 +591,7 @@ Rails.application.routes.draw do
         end
       end
     end
+    resources :custom_label_types
     resources :additional_registrant_accesses, only: [] do
       member do
         put :accept_readonly

--- a/db/migrate/20260714023225_add_custom_labels.rb
+++ b/db/migrate/20260714023225_add_custom_labels.rb
@@ -1,0 +1,20 @@
+class AddCustomLabels < ActiveRecord::Migration[8.1]
+  def change
+    create_table :custom_label_types do |t|
+      t.string :name, null: false
+      t.string :paper_size, null: false
+      t.string :paper_size_custom
+      t.integer :columns, null: false
+      t.integer :rows, null: false
+      t.float :top_margin, null: false
+      t.float :bottom_margin, null: false
+      t.float :left_margin, null: false
+      t.float :right_margin, null: false
+      t.float :column_gutter, null: false
+      t.float :row_gutter, null: false
+      t.integer :created_by_id, null: false
+      t.string :description
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_04_122530) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_14_023225) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -340,6 +340,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_122530) do
     t.integer "price_cents"
     t.datetime "updated_at", precision: nil
     t.index ["code"], name: "index_coupon_codes_on_code", unique: true
+  end
+
+  create_table "custom_label_types", force: :cascade do |t|
+    t.float "bottom_margin", null: false
+    t.float "column_gutter", null: false
+    t.integer "columns", null: false
+    t.datetime "created_at", null: false
+    t.integer "created_by_id", null: false
+    t.string "description"
+    t.float "left_margin", null: false
+    t.string "name", null: false
+    t.string "paper_size", null: false
+    t.string "paper_size_custom"
+    t.float "right_margin", null: false
+    t.float "row_gutter", null: false
+    t.integer "rows", null: false
+    t.float "top_margin", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "distance_attempts", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
When printing award labels, sometimes we need a different sheet structure than those we have used previously.
We used to have to do this through manual code modification, to add a new label definition. now we can do it through a UI, allowing faster/easier iteration.