### PR TITLE
Add more reply to email options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ gem 'tolk', github: 'rdunlop/tolk', branch: 'improve_import_export'
 
 # multi-tenancy
 gem 'pry-rails' # required for apartment console customization
+gem 'pry', github: 'pry/pry', branch: 'master' # Use master branch until > 0.16.0 fixes ruby 4 readline support
 gem 'ros-apartment', require: 'apartment'
 gem 'ros-apartment-sidekiq', require: 'apartment-sidekiq'
 
@@ -132,7 +133,6 @@ group :unicon, :naucc, :development, :test, :cucumber, :caching do
   gem 'bullet'
   # gem 'brakeman'
   gem 'foreman'
-  gem 'pry'
 end
 
 # To use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,16 @@ GIT
     ttfunk (1.8.0)
 
 GIT
+  remote: https://github.com/pry/pry.git
+  revision: 135640262879544c6bfecbf3e78511289bfe956c
+  branch: master
+  specs:
+    pry (0.16.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      reline (>= 0.6.0)
+
+GIT
   remote: https://github.com/rdunlop/tolk.git
   revision: 8342a4ef228966541fb1815ce9eedeca481663f5
   branch: improve_import_export
@@ -429,10 +439,6 @@ GEM
     prism (1.9.0)
     prop_initializer (0.4.0)
       zeitwerk (>= 2.6.18)
-    pry (0.16.0)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-      reline (>= 0.6.0)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
     public_suffix (6.0.2)
@@ -740,7 +746,7 @@ DEPENDENCIES
   poltergeist
   prawn
   prawn-labels
-  pry
+  pry!
   pry-rails
   puma
   pundit

--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -66,6 +66,7 @@ class EmailsController < ApplicationController
       mass_email = MassEmail.new
       mass_email.subject = @email_form.subject
       mass_email.body = @email_form.body
+      mass_email.additional_reply_to_emails = @email_form.reply_to_emails_to_store(current_user)
       email_addresses = (@filter.user_emails + @filter.registrant_emails).uniq.compact
       mass_email.email_addresses = email_addresses
       mass_email.email_addresses_description = @filter.detailed_description

--- a/app/javascript/controllers/mass_email_reply_to_controller.js
+++ b/app/javascript/controllers/mass_email_reply_to_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["checkbox", "additional", "display"]
+  static values = { contactEmail: String, userEmail: String }
+
+  connect() {
+    this.update()
+  }
+
+  update() {
+    const addresses = [this.contactEmailValue]
+
+    if (this.checkboxTarget.checked) {
+      addresses.push(this.userEmailValue)
+    }
+
+    this.additionalTarget.value
+      .split(",")
+      .map((email) => email.trim())
+      .filter((email) => email.length > 0)
+      .forEach((email) => addresses.push(email))
+
+    this.displayTarget.textContent = [...new Set(addresses)].join(", ")
+  }
+}

--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -19,11 +19,11 @@ class Notifications < TenantAwareMailer
     mail to: requesting_user.email, subject: 'Registration Access Granted'
   end
 
-  def send_mass_email(subject, body, addresses, opt_out_code)
+  def send_mass_email(subject, body, addresses, opt_out_code, reply_to_addresses)
     @body = body
     @opt_out_code = opt_out_code
 
-    mail bcc: addresses, subject: subject, reply_to: EventConfiguration.singleton.contact_email
+    mail bcc: addresses, subject: subject, reply_to: reply_to_addresses
   end
 
   def event_confirmation_email(to_addresses, reply_to, subject, body)

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -4,7 +4,7 @@ class Email
   include ActiveModel::Validations
   include ActiveModel::Conversion
 
-  attr_accessor :subject, :body
+  attr_accessor :subject, :body, :include_my_email, :additional_reply_to_emails
 
   validates :subject, :body, presence: true
 
@@ -16,5 +16,15 @@ class Email
 
   def persisted?
     false
+  end
+
+  def include_my_email?
+    ActiveModel::Type::Boolean.new.cast(include_my_email)
+  end
+
+  def reply_to_emails_to_store(current_user)
+    addresses = additional_reply_to_emails.to_s.split(",").map(&:strip).reject(&:blank?)
+    addresses << current_user.email if include_my_email?
+    addresses.uniq.join(", ")
   end
 end

--- a/app/models/event_configuration.rb
+++ b/app/models/event_configuration.rb
@@ -60,6 +60,7 @@
 #  stripe_webhook_secret                         :string
 #  imported_registrants                          :boolean          default(FALSE), not null
 #  registration_period_last_checked_at           :datetime
+#  enabled_label_types                           :string
 #  short_name                                    :string
 #  long_name                                     :string
 #  location                                      :string

--- a/app/models/mass_email.rb
+++ b/app/models/mass_email.rb
@@ -11,6 +11,7 @@
 #  email_addresses_description :string
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
+#  additional_reply_to_emails  :string
 #
 # Indexes
 #
@@ -29,21 +30,29 @@ class MassEmail < ApplicationRecord
         # wait a few second for set of emails to prevent hitting SES Rate limit
         addresses.each do |address|
           opt_out_code = MailOptOut.create_if_not_present(address).opt_out_code
-          Notifications.send_mass_email(subject, body, [address], opt_out_code).deliver_later(wait: index.seconds * 3)
+          Notifications.send_mass_email(subject, body, [address], opt_out_code, reply_to_addresses).deliver_later(wait: index.seconds * 3)
         end
       end
     else
       # Send emails in groups of 40
       addresses.each_slice(40).with_index do |addresses, index|
         # wait a few second for each email to prevent hitting SES Rate limit
-        Notifications.send_mass_email(subject, body, addresses, nil).deliver_later(wait: index.seconds * 3)
+        Notifications.send_mass_email(subject, body, addresses, nil, reply_to_addresses).deliver_later(wait: index.seconds * 3)
       end
     end
+  end
+
+  def reply_to_addresses
+    ([EventConfiguration.singleton.contact_email] + parsed_additional_reply_to_emails).uniq
   end
 
   private
 
   def addresses
     ([sent_by.email] + email_addresses).uniq
+  end
+
+  def parsed_additional_reply_to_emails
+    additional_reply_to_emails.to_s.split(",").map(&:strip).reject(&:blank?)
   end
 end

--- a/app/views/emails/list.html.haml
+++ b/app/views/emails/list.html.haml
@@ -50,7 +50,12 @@ At the bottom of this page, you can use the system to send e-mails, if you wish.
     = EventConfiguration.singleton.contact_email
     %br
     %b Reply-to:
-    = EventConfiguration.singleton.contact_email
+    %span{data: {"mass-email-reply-to-target": "display"}}= EventConfiguration.singleton.contact_email
+    %br
+    .mass-email-reply-to{data: {controller: "mass-email-reply-to", "mass-email-reply-to-contact-email-value": EventConfiguration.singleton.contact_email, "mass-email-reply-to-user-email-value": current_user.email}}
+      = f.input :include_my_email, as: :boolean, label: "Include my email in the reply-to list", input_html: {data: {"mass-email-reply-to-target": "checkbox", action: "change->mass-email-reply-to#update"}}
+      = f.label :additional_reply_to_emails, "Additional reply-to emails"
+      = f.text_field :additional_reply_to_emails, data: {"mass-email-reply-to-target": "additional", action: "input->mass-email-reply-to#update"}
     %br
     %b BCC:
     You +

--- a/app/views/emails/list.html.haml
+++ b/app/views/emails/list.html.haml
@@ -1,3 +1,5 @@
+- content_for :importmap_modules do
+  = javascript_import_module_tag "controllers"
 %h1 Email multiple people
 
 At the bottom of this page, you can use the system to send e-mails, if you wish.
@@ -49,23 +51,24 @@ At the bottom of this page, you can use the system to send e-mails, if you wish.
     %b From:
     = EventConfiguration.singleton.contact_email
     %br
-    %b Reply-to:
-    %span{data: {"mass-email-reply-to-target": "display"}}= EventConfiguration.singleton.contact_email
-    %br
-    .mass-email-reply-to{data: {controller: "mass-email-reply-to", "mass-email-reply-to-contact-email-value": EventConfiguration.singleton.contact_email, "mass-email-reply-to-user-email-value": current_user.email}}
-      = f.input :include_my_email, as: :boolean, label: "Include my email in the reply-to list", input_html: {data: {"mass-email-reply-to-target": "checkbox", action: "change->mass-email-reply-to#update"}}
-      = f.label :additional_reply_to_emails, "Additional reply-to emails"
-      = f.text_field :additional_reply_to_emails, data: {"mass-email-reply-to-target": "additional", action: "input->mass-email-reply-to#update"}
-    %br
-    %b BCC:
-    You +
-    All of the email addresses listed above
-    %br
-    = f.label :subject
-    = f.text_field :subject
-    %br
-    = f.rich_text_area :body
-    %br
-    = f.button :submit, "Send Email", class: "focus_button"
+    %div{data: {controller: "mass-email-reply-to", "mass-email-reply-to-contact-email-value": EventConfiguration.singleton.contact_email, "mass-email-reply-to-user-email-value": current_user.email}}
+      %b Reply-to:
+      %span{data: {"mass-email-reply-to-target": "display"}}= EventConfiguration.singleton.contact_email
+      %br
+      .mass-email-reply-to
+        = f.input :include_my_email, as: :boolean, label: "Include my email in the reply-to list", input_html: {data: {"mass-email-reply-to-target": "checkbox", action: "change->mass-email-reply-to#update"}}
+        = f.label :additional_reply_to_emails, "Additional reply-to emails"
+        = f.text_field :additional_reply_to_emails, data: {"mass-email-reply-to-target": "additional", action: "input->mass-email-reply-to#update"}
+      %br
+      %b BCC:
+      You +
+      All of the email addresses listed above
+      %br
+      = f.label :subject
+      = f.text_field :subject
+      %br
+      = f.rich_text_area :body
+      %br
+      = f.button :submit, "Send Email", class: "focus_button"
   %hr
   = link_to "Start over", emails_path, class: "back_link"

--- a/app/views/emails/sent.html.haml
+++ b/app/views/emails/sent.html.haml
@@ -24,3 +24,12 @@
   %b Address Description
   = @email.email_addresses_description
 
+%div
+  %b Reply-To: Contact Email
+  = EventConfiguration.singleton.contact_email
+
+- if @email.additional_reply_to_emails.present?
+  %div
+    %b Reply-To: Additional Emails
+    = @email.additional_reply_to_emails
+

--- a/db/migrate/20260721000000_add_additional_reply_to_emails_to_mass_emails.rb
+++ b/db/migrate/20260721000000_add_additional_reply_to_emails_to_mass_emails.rb
@@ -1,0 +1,5 @@
+class AddAdditionalReplyToEmailsToMassEmails < ActiveRecord::Migration[8.0]
+  def change
+    add_column :mass_emails, :additional_reply_to_emails, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_14_023225) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_21_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -463,6 +463,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_023225) do
     t.string "currency_code"
     t.text "custom_waiver_text"
     t.boolean "display_confirmed_events", default: false, null: false
+    t.string "enabled_label_types"
     t.string "enabled_locales", null: false
     t.date "event_sign_up_closed_date"
     t.string "event_url"
@@ -828,6 +829,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_023225) do
   end
 
   create_table "mass_emails", id: :serial, force: :cascade do |t|
+    t.string "additional_reply_to_emails"
     t.text "body"
     t.datetime "created_at", precision: nil, null: false
     t.text "email_addresses", array: true
@@ -1271,6 +1273,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_023225) do
     t.datetime "updated_at", precision: nil, null: false
     t.index ["competitor_id"], name: "index_standard_skill_scores_on_competitor_id"
     t.index ["judge_id", "competitor_id"], name: "index_standard_skill_scores_on_judge_id_and_competitor_id", unique: true
+  end
+
+  create_table "system_label_types", force: :cascade do |t|
+    t.float "bottom_margin", null: false
+    t.float "column_gutter", null: false
+    t.integer "columns", null: false
+    t.datetime "created_at", null: false
+    t.string "description"
+    t.float "left_margin", null: false
+    t.string "name", null: false
+    t.string "paper_size", null: false
+    t.string "paper_size_custom"
+    t.float "right_margin", null: false
+    t.float "row_gutter", null: false
+    t.integer "rows", null: false
+    t.float "top_margin", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_system_label_types_on_name", unique: true
   end
 
   create_table "tenant_aliases", id: :serial, force: :cascade do |t|

--- a/previews/mailers/notifications_preview.rb
+++ b/previews/mailers/notifications_preview.rb
@@ -12,7 +12,7 @@ class NotificationsPreview < ActionMailer::Preview
   end
 
   def send_mass_email
-    Notifications.send_mass_email(email.subject, email.body, addresses)
+    Notifications.send_mass_email(email.subject, email.body, addresses, "opt_out_code_123", reply_to_addresses)
   end
 
   ######### ADMIN
@@ -53,5 +53,9 @@ class NotificationsPreview < ActionMailer::Preview
 
   def addresses
     ["robin+test@dunlopeb.com", "robin+test2@dunlopweb.com"]
+  end
+
+  def reply_to_addresses
+    [EventConfiguration.singleton.contact_email, "organizer@example.com"]
   end
 end

--- a/spec/controllers/emails_controller_spec.rb
+++ b/spec/controllers/emails_controller_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe EmailsController do
   before do
     @user = FactoryBot.create(:super_admin_user)
+    EventConfiguration.singleton.update(contact_email: "contact@example.com")
     sign_in @user
   end
 
@@ -18,6 +19,17 @@ describe EmailsController do
       get :list, params: { filter_email: { filter: "confirmed_accounts" } }
       expect(response).to be_successful
     end
+
+    it "includes the checkbox for include_my_email" do
+      get :list, params: { filter_email: { filter: "confirmed_accounts" } }
+      expect(response.body).to include("Include my email in the reply-to list")
+      expect(response.body).to include("mass-email-reply-to")
+    end
+
+    it "includes the text field for additional_reply_to_emails" do
+      get :list, params: { filter_email: { filter: "confirmed_accounts" } }
+      expect(response.body).to include("Additional reply-to emails")
+    end
   end
 
   describe "GET download" do
@@ -32,6 +44,20 @@ describe EmailsController do
       mass_email = FactoryBot.create(:mass_email)
       get :sent, params: { id: mass_email.id }
       expect(response).to be_successful
+    end
+
+    it "shows contact email in reply-to section" do
+      mass_email = FactoryBot.create(:mass_email)
+      get :sent, params: { id: mass_email.id }
+      expect(response.body).to include("Reply-To: Contact Email")
+      expect(response.body).to include(EventConfiguration.singleton.contact_email)
+    end
+
+    it "shows additional emails when present" do
+      mass_email = FactoryBot.create(:mass_email, additional_reply_to_emails: "extra@example.com, another@example.com")
+      get :sent, params: { id: mass_email.id }
+      expect(response.body).to include("Reply-To: Additional Emails")
+      expect(response.body).to include("extra@example.com, another@example.com")
     end
   end
 
@@ -66,6 +92,30 @@ describe EmailsController do
 
       second_message = ActionMailer::Base.deliveries.second
       expect(second_message.bcc.count).to eq(11) # 10 remaining from 50, plus 1 super_admin (self)
+    end
+
+    it "includes user email in reply-to when checkbox is checked" do
+      FactoryBot.create(:user)
+      ActionMailer::Base.deliveries.clear
+      post :create, params: { email: { subject: "Hello werld", body: "This is the body", include_my_email: "1" }, filter: "confirmed_accounts", arguments: "" }
+      message = ActionMailer::Base.deliveries.first
+      expect(message.reply_to).to include(@user.email)
+    end
+
+    it "includes additional reply-to emails" do
+      FactoryBot.create(:user)
+      ActionMailer::Base.deliveries.clear
+      post :create, params: { email: { subject: "Hello werld", body: "This is the body", additional_reply_to_emails: "extra@example.com" }, filter: "confirmed_accounts", arguments: "" }
+      message = ActionMailer::Base.deliveries.first
+      expect(message.reply_to).to include("extra@example.com")
+    end
+
+    it "stores additional_reply_to_emails on the mass_email" do
+      FactoryBot.create(:user)
+      ActionMailer::Base.deliveries.clear
+      post :create, params: { email: { subject: "Hello werld", body: "This is the body", additional_reply_to_emails: "a@example.com, b@example.com" }, filter: "confirmed_accounts", arguments: "" }
+      mass_email = MassEmail.last
+      expect(mass_email.additional_reply_to_emails).to eq("a@example.com, b@example.com")
     end
   end
 end

--- a/spec/factories/event_configurations.rb
+++ b/spec/factories/event_configurations.rb
@@ -60,6 +60,7 @@
 #  stripe_webhook_secret                         :string
 #  imported_registrants                          :boolean          default(FALSE), not null
 #  registration_period_last_checked_at           :datetime
+#  enabled_label_types                           :string
 #  short_name                                    :string
 #  long_name                                     :string
 #  location                                      :string

--- a/spec/factories/mass_emails.rb
+++ b/spec/factories/mass_emails.rb
@@ -22,6 +22,7 @@ end
 #  email_addresses_description :string
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
+#  additional_reply_to_emails  :string
 #
 # Indexes
 #

--- a/spec/mailers/notifications_spec.rb
+++ b/spec/mailers/notifications_spec.rb
@@ -29,11 +29,16 @@ describe Notifications do
 
   describe "send_mass_email" do
     let(:mail) do
-      described_class.send_mass_email("subejct", "Body", ["a@b.com"], "abc123")
+      described_class.send_mass_email("subejct", "Body", ["a@b.com"], "abc123", ["guy@convention.com"])
     end
 
     it "sets the reply-to address" do
       expect(mail.reply_to).to match(["guy@convention.com"])
+    end
+
+    it "sets multiple reply-to addresses" do
+      mail = described_class.send_mass_email("subejct", "Body", ["a@b.com"], "abc123", ["guy@convention.com", "extra@example.com"])
+      expect(mail.reply_to).to match(["guy@convention.com", "extra@example.com"])
     end
   end
 

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -13,4 +13,64 @@ describe Email do
     @email.subject = nil
     expect(@email.valid?).to eq(false)
   end
+
+  describe "#include_my_email?" do
+    it "is falsey when nil" do
+      @email.include_my_email = nil
+      expect(@email).not_to be_include_my_email
+    end
+
+    it "is falsey when '0'" do
+      @email.include_my_email = "0"
+      expect(@email).not_to be_include_my_email
+    end
+
+    it "is truthy when '1'" do
+      @email.include_my_email = "1"
+      expect(@email).to be_include_my_email
+    end
+
+    it "is truthy when true" do
+      @email.include_my_email = true
+      expect(@email).to be_include_my_email
+    end
+  end
+
+  describe "#reply_to_emails_to_store" do
+    let(:user) { FactoryBot.create(:user, email: "sender@example.com") }
+
+    it "returns empty string when nothing is set" do
+      @email.include_my_email = nil
+      @email.additional_reply_to_emails = nil
+      expect(@email.reply_to_emails_to_store(user)).to eq("")
+    end
+
+    it "includes user email when checkbox is checked" do
+      @email.include_my_email = "1"
+      @email.additional_reply_to_emails = nil
+      expect(@email.reply_to_emails_to_store(user)).to eq("sender@example.com")
+    end
+
+    it "parses and strips additional emails" do
+      @email.include_my_email = nil
+      @email.additional_reply_to_emails = "a@example.com, b@example.com"
+      expect(@email.reply_to_emails_to_store(user)).to eq("a@example.com, b@example.com")
+    end
+
+    it "deduplicates user email from additional emails" do
+      @email.include_my_email = "1"
+      @email.additional_reply_to_emails = "sender@example.com, a@example.com"
+      result = @email.reply_to_emails_to_store(user)
+      expect(result).to include("sender@example.com")
+      expect(result).to include("a@example.com")
+      expect(result.split(", ").length).to eq(2)
+    end
+
+    it "ignores blank additional emails" do
+      @email.include_my_email = nil
+      @email.additional_reply_to_emails = "a@example.com, , b@example.com"
+      result = @email.reply_to_emails_to_store(user)
+      expect(result).to eq("a@example.com, b@example.com")
+    end
+  end
 end

--- a/spec/models/event_configuration_spec.rb
+++ b/spec/models/event_configuration_spec.rb
@@ -60,6 +60,7 @@
 #  stripe_webhook_secret                         :string
 #  imported_registrants                          :boolean          default(FALSE), not null
 #  registration_period_last_checked_at           :datetime
+#  enabled_label_types                           :string
 #  short_name                                    :string
 #  long_name                                     :string
 #  location                                      :string

--- a/spec/models/mass_email_spec.rb
+++ b/spec/models/mass_email_spec.rb
@@ -24,6 +24,31 @@ describe MassEmail do
       expect(ActionMailer::Base.deliveries.first.bcc).to include(user.email)
     end
   end
+
+  describe "#reply_to_addresses" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:email) { FactoryBot.create(:mass_email, sent_by: user) }
+
+    it "returns contact email when additional emails are blank" do
+      email.additional_reply_to_emails = nil
+      expect(email.reply_to_addresses).to eq([EventConfiguration.singleton.contact_email])
+    end
+
+    it "includes parsed additional addresses" do
+      email.additional_reply_to_emails = "extra1@example.com, extra2@example.com"
+      result = email.reply_to_addresses
+      expect(result).to include(EventConfiguration.singleton.contact_email)
+      expect(result).to include("extra1@example.com")
+      expect(result).to include("extra2@example.com")
+    end
+
+    it "deduplicates addresses" do
+      contact_email = EventConfiguration.singleton.contact_email
+      email.additional_reply_to_emails = "#{contact_email}, extra@example.com"
+      result = email.reply_to_addresses
+      expect(result.count(contact_email)).to eq(1)
+    end
+  end
 end
 
 # == Schema Information
@@ -39,6 +64,7 @@ end
 #  email_addresses_description :string
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
+#  additional_reply_to_emails  :string
 #
 # Indexes
 #


### PR DESCRIPTION
Allows a director to enter their own email as another "reply-to" target when sending mass mail to folks in their competition.