### PR TITLE
Fix ability to view embedded info pages

### DIFF
--- a/app/views/pages/_embedded_page.html.haml
+++ b/app/views/pages/_embedded_page.html.haml
@@ -1,6 +1,6 @@
 %h3= page.title
 
 .content
-  = page.body.html_safe
+  = page.body
 
 %hr


### PR DESCRIPTION
When we adjusted the way that the page model works, we need to adjust the way that we output the pages