### PR TITLE
Fix Stimulus controller precompile for staging/production

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,8 @@
 # Be sure to restart your server when you modify this file.
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = '1.0'
+
+# importmap-rails adds app/javascript to Sprockets' asset *paths* (so files can be
+# found) but does not add individual files to the precompile list. Without this,
+# Stimulus controllers 404 in production/staging where config.assets.compile = false.
+Rails.application.config.assets.precompile += Dir.glob("app/javascript/controllers/**/*.js").map { |f| f.sub("app/javascript/", "") }


### PR DESCRIPTION
Remove incorrect 'digest = false' that disabled fingerprinting globally. Keep only the precompile-list addition, which is necessary because importmap-rails adds app/javascript to Sprockets' asset paths but does not automatically precompile individual files. Without explicit precompile list entries, controllers 404 in production/staging where config.assets.compile = false.

Fingerprinting remains enabled (Sprockets' default). The javascript_import_module_tag helper resolves pinned logical names to their digested URLs automatically at request time, the same way stylesheet_link_tag and asset_path do elsewhere in the app.